### PR TITLE
chore(ci): configure allowed tools for Claude Renovate PR review

### DIFF
--- a/.github/workflows/claude-renovate-pr-review.yml
+++ b/.github/workflows/claude-renovate-pr-review.yml
@@ -18,3 +18,8 @@ jobs:
       - uses: koki-develop/claude-renovate-review@a20f64e3ea03ffd40a8995f5d9087956e42d5e6c # v1.0.2
         with:
           claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed-tools: |
+            WebFetch(domain:github.com)
+            WebFetch(domain:npm.pkg.github.com)
+            WebFetch(domain:www.npmjs.com)
+            WebFetch(domain:raw.githubusercontent.com)


### PR DESCRIPTION
## Summary
- Add allowed-tools configuration to Claude Renovate PR review workflow
- Enable access to GitHub and npm registry domains for dependency analysis

## Changes
- Configure allowed tools in `.github/workflows/claude-renovate-pr-review.yml`:
  - WebFetch for github.com domain
  - WebFetch for npm.pkg.github.com domain  
  - WebFetch for www.npmjs.com domain
  - WebFetch for raw.githubusercontent.com domain

## Benefits
- Allows Claude to fetch dependency information from GitHub and npm registries
- Enables more comprehensive dependency review and analysis
- Improves automated PR review quality for Renovate dependency updates

🤖 Generated with [Claude Code](https://claude.ai/code)