### PR TITLE
fix: use Chrome User-Agent for Amazon URLs

### DIFF
--- a/src/pages/embed/index.ts
+++ b/src/pages/embed/index.ts
@@ -9,8 +9,8 @@ export const prerender = false;
 const DEFAULT_CACHE_MAX_AGE = 60 * 60; // 1 hour
 const FETCH_TIMEOUT_MS = 10000; // 10 seconds per request
 const AMAZON_URL_PREFIXES = ['https://www.amazon.co.jp/', 'https://amzn.asia/'];
-const GOOGLEBOT_USER_AGENT =
-  'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
+const CHROME_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
 const DEFAULT_USER_AGENT = 'blog.lacolaco.net';
 
 // 型定義
@@ -55,7 +55,7 @@ export async function GET(context: APIContext): Promise<Response> {
 function getFetchConfig(url: string): FetchConfig {
   const isAmazonRequest = AMAZON_URL_PREFIXES.some((domain) => url.startsWith(domain));
   return {
-    userAgent: isAmazonRequest ? GOOGLEBOT_USER_AGENT : DEFAULT_USER_AGENT,
+    userAgent: isAmazonRequest ? CHROME_USER_AGENT : DEFAULT_USER_AGENT,
     cacheTtl: DEFAULT_CACHE_MAX_AGE,
   };
 }


### PR DESCRIPTION
## Summary
User-AgentをGooglebotからChromeに変更してAmazon URL取得成功率の改善を検証。

## 現状
- 本番環境（Googlebot UA）: 3件中1件成功（33%）
- ローカル環境: User-Agentに関わらず全て成功

## 変更内容
- `GOOGLEBOT_USER_AGENT` → `CHROME_USER_AGENT`
- Chrome 131 on macOS のUser-Agent文字列を使用

## 検証予定
Cloud Run環境でChrome UAを使用した場合の成功率を測定:
```bash
curl "https://pr-XXXX.../embed?url=https://www.amazon.co.jp/dp/B002IJ6VK4"
curl "https://pr-XXXX.../embed?url=https://www.amazon.co.jp/dp/B0CP3BBKJW"
curl "https://pr-XXXX.../embed?url=https://www.amazon.co.jp/dp/B0D7QZ21CD"
```

Googlebot UAで成功していたB002IJ6VK4が引き続き成功し、
失敗していたB0CP3BBKJWとB0D7QZ21CDが改善するか確認。