### PR TITLE
ci: skip tests on content-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: ci
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'src/content/post/**'
+      - 'public/images/**'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

コンテンツファイルのみが変更された場合、CIワークフローをスキップするように設定しました。

## Changes

- `.github/workflows/ci.yml`に`paths-ignore`を追加
  - `src/content/post/**`
  - `public/images/**`

## Behavior

- **コンテンツのみの変更時**: CIワークフロー全体がスキップされ、GitHubのUIで「Skipped」と表示される
- **コード変更を含む場合**: 通常通り`build`と`test`ジョブが実行される

## Benefits

- コンテンツ更新時のCI実行時間とリソースを節約
- PRのフィードバックサイクルを高速化

## Test Plan

- [ ] コンテンツファイルのみを変更したPRを作成し、CIがスキップされることを確認
- [ ] コードファイルを変更したPRを作成し、CIが実行されることを確認

Closes #1113