### PR TITLE
ci(claude): add WebSearch to allowed tools

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowedTools Bash(pnpm format),Bash(pnpm lint),Bash(pnpm test:*),Bash(pnpm build),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr view:*),Bash(gh issue view:*)'
+          claude_args: '--allowedTools WebSearch,Bash(pnpm format),Bash(pnpm lint),Bash(pnpm test:*),Bash(pnpm build),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr view:*),Bash(gh issue view:*)'
 


### PR DESCRIPTION
## Summary
- Claude Code ActionのallowedToolsにWebSearchを追加
- CI環境でWeb検索ツールが権限不足で拒否される問題を解消

## Test plan
- [ ] Claude Code Actionが@claude呼び出し時にWebSearchを使用できることを確認