### PR TITLE
ci: enable sticky comment for Claude Code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "*"
+          use_sticky_comment: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Claude Code Reviewワークフローに`use_sticky_comment`オプションを有効化しました。

## Changes

- `.github/workflows/claude-code-review.yml`に`use_sticky_comment: true`を追加
  - これにより、同一PRに対するレビューコメントが新規作成ではなく更新される形式になります

## Motivation

PRのコメント欄が複数のレビューコメントで溢れないようにするため、スティッキーコメント機能を有効化しました。