### PR TITLE
refactor: replace fetch with undici for Cloud Run 503 errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "satori": "^0.18.3",
+    "undici": "^7.16.0",
     "unist-util-visit": "^5.0.0",
     "yaml": "^2.8.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       satori:
         specifier: ^0.18.3
         version: 0.18.3
+      undici:
+        specifier: ^7.16.0
+        version: 7.16.0
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.0.0

--- a/src/libs/embed/fetchPageMetadata.ts
+++ b/src/libs/embed/fetchPageMetadata.ts
@@ -1,0 +1,150 @@
+import { load, type CheerioAPI } from 'cheerio';
+import pRetry, { AbortError } from 'p-retry';
+import { request } from 'undici';
+
+// 定数
+const FETCH_TIMEOUT_MS = 10000; // 10 seconds per request
+const AMAZON_URL_PREFIXES = ['https://www.amazon.co.jp/', 'https://amzn.asia/'];
+const GOOGLEBOT_USER_AGENT =
+  'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
+const DEFAULT_USER_AGENT = 'blog.lacolaco.net';
+
+// 型定義
+export interface PageMetadata {
+  title: string;
+  description: string;
+  imageUrl: string | null;
+  cacheControl: string | null;
+}
+
+interface FetchConfig {
+  userAgent: string;
+  cacheTtl: number;
+}
+
+// ヘルパー関数
+function getFetchConfig(url: string): FetchConfig {
+  const isAmazonRequest = AMAZON_URL_PREFIXES.some((domain) => url.startsWith(domain));
+  return {
+    userAgent: isAmazonRequest ? GOOGLEBOT_USER_AGENT : DEFAULT_USER_AGENT,
+    cacheTtl: 3600, // 1 hour
+  };
+}
+
+function extractTitle($: CheerioAPI, fallbackUrl: string): string {
+  const metaOgTitle = $('head>meta[property="og:title"]').attr('content');
+  if (metaOgTitle) return metaOgTitle;
+
+  const metaTitle = $('head>meta[name="title"]').attr('content');
+  if (metaTitle) return metaTitle;
+
+  const docTitle = $('title').text();
+  if (docTitle) return docTitle;
+
+  return fallbackUrl;
+}
+
+function extractDescription($: CheerioAPI): string {
+  const metaOgDescription = $('head>meta[property="og:description"]').attr('content');
+  if (metaOgDescription) return metaOgDescription;
+
+  const metaDescription = $('head>meta[name="description"]').attr('content');
+  if (metaDescription) return metaDescription;
+
+  const metaTwitterDescription = $('head>meta[name="twitter:description"]').attr('content');
+  if (metaTwitterDescription) return metaTwitterDescription;
+
+  return '';
+}
+
+function extractImageUrl($: CheerioAPI): string | null {
+  const metaOgImage = $('head>meta[property="og:image"]').attr('content');
+  if (metaOgImage) return metaOgImage;
+
+  const metaTwitterImage = $('head>meta[name="twitter:image"]').attr('content');
+  if (metaTwitterImage) return metaTwitterImage;
+
+  const metaImage = $('head>meta[name="image"]').attr('content');
+  if (metaImage) return metaImage;
+
+  const firstImg = $('img').first().attr('src');
+  if (firstImg) return firstImg;
+
+  return null;
+}
+
+/**
+ * 指定されたURLのページメタデータを取得する
+ * リトライ機能付きでHTTPリクエストを実行し、OGタグなどからメタデータを抽出する
+ *
+ * @param url - 取得対象のURL
+ * @returns ページメタデータ
+ */
+export async function fetchPageMetadata(url: string): Promise<PageMetadata> {
+  const config = getFetchConfig(url);
+
+  try {
+    const response = await pRetry(
+      async () => {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+        try {
+          const { statusCode, headers, body } = await request(url, {
+            signal: controller.signal,
+            method: 'GET',
+            headers: {
+              'user-agent': config.userAgent,
+              accept: 'text/html',
+              'accept-charset': 'utf-8',
+            },
+          });
+
+          clearTimeout(timeoutId);
+
+          // 4xx系エラーはリトライしない
+          if (statusCode >= 400 && statusCode < 500) {
+            throw new AbortError(`Client error: ${statusCode}`);
+          }
+
+          // 5xx系エラーはリトライ対象
+          if (statusCode >= 500) {
+            throw new Error(`Server error: ${statusCode}`);
+          }
+
+          return { statusCode, headers, body };
+        } catch (error) {
+          clearTimeout(timeoutId);
+          throw error;
+        }
+      },
+      {
+        retries: 3,
+        minTimeout: 1000, // 1秒
+        maxTimeout: 4000, // 4秒
+        factor: 2, // 指数バックオフ係数 (1秒 → 2秒 → 4秒)
+        onFailedAttempt: (error) => {
+          console.warn(`Retry ${error.attemptNumber}/3: ${url}`);
+        },
+      },
+    );
+
+    const html = await response.body.text();
+    const $ = load(html);
+
+    return {
+      title: extractTitle($, url),
+      description: extractDescription($),
+      imageUrl: extractImageUrl($),
+      cacheControl: (response.headers['cache-control'] as string) || null,
+    };
+  } catch (error) {
+    console.error(`Failed to fetch ${url}:`, error);
+    return {
+      title: url,
+      description: '',
+      imageUrl: null,
+      cacheControl: 'max-age=60, must-revalidate',
+    };
+  }
+}

--- a/src/pages/embed/index.ts
+++ b/src/pages/embed/index.ts
@@ -1,30 +1,11 @@
 import type { APIContext } from 'astro';
-import { load, type CheerioAPI } from 'cheerio';
-import pRetry, { AbortError } from 'p-retry';
 import escapeHtml from 'escape-html';
+import { fetchPageMetadata, type PageMetadata } from '../../libs/embed/fetchPageMetadata';
 
 export const prerender = false;
 
 // 定数
 const DEFAULT_CACHE_MAX_AGE = 60 * 60; // 1 hour
-const FETCH_TIMEOUT_MS = 10000; // 10 seconds per request
-const AMAZON_URL_PREFIXES = ['https://www.amazon.co.jp/', 'https://amzn.asia/'];
-const GOOGLEBOT_USER_AGENT =
-  'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
-const DEFAULT_USER_AGENT = 'blog.lacolaco.net';
-
-// 型定義
-interface PageMetadata {
-  title: string;
-  description: string;
-  imageUrl: string | null;
-  cacheControl: string | null;
-}
-
-interface FetchConfig {
-  userAgent: string;
-  cacheTtl: number;
-}
 
 /**
  * `/embed` エンドポイントのハンドラー
@@ -49,125 +30,6 @@ export async function GET(context: APIContext): Promise<Response> {
       'cache-control': metadata.cacheControl || `max-age=${DEFAULT_CACHE_MAX_AGE}`,
     },
   });
-}
-
-// ヘルパー関数
-function getFetchConfig(url: string): FetchConfig {
-  const isAmazonRequest = AMAZON_URL_PREFIXES.some((domain) => url.startsWith(domain));
-  return {
-    userAgent: isAmazonRequest ? GOOGLEBOT_USER_AGENT : DEFAULT_USER_AGENT,
-    cacheTtl: DEFAULT_CACHE_MAX_AGE,
-  };
-}
-
-function extractTitle($: CheerioAPI, fallbackUrl: string): string {
-  const metaOgTitle = $('head>meta[property="og:title"]').attr('content');
-  if (metaOgTitle) return metaOgTitle;
-
-  const metaTitle = $('head>meta[name="title"]').attr('content');
-  if (metaTitle) return metaTitle;
-
-  const docTitle = $('title').text();
-  if (docTitle) return docTitle;
-
-  return fallbackUrl;
-}
-
-function extractDescription($: CheerioAPI): string {
-  const metaOgDescription = $('head>meta[property="og:description"]').attr('content');
-  if (metaOgDescription) return metaOgDescription;
-
-  const metaDescription = $('head>meta[name="description"]').attr('content');
-  if (metaDescription) return metaDescription;
-
-  const metaTwitterDescription = $('head>meta[name="twitter:description"]').attr('content');
-  if (metaTwitterDescription) return metaTwitterDescription;
-
-  return '';
-}
-
-function extractImageUrl($: CheerioAPI): string | null {
-  const metaOgImage = $('head>meta[property="og:image"]').attr('content');
-  if (metaOgImage) return metaOgImage;
-
-  const metaTwitterImage = $('head>meta[name="twitter:image"]').attr('content');
-  if (metaTwitterImage) return metaTwitterImage;
-
-  const metaImage = $('head>meta[name="image"]').attr('content');
-  if (metaImage) return metaImage;
-
-  const firstImg = $('img').first().attr('src');
-  if (firstImg) return firstImg;
-
-  return null;
-}
-
-export async function fetchPageMetadata(url: string): Promise<PageMetadata> {
-  const config = getFetchConfig(url);
-
-  try {
-    const response = await pRetry(
-      async () => {
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-
-        try {
-          const res = await fetch(url, {
-            signal: controller.signal,
-            headers: {
-              'user-agent': config.userAgent,
-              accept: 'text/html',
-              'accept-charset': 'utf-8',
-            },
-          });
-
-          clearTimeout(timeoutId);
-
-          // 4xx系エラーはリトライしない
-          if (res.status >= 400 && res.status < 500) {
-            throw new AbortError(`Client error: ${res.status}`);
-          }
-
-          // 5xx系エラーはリトライ対象
-          if (!res.ok) {
-            throw new Error(`Server error: ${res.status}`);
-          }
-
-          return res;
-        } catch (error) {
-          clearTimeout(timeoutId);
-          throw error;
-        }
-      },
-      {
-        retries: 3,
-        minTimeout: 1000, // 1秒
-        maxTimeout: 4000, // 4秒
-        factor: 2, // 指数バックオフ係数 (1秒 → 2秒 → 4秒)
-        onFailedAttempt: (error) => {
-          console.warn(`Retry ${error.attemptNumber}/3: ${url}`);
-        },
-      },
-    );
-
-    const html = await response.text();
-    const $ = load(html);
-
-    return {
-      title: extractTitle($, url),
-      description: extractDescription($),
-      imageUrl: extractImageUrl($),
-      cacheControl: response.headers.get('cache-control'),
-    };
-  } catch (error) {
-    console.error(`Failed to fetch ${url}:`, error);
-    return {
-      title: url,
-      description: '',
-      imageUrl: null,
-      cacheControl: 'max-age=60, must-revalidate',
-    };
-  }
 }
 
 function getEmbedStyles(): string {
@@ -242,7 +104,7 @@ function getEmbedStyles(): string {
       .webpage-card {
         height: 7rem;
       }
-      
+
       .webpage-card-image {
         display: block;
       }


### PR DESCRIPTION
## Summary
Amazon URLの503エラーを解決するため、fetchをundiciに置き換え。

## 問題
- Cloud Run環境でAmazon URLを取得すると503エラー
- ローカル環境では成功
- Cloud RunのIPアドレス/リージョンがAmazonにブロックされている可能性

## 解決策
- `fetch` → `undici.request` に変更
- undiciは異なるTLS/SSL実装とヘッダー処理を持ち、Cloud RunのIP制限を回避できる可能性

## 追加の改善
- ビジネスロジックを `src/libs/embed/` に分離
- `src/pages/embed/index.ts` はルーティングのみ

## テスト
- [x] ローカルで全テストPASS (5/5)
- [x] Lint & Format & Build成功
- [ ] Cloud Runでの503エラー解決を検証

## Test Plan
1. Cloud Runデプロイ完了後
2. Amazon URL でテスト: `curl "https://pr-XXXX.a.run.app/embed?url=https://www.amazon.co.jp/dp/B0CP3BBKJW"`
3. タイトルが実際の商品名かどうか確認（フォールバックURLでないこと）

## Related
- PR #1230 (merged): p-retry追加、XSS対策、タイムアウト追加