### PR TITLE
ci: add Playwright domain access to renovate PR review workflow

### DIFF
--- a/.github/workflows/claude-renovate-pr-review.yml
+++ b/.github/workflows/claude-renovate-pr-review.yml
@@ -29,3 +29,4 @@ jobs:
             WebFetch(domain:docs.iconify.design)
             WebFetch(domain:eslint.org)
             WebFetch(domain:typescript-eslint.io)
+            WebFetch(domain:playwright.dev)


### PR DESCRIPTION
PlaywrightドメインをRenovate PRレビューワークフローに追加

## 変更内容

GitHubワークフロー `.github/workflows/claude-renovate-pr-review.yml` に以下のPlaywright関連ドメインを追加しました：

- `playwright.dev` - Playwright公式ドキュメント

## 目的

Renovate PRレビュー時にPlaywright関連の更新について、公式ドキュメントを参照して適切なレビューコメントを生成できるようにします。

## 影響範囲

- GitHub Actions ワークフローのみ
- 依存関係の更新PRレビューの品質向上