### PR TITLE
chore: reduce sync-with-notion cron interval from 5min to 2h

### DIFF
--- a/.github/workflows/sync-with-notion.yml
+++ b/.github/workflows/sync-with-notion.yml
@@ -2,7 +2,7 @@ name: sync-with-notion
 
 on:
   schedule:
-    - cron: '0/5 * * * *'
+    - cron: '0 */2 * * *'
   workflow_dispatch:
     inputs:
       forceUpdate:


### PR DESCRIPTION
## Summary
- `sync-with-notion.yml` の cron 間隔を5分(`0/5 * * * *`)から2時間(`0 */2 * * *`)に変更
- Webhook駆動の `repository_dispatch` が Notion コンテンツ変更時の即時同期を担うため、cron は missed webhook のセーフティネットとしてのみ機能
- 2時間間隔で十分

## Test plan
- [ ] GitHub Actions の Schedule トリガーが正しく2時間間隔で動作することを確認
- [ ] `repository_dispatch` による即時同期が引き続き正常に動作することを確認

https://claude.ai/code/session_01FkBMYhdYW8ErDJvRZW1dGe