### PR TITLE
fix: improve documentation for auto-generated files (tags.json, categories.json)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
 ![deploy](https://github.com/lacolaco/blog.lacolaco.net/workflows/deploy-production/badge.svg)
+
+# blog.lacolaco.net
+
+Astro 5.x + Notion CMSによる個人ブログ。Angular技術ブログを中心に、日英バイリンガル対応。
+
+## 開発ガイドライン
+
+詳細な開発ガイドラインは [CLAUDE.md](./CLAUDE.md) を参照してください。
+
+## 自動生成ファイル
+
+**⚠️ 重要: 以下のファイルは自動生成されます。手動で編集しないでください。**
+
+- `src/content/post/**/*.md` - Notionから同期された記事ファイル
+- `src/content/post/metadata.json` - Notionメタデータ
+- `src/content/tags/tags.json` - タグ定義
+- `src/content/categories/categories.json` - カテゴリ定義
+- `public/images/**/*` - 記事内画像
+
+詳細は [tools/notion-sync/README.md](./tools/notion-sync/README.md) を参照してください。
+
+## コマンド
+
+```bash
+# 開発サーバー起動
+pnpm dev
+
+# Notionから記事を同期
+pnpm notion-sync
+
+# ビルド
+pnpm build
+
+# テスト
+pnpm test:tools
+
+# Lint & Format
+pnpm lint
+pnpm format
+```
+
+## デプロイ
+
+- **Production**: `main` ブランチへのpushで自動デプロイ（GCP Cloud Run）
+- **Preview**: Pull Requestで自動デプロイ（プレビュー環境）
+
+## アーキテクチャ
+
+- **フレームワーク**: Astro 5.x + React
+- **CMS**: Notion
+- **スタイリング**: Tailwind CSS 4.x
+- **ホスティング**: Google Cloud Run
+- **CI/CD**: GitHub Actions

--- a/tools/notion-sync/README.md
+++ b/tools/notion-sync/README.md
@@ -88,6 +88,14 @@ src/content/post/
 
 ### 生成されるファイル
 
+**⚠️ 警告: すべての生成ファイルは自動生成されます。手動編集しないでください。**
+
+- `src/content/post/**/*.md` - 記事Markdownファイル
+- `src/content/post/metadata.json` - Notionメタデータ
+- `src/content/tags/tags.json` - タグ定義（**DO NOT EDIT**）
+- `src/content/categories/categories.json` - カテゴリ定義（**DO NOT EDIT**）
+- `public/images/**/*` - 記事内画像
+
 #### src/content/post/metadata.json
 
 Notion datasourceから取得したメタデータ（@lacolaco/notion-sync@2.3.0以降）：
@@ -116,9 +124,9 @@ Notion datasourceから取得したメタデータ（@lacolaco/notion-sync@2.3.0
 }
 ```
 
-#### src/content/tags/tags.json
+#### src/content/tags/tags.json (**DO NOT EDIT**)
 
-metadata.jsonから生成される旧フォーマット（色情報付き）：
+metadata.jsonから自動生成される旧フォーマット（色情報付き）。**手動編集禁止**：
 
 ```json
 {
@@ -131,9 +139,9 @@ metadata.jsonから生成される旧フォーマット（色情報付き）：
 
 src/libs/post/properties.tsでインポートされ、`Tags` zodスキーマで検証される。
 
-#### src/content/categories/categories.json
+#### src/content/categories/categories.json (**DO NOT EDIT**)
 
-metadata.jsonから生成される旧フォーマット（色情報付き）：
+metadata.jsonから自動生成される旧フォーマット（色情報付き）。**手動編集禁止**：
 
 ```json
 {


### PR DESCRIPTION
## Summary

Improve documentation for auto-generated files, especially `tags.json` and `categories.json`.

## Changes

### tools/notion-sync/README.md
- Add **⚠️ warning section** for all auto-generated files
- Add **DO NOT EDIT** warnings to `tags.json` and `categories.json` sections
- List all auto-generated files with descriptions

### README.md (root)
- Add project overview and description
- Add **Auto-generated Files** section with explicit warnings
- Add development commands and architecture overview
- Link to detailed documentation (CLAUDE.md, tools/notion-sync/README.md)

## Why This Fix?

This addresses the lack of clear documentation about auto-generated files, which could lead to:
- Developers accidentally editing auto-generated files
- Loss of changes when files are regenerated
- Confusion about the project structure

## Test Plan

- [x] pnpm format
- [x] pnpm lint