### PR TITLE
fix: use rendered HTML in full RSS feeds

### DIFF
--- a/src/pages/categories/[category].en.full.xml.ts
+++ b/src/pages/categories/[category].en.full.xml.ts
@@ -42,7 +42,7 @@ export async function GET(context: APIContext<Props>) {
         pubDate: post.data.created_time,
         link: `/posts/${post.data.slug}.en`,
         categories: post.data.tags,
-        content: post.body,
+        content: post.rendered?.html,
       };
     }),
   });

--- a/src/pages/categories/[category].full.xml.ts
+++ b/src/pages/categories/[category].full.xml.ts
@@ -42,7 +42,7 @@ export async function GET(context: APIContext<Props>) {
         pubDate: post.data.created_time,
         link: `/posts/${post.data.slug}`,
         categories: post.data.tags,
-        content: post.body,
+        content: post.rendered?.html,
       };
     }),
   });

--- a/src/pages/index.en.full.xml.ts
+++ b/src/pages/index.en.full.xml.ts
@@ -17,7 +17,7 @@ export async function GET(context: APIContext) {
         pubDate: post.data.created_time,
         link: `/posts/${post.data.slug}.en`,
         categories: post.data.tags,
-        content: post.body,
+        content: post.rendered?.html,
       };
     }),
   });

--- a/src/pages/index.full.xml.ts
+++ b/src/pages/index.full.xml.ts
@@ -17,7 +17,7 @@ export async function GET(context: APIContext) {
         pubDate: post.data.created_time,
         link: `/posts/${post.data.slug}`,
         categories: post.data.tags,
-        content: post.body,
+        content: post.rendered?.html,
       };
     }),
   });

--- a/src/pages/tags/[tag].en.full.xml.ts
+++ b/src/pages/tags/[tag].en.full.xml.ts
@@ -40,7 +40,7 @@ export async function GET(context: APIContext<Props>) {
         pubDate: post.data.created_time,
         link: `/posts/${post.data.slug}.en`,
         categories: post.data.tags,
-        content: post.body,
+        content: post.rendered?.html,
       };
     }),
   });

--- a/src/pages/tags/[tag].full.xml.ts
+++ b/src/pages/tags/[tag].full.xml.ts
@@ -40,7 +40,7 @@ export async function GET(context: APIContext<Props>) {
         pubDate: post.data.created_time,
         link: `/posts/${post.data.slug}`,
         categories: post.data.tags,
-        content: post.body,
+        content: post.rendered?.html,
       };
     }),
   });


### PR DESCRIPTION
## Summary
- Use `post.rendered?.html` instead of `post.body` in full RSS feeds
- Fixes line breaks being omitted in RSS content

## Problem
Raw markdown body loses formatting when rendered in RSS readers - all line breaks were stripped.

## Solution
Use Astro's pre-rendered HTML (`post.rendered?.html`) which preserves proper formatting with HTML tags.