### PR TITLE
feat(ui): add image lightbox and reduce inline image height

### DIFF
--- a/src/components/ImageLightbox.astro
+++ b/src/components/ImageLightbox.astro
@@ -1,0 +1,36 @@
+<!-- 記事画像のクリック拡大ビュー -->
+<dialog id="image-lightbox" aria-label="画像の拡大表示" class="m-0 p-0 border-none bg-transparent max-w-full max-h-full w-screen h-screen">
+  <img class="w-full h-full object-contain p-4" alt="" />
+</dialog>
+
+<style>
+  #image-lightbox::backdrop {
+    background: rgba(0, 0, 0, 0.8);
+  }
+</style>
+
+<script>
+  const dialog = document.getElementById('image-lightbox') as HTMLDialogElement;
+  const dialogImg = dialog.querySelector('img')!;
+
+  // backdrop クリックで閉じる
+  dialog.addEventListener('click', (e) => {
+    if (e.target === dialog) {
+      dialog.close();
+    }
+  });
+
+  // 画像クリックでも閉じる
+  dialogImg.addEventListener('click', () => {
+    dialog.close();
+  });
+
+  // 記事内画像にクリックハンドラを付与
+  document.querySelectorAll<HTMLImageElement>('.markdown-body :is(p, figure) > img').forEach((img) => {
+    img.addEventListener('click', () => {
+      dialogImg.src = img.src;
+      dialogImg.alt = img.alt;
+      dialog.showModal();
+    });
+  });
+</script>

--- a/src/layouts/PostDetailPage.astro
+++ b/src/layouts/PostDetailPage.astro
@@ -11,6 +11,7 @@ import ShareButtons from '../components/ShareButtons.astro';
 import Tag from '../components/Tag.astro';
 import TagList from '../components/TagList.astro';
 import ArticleSummarizer from '../components/ArticleSummarizer';
+import ImageLightbox from '../components/ImageLightbox.astro';
 import { SITE_TITLE } from '../consts';
 import { queryAvailablePosts } from '@lib/query';
 import { getRelativePostUrl } from '../libs/compat';
@@ -130,6 +131,8 @@ const alternatePost = alternateLocalePosts.length > 0 ? alternateLocalePosts[0] 
     </MainContainer>
 
     <Footer class="py-4" />
+
+    <ImageLightbox />
 
     {features?.tweet ? <script is:inline async src="https://platform.twitter.com/widgets.js" charset="utf-8" /> : null}
     {features?.mermaid ? (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -132,7 +132,9 @@
 
     p > img,
     figure > img {
-      @apply max-w-full box-content place-self-center object-contain w-full md:max-w-(--breakpoint-md) max-h-[75vh];
+      @apply max-w-full block mx-auto object-contain md:max-w-(--breakpoint-md) cursor-pointer transition-opacity duration-200 hover:opacity-80;
+      max-height: 50vh;
+      max-height: 50dvh;
     }
 
     figure {


### PR DESCRIPTION
## Summary
- 記事中の画像の高さ上限を `75vh` → `50dvh` に縮小（`50vh` フォールバック付き）
- 画像クリックで `<dialog>` ベースのライトボックスを開く機能を追加
- ホバー時の視覚フィードバック（opacity変化）を追加
- 画像の中央配置を `place-self-center` から `block mx-auto` に修正

## Test plan
- [ ] 画像を含む記事ページで高さが50dvh以下に収まることを確認
- [ ] 画像クリックでライトボックスが開くことを確認
- [ ] ライトボックス内画像クリック / backdrop クリック / Escキーで閉じることを確認
- [ ] ホバー時にopacity変化があることを確認
- [ ] モバイル表示で画像が中央配置されていることを確認