### PR TITLE
feat(ci): add Iconify docs domain to allowed tools for Renovate PR review

### DIFF
--- a/.github/workflows/claude-renovate-pr-review.yml
+++ b/.github/workflows/claude-renovate-pr-review.yml
@@ -25,3 +25,4 @@ jobs:
             WebFetch(domain:raw.githubusercontent.com)
             WebFetch(domain:www.astro.build)
             WebFetch(domain:tailwindcss.com)
+            WebFetch(domain:docs.iconify.design)


### PR DESCRIPTION
## 概要

RenovateのPRレビュー時にIconifyドキュメントサイトへのアクセスを許可する設定を追加。

## 変更内容

- `docs.iconify.design`ドメインを`allowed-tools`に追加
- Iconify関連の依存関係更新時により詳細な情報を取得可能に

## 背景

Iconifyアイコンライブラリの更新情報やドキュメントをRenovateのPRレビューで参照できるようにするため。