### PR TITLE
chore(ci): exclude renovate bot from Claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,7 +13,8 @@ on:
 jobs:
   claude-review:
     # Optional: Filter by PR author
-    # if: |
+    if: |
+        github.event.pull_request.user.login != 'renovate[bot]'
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'


### PR DESCRIPTION
## Summary
- Exclude renovate[bot] PRs from Claude code review workflow
- Prevents unnecessary Claude reviews on automated dependency updates

## Test plan
- Check that renovate PRs are no longer triggered for Claude review
- Verify other PRs still trigger Claude review as expected

🤖 Generated with [Claude Code](https://claude.ai/code)