### PR TITLE
fix: improve HTTP headers for Amazon URL compatibility

### DIFF
--- a/src/pages/embed/index.ts
+++ b/src/pages/embed/index.ts
@@ -115,9 +115,10 @@ export async function fetchPageMetadata(url: string): Promise<PageMetadata> {
           const res = await fetch(url, {
             signal: controller.signal,
             headers: {
-              'user-agent': config.userAgent,
-              accept: 'text/html',
-              'accept-charset': 'utf-8',
+              'User-Agent': config.userAgent,
+              'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+              'Accept-Language': 'ja,en-US;q=0.9,en;q=0.8',
+              'Accept-Charset': 'utf-8',
             },
           });
 


### PR DESCRIPTION
## Summary
HTTPヘッダーを改善してAmazon URLの取得成功率向上を試みる。

## 変更内容
- `Accept`ヘッダー改善: より詳細なMIMEタイプリスト
- `Accept-Language`追加: ja,en-US;q=0.9,en;q=0.8
- ヘッダー名を標準的な大文字小文字に統一

## リトライ設定
変更なし（3回、1s→2s→4s）

## 検証
Cloud Run環境で成功率を測定:
- B002IJ6VK4
- B0CP3BBKJW  
- B0D7QZ21CD