### PR TITLE
ci: add Astro and Tailwind documentation domains to Claude workflow

### DIFF
--- a/.github/workflows/claude-renovate-pr-review.yml
+++ b/.github/workflows/claude-renovate-pr-review.yml
@@ -23,3 +23,5 @@ jobs:
             WebFetch(domain:npm.pkg.github.com)
             WebFetch(domain:www.npmjs.com)
             WebFetch(domain:raw.githubusercontent.com)
+            WebFetch(domain:www.astro.build)
+            WebFetch(domain:tailwindcss.com)


### PR DESCRIPTION
## Summary

This PR adds two additional domains to the Claude workflow for accessing documentation:

- `www.astro.build` - Official Astro documentation
- `tailwindcss.com` - Official Tailwind CSS documentation

This allows Claude to fetch the latest documentation from these sources during Renovate PR reviews, improving the quality of automated dependency update reviews.

## Changes

- Added `WebFetch(domain:www.astro.build)` to the workflow configuration
- Added `WebFetch(domain:tailwindcss.com)` to the workflow configuration