### PR TITLE
feat(remark-embed): support YouTube Shorts and Live URLs

### DIFF
--- a/tools/remark-embed/handlers.ts
+++ b/tools/remark-embed/handlers.ts
@@ -82,7 +82,7 @@ function createYouTubeHandler(config: EmbedConfig): EmbedHandler {
       const youtubeConfig = { ...defaultYouTubeConfig, ...config.youtube };
 
       const match = url.match(
-        /^(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:watch\?v=|embed\/|v\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/,
+        /^(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:watch\?v=|embed\/|v\/|shorts\/|live\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/,
       );
       const videoId = match ? match[1] : undefined;
       if (!videoId) {

--- a/tools/remark-embed/index.spec.ts
+++ b/tools/remark-embed/index.spec.ts
@@ -66,6 +66,63 @@ describe('remarkEmbed', () => {
       const result = await processMarkdown(markdown);
       assert.equal(result, expectedHtml);
     });
+
+    test('YouTube ShortsのURLであるとき、YouTube動画が埋め込まれる', async () => {
+      const markdown = 'https://youtube.com/shorts/0uFosrTxYCc';
+      const videoId = '0uFosrTxYCc';
+      const expectedHtml = `
+<div class="block-link block-link-youtube">
+  <iframe
+    width="560"
+    height="315"
+    src="https://www.youtube.com/embed/${videoId}"
+    style="border: none;"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen
+  ></iframe>
+</div>
+      `.trim();
+      const result = await processMarkdown(markdown);
+      assert.equal(result, expectedHtml);
+    });
+
+    test('YouTube ShortsのURL（クエリパラメータ付き）であるとき、YouTube動画が埋め込まれる', async () => {
+      const markdown = 'https://youtube.com/shorts/0uFosrTxYCc?feature=share';
+      const videoId = '0uFosrTxYCc';
+      const expectedHtml = `
+<div class="block-link block-link-youtube">
+  <iframe
+    width="560"
+    height="315"
+    src="https://www.youtube.com/embed/${videoId}"
+    style="border: none;"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen
+  ></iframe>
+</div>
+      `.trim();
+      const result = await processMarkdown(markdown);
+      assert.equal(result, expectedHtml);
+    });
+
+    test('YouTube liveのURLであるとき、YouTube動画が埋め込まれる', async () => {
+      const markdown = 'https://www.youtube.com/live/ATlbJnc4d3o';
+      const videoId = 'ATlbJnc4d3o';
+      const expectedHtml = `
+<div class="block-link block-link-youtube">
+  <iframe
+    width="560"
+    height="315"
+    src="https://www.youtube.com/embed/${videoId}"
+    style="border: none;"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen
+  ></iframe>
+</div>
+      `.trim();
+      const result = await processMarkdown(markdown);
+      assert.equal(result, expectedHtml);
+    });
   });
 
   describe('WebページURLの埋め込み', () => {


### PR DESCRIPTION
## Summary

- YouTube Shorts (`/shorts/`) および Live (`/live/`) の URL パターンに対応
- Notion の外部動画ブロックから取り込まれたこれらの URL が iframe 埋め込みとして正しくレンダリングされるようになった

## Changes

- `tools/remark-embed/handlers.ts`: YouTube URL の正規表現を拡張して `shorts/` と `live/` パスをサポート
- `tools/remark-embed/index.spec.ts`: YouTube Shorts と Live URL 用のテストケースを 3 件追加

## Test Plan

- [x] すべてのテストが成功 (56/56 passed)
- [x] lint 成功
- [x] format 成功
- [x] build 成功
- [x] Shorts URL が iframe として埋め込まれることを確認
- [x] Live URL が iframe として埋め込まれることを確認