### PR TITLE
chore(renovate): add fontsource packages automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,6 +27,11 @@
       "groupName": "iconify packages",
       "matchPackageNames": ["@iconify/**"],
       "automerge": true
+    },
+    {
+      "matchPackageNames": ["@fontsource/**"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add automerge configuration for `@fontsource/*` packages to enable automatic merging of minor and patch updates in Renovate.

### Changes

- Added new package rule for `@fontsource/**` packages
- Configured automerge for `minor` and `patch` updates only
- Follows the same pattern as existing `@types/**` and `@iconify/**` configurations

### Rationale

Font packages from the Fontsource project are typically stable and safe to update automatically. This change:
- Reduces manual review overhead for routine font package updates
- Maintains consistency with other auto-merged dependency groups
- Applies only to minor and patch updates (major versions still require manual review)

## Test Plan

- [x] Lint checks passed (`pnpm lint`)
- [x] Code formatting completed (`pnpm format`)
- [x] All tests passed (`pnpm test:tools`) - 127/127 tests passed
- [x] Renovate configuration is valid JSON

### Manual Verification

1. Verify JSON syntax is valid
2. Confirm automerge only applies to minor/patch updates
3. Wait for next Renovate run to test automerge behavior