### PR TITLE
ci: add ESLint domain access to renovate PR review workflow

### DIFF
--- a/.github/workflows/claude-renovate-pr-review.yml
+++ b/.github/workflows/claude-renovate-pr-review.yml
@@ -27,3 +27,5 @@ jobs:
             WebFetch(domain:www.astro.build)
             WebFetch(domain:tailwindcss.com)
             WebFetch(domain:docs.iconify.design)
+            WebFetch(domain:eslint.org)
+            WebFetch(domain:typescript-eslint.io)


### PR DESCRIPTION
ESLintドメインをRenovate PRレビューワークフローに追加

## 変更内容

GitHubワークフロー  に以下のESLint関連ドメインを追加しました：

-  - ESLint公式ドキュメント
-  - TypeScript ESLint公式ドキュメント

## 目的

Renovate PRレビュー時にESLintおよびTypeScript ESLint関連の更新について、公式ドキュメントを参照して適切なレビューコメントを生成できるようにします。

## 影響範囲

- GitHub Actions ワークフローのみ
- 依存関係の更新PRレビューの品質向上