### PR TITLE
feat(layout): add description to header in post detail page

### DIFF
--- a/src/layouts/PostDetailPage.astro
+++ b/src/layouts/PostDetailPage.astro
@@ -49,7 +49,7 @@ const { Content } = await render(entry);
   </head>
 
   <body class="font-base bg-default">
-    <Header class="" />
+    <Header showDescription class="" />
 
     <MainContainer>
       <article class="py-8 lg:py-16">


### PR DESCRIPTION
## Summary

投稿詳細ページのヘッダーにdescriptionを表示するように変更しました。

## Changes

- `PostDetailPage.astro`で`Header`コンポーネントに`showDescription`プロパティを追加

## Test plan

- [ ] ビルドが成功すること
- [ ] 投稿詳細ページでヘッダーにdescriptionが表示されること