### PR TITLE
fix: add required commands to claude_args allowedTools

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: '--allowedTools Bash(pnpm format),Bash(pnpm lint),Bash(pnpm test:*),Bash(pnpm build),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr view:*),Bash(gh issue view:*)'
 


### PR DESCRIPTION
GitHub ActionsのClaude Code Actionで必要なコマンドが実行できなかった問題を修正。

## 問題

以下のジョブでpermission denialが発生：
- https://github.com/lacolaco/blog.lacolaco.net/actions/runs/20388618461 (`pnpm format`が実行できない)
- https://github.com/lacolaco/blog.lacolaco.net/actions/runs/20389761382 (`gh pr create`が実行できない)

## 原因

`.github/workflows/claude.yml`で`claude_args`が未設定のため、デフォルトの`allowedTools`のみが使用され、必要なコマンドが含まれていなかった。

## 修正内容

`claude_args`に以下のコマンドを追加：
- `Bash(pnpm format)` - format error自動修正
- `Bash(pnpm lint)` - lint error自動修正
- `Bash(pnpm test:*)` - テスト実行
- `Bash(pnpm build)` - ビルド確認
- `Bash(gh pr create:*)` - PR作成
- `Bash(gh pr edit:*)` - PR編集
- `Bash(gh pr view:*)` - PR情報取得
- `Bash(gh issue view:*)` - Issue情報取得

## 効果

Claudeがformat errorの自動修正やPR作成を実行できるようになる。