### PR TITLE
fix: remove synchronize trigger from claude-code-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"


### PR DESCRIPTION
## Summary
- Remove `synchronize` trigger from claude-code-review workflow
- Only run Claude Code review when PR is opened, not on every subsequent commit

## Reason
- Reduces noise from repeated review comments
- Review on PR creation is sufficient