### PR TITLE
chore(ci): pin GitHub Actions versions and add communication guidelines

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude-renovate-pr-review.yml
+++ b/.github/workflows/claude-renovate-pr-review.yml
@@ -1,0 +1,20 @@
+name: Claude Renovate Review
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+
+jobs:
+  claude-renovate-review:
+    if: github.event.pull_request.user.login == 'renovate[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # for commenting on the PR
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: koki-develop/claude-renovate-review@a20f64e3ea03ffd40a8995f5d9087956e42d5e6c # v1.0.2
+        with:
+          claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,5 +344,6 @@ pnpm dev --host                      # Expose dev server to network
 
 - CLAUDE.md is always written in English
 - This is a Japanese development environment - use Japanese for code comments
+- **ALWAYS communicate with users in Japanese** for chat messages, code reviews, and all interactions
 - Never use `as any` type assertions - define proper types
 - Conventional Commits format required for all commits


### PR DESCRIPTION
## Summary
- GitHub Actionsのセキュリティ向上のためactions/checkoutを具体的なコミットハッシュにピン留め
- CLAUDE.mdに日本語コミュニケーション要件を追加
- Renovate PR用の新しいレビューワークフローを追加

## Changes
- `.github/workflows/claude-code-review.yml`: actions/checkout@v4 → @11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
- `.github/workflows/claude.yml`: 同様にactions/checkoutをピン留め
- `CLAUDE.md`: 日本語コミュニケーション指示を追加
- `.github/workflows/claude-renovate-pr-review.yml`: 新規追加

## Test plan
- [ ] ワークフローファイルの構文が正しいことを確認
- [ ] 新しいワークフローが適切に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)