### PR TITLE
feat(ui): モバイル表示の包括的レスポンシブ改善

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -8,7 +8,7 @@ type Props = {
 const { class: className } = Astro.props;
 ---
 
-<footer class="max-w-(--breakpoint-lg) mx-[2rem] lg:mx-auto" class:list={className}>
+<footer class="max-w-(--breakpoint-lg) mx-0 px-4 md:mx-[2rem] md:px-0 lg:mx-auto" class:list={className}>
   <div
     class="flex flex-col items-center justify-between pt-[32px] pb-[8px] text-sm text-default border-transparent border-solid border-t-default"
   >

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -10,20 +10,20 @@ const { class: className, showDescription } = Astro.props;
 ---
 
 <header
-  class="group max-w-(--breakpoint-lg) mx-[2rem] lg:mx-auto flex flex-col py-4"
+  class="group max-w-(--breakpoint-lg) px-4 md:px-0 md:mx-[1rem] lg:mx-auto flex flex-col py-3 md:py-4 bg-white md:bg-transparent border-b border-gray-200 md:border-b-0"
   class:list={className}
 >
-  <div class="w-full grid grid-rows-[34px] grid-cols-[1fr_auto_1fr] items-center">
-    <div></div>
+  <div class="w-full flex items-center justify-between md:grid md:grid-rows-[34px] md:grid-cols-[1fr_auto_1fr]">
+    <div class="hidden md:block"></div>
     <div>
       <a
         href="/"
-        class="font-title text-center text-2xl font-semibold text-default hover:text-default-muted hover:underline"
+        class="font-title text-lg md:text-2xl font-semibold text-default hover:text-default-muted hover:underline"
       >
         {SITE_TITLE}
       </a>
     </div>
-    <div class="flex flex-row items-center justify-end gap-x-4 text-sm font-semibold">
+    <div class="flex flex-row items-center justify-end gap-x-2 md:gap-x-4 text-sm font-semibold">
       <div class="flex items-center">
         <search-toggle-button>
           <button class="text-default leading-0 rounded-full p-1" title="tags">
@@ -32,15 +32,16 @@ const { class: className, showDescription } = Astro.props;
         </search-toggle-button>
       </div>
       <div class="flex items-center">
-        <a href="/tags/" class="text-default hover:text-default-muted hover:no-underline" title="tags">Tags</a>
+        <a href="/tags/" class="text-default hover:text-default-muted hover:no-underline leading-0 rounded-full p-1" title="Tags">
+          <span class="icon-[mdi--tag-outline] text-[20px] md:hidden"></span>
+          <span class="hidden md:inline">Tags</span>
+        </a>
       </div>
       <div class="flex items-center">
         <a href="https://lacolaco.net" target="_blank" rel="noopener" title="profile">
           <img
-            class="rounded-full border border-solid border-gray-400 block"
+            class="rounded-full border border-solid border-gray-400 block w-6 h-6 md:w-8 md:h-8"
             src="/icons/laco.png"
-            height="32"
-            width="32"
           />
         </a>
       </div>
@@ -48,7 +49,7 @@ const { class: className, showDescription } = Astro.props;
   </div>
   {
     showDescription && (
-      <div class="w-full font-title flex flex-col items-center mt-3">
+      <div class="w-full font-title flex-col items-center mt-1 md:mt-3 hidden md:flex">
         <p data-description class="text-center text-xs text-default-muted">
           {SITE_DESCRIPTION}
         </p>

--- a/src/components/MainContainer.astro
+++ b/src/components/MainContainer.astro
@@ -7,7 +7,7 @@ const { class: className } = Astro.props;
 ---
 
 <main
-  class="max-w-(--breakpoint-lg) mx-[1rem] lg:mx-auto px-8 lg:px-16 bg-white rounded-lg shadow-lg"
+  class="max-w-(--breakpoint-lg) mx-0 md:mx-[1rem] lg:mx-auto px-4 lg:px-16 bg-white rounded-none md:rounded-lg shadow-none md:shadow-lg"
   class:list={className}
 >
   <slot />

--- a/src/components/PostNavigation.astro
+++ b/src/components/PostNavigation.astro
@@ -22,7 +22,7 @@ if (!prev && !next) {
         <a
           href={getRelativePostUrl(next)}
           aria-label={`次の記事: ${next.data.title}`}
-          class="group block p-4 md:p-6 rounded-2xl bg-white transition-all duration-300 ease-in-out shadow-[6px_6px_12px_rgba(163,177,198,0.4),-6px_-6px_12px_rgba(255,255,255,0.4)] hover:shadow-[inset_4px_4px_8px_rgba(163,177,198,0.4),inset_-4px_-4px_8px_rgba(255,255,255,0.4)]"
+          class="group block p-4 md:p-6 rounded-lg border border-gray-200 bg-white transition-colors hover:bg-gray-50"
         >
           <div class="flex items-center gap-2 md:gap-3">
             <span
@@ -45,7 +45,7 @@ if (!prev && !next) {
         <a
           href={getRelativePostUrl(prev)}
           aria-label={`前の記事: ${prev.data.title}`}
-          class="group block p-4 md:p-6 rounded-2xl bg-white transition-all duration-300 ease-in-out shadow-[6px_6px_12px_rgba(163,177,198,0.4),-6px_-6px_12px_rgba(255,255,255,0.4)] hover:shadow-[inset_4px_4px_8px_rgba(163,177,198,0.4),inset_-4px_-4px_8px_rgba(255,255,255,0.4)]"
+          class="group block p-4 md:p-6 rounded-lg border border-gray-200 bg-white transition-colors hover:bg-gray-50"
         >
           <div class="flex items-center gap-2 md:gap-3 md:flex-row-reverse">
             <span

--- a/src/components/ShareButtons.astro
+++ b/src/components/ShareButtons.astro
@@ -9,46 +9,49 @@ const { title, url } = Astro.props;
 const encodedTitle = encodeURIComponent(title);
 ---
 
-<section class="mt-4 flex flex-wrap justify-between content-center items-center space-x-2">
+<section class="mt-4 flex items-center gap-3">
   <a
     href={`https://twitter.com/intent/tweet?original_referer=${url}&text=${encodedTitle}&url=${url}`}
     target="_blank"
-    class="inline-flex items-center gap-x-1 px-2 py-1 text-xs leading-tight font-bold text-white bg-black rounded-md hover:bg-gray-700"
+    class="inline-flex items-center justify-center w-10 h-10 text-white bg-black rounded-full hover:bg-gray-700 transition-colors"
+    title="Xでポスト"
   >
-    <span class="icon-[bi--twitter-x] inline-block"></span>
-    ポスト
+    <span class="icon-[bi--twitter-x] inline-block text-base"></span>
   </a>
 
   <a
     href={`https://bsky.app/intent/compose?text=${encodedTitle + " "+ url}`}
     target="_blank"
-    class="inline-flex items-center gap-x-1 px-2 py-1 text-xs leading-tight font-bold text-lime-100 bg-[#1084fd] rounded-md hover:bg-blue-600"
+    class="inline-flex items-center justify-center w-10 h-10 text-white bg-[#1084fd] rounded-full hover:bg-blue-600 transition-colors"
+    title="Blueskyでシェア"
   >
-    <span class="icon-[simple-icons--bluesky] inline-block"></span>
-    share to bluesky
+    <span class="icon-[simple-icons--bluesky] inline-block text-base"></span>
   </a>
 
   <a
     href={`https://misskey-hub.net/share/?text=${encodedTitle}&url=${url}&visibility=public&localOnly=0`}
     target="_blank"
-    class="inline-flex items-center gap-x-1 px-2 py-1 text-xs leading-tight font-bold text-lime-100 bg-lime-700 rounded-md hover:bg-lime-600"
+    class="inline-flex items-center justify-center w-10 h-10 text-white bg-lime-700 rounded-full hover:bg-lime-600 transition-colors"
+    title="Misskeyでシェア"
   >
-    <span class="icon-[simple-icons--misskey] inline-block"></span>
-    share to misskey
+    <span class="icon-[simple-icons--misskey] inline-block text-base"></span>
   </a>
 
   <a
     href={`https://donshare.net/share.html?text=${encodedTitle}&url=${url}`}
     target="_blank"
-    class="inline-flex items-center gap-x-1 px-2 py-1 text-xs leading-tight font-bold text-white bg-blue-500 rounded-md hover:bg-blue-600"
+    class="inline-flex items-center justify-center w-10 h-10 text-white bg-blue-500 rounded-full hover:bg-blue-600 transition-colors"
+    title="Mastodonでシェア"
   >
-    <span class="icon-[simple-icons--mastodon] inline-block"></span>
-    donshare
+    <span class="icon-[simple-icons--mastodon] inline-block text-base"></span>
   </a>
 
   <div class="flex-auto"></div>
   <button
-    class="px-2 py-1 text-sm leading-tight rounded-md border border-solid border-gray-700 hover:bg-muted"
-    onclick="window.scrollTo(0, 0);">Scroll to top</button
+    class="inline-flex items-center justify-center w-10 h-10 rounded-full border border-gray-300 text-muted hover:text-default hover:bg-gray-100 transition-colors"
+    onclick="window.scrollTo(0, 0);"
+    title="ページ上部へ"
   >
+    <span class="icon-[mdi--arrow-up] inline-block text-lg"></span>
+  </button>
 </section>

--- a/src/layouts/List.astro
+++ b/src/layouts/List.astro
@@ -37,7 +37,7 @@ const postsByYear = Array.from(
     <BaseHead title={SITE_TITLE} description={''} />
   </head>
 
-  <body class="font-base bg-default">
+  <body class="font-base bg-default text-default">
     <Header showDescription />
 
     <MainContainer>

--- a/src/layouts/PostDetailPage.astro
+++ b/src/layouts/PostDetailPage.astro
@@ -59,12 +59,12 @@ const alternatePost = alternateLocalePosts.length > 0 ? alternateLocalePosts[0] 
     ) : null}
   </head>
 
-  <body class="font-base bg-default">
+  <body class="font-base bg-default text-default">
     <Header showDescription class="" />
 
     <MainContainer>
-      <article class="py-8 lg:py-16">
-        <header class="mb-6">
+      <article class="pt-4 pb-10 lg:pt-16 lg:pb-16">
+        <header class="mb-3 lg:mb-6">
           <div class="leading-none">
             <span class="text-sm text-muted">
               {
@@ -83,7 +83,7 @@ const alternatePost = alternateLocalePosts.length > 0 ? alternateLocalePosts[0] 
                 )
               }
             </span>
-            <h1 class="text-2xl font-semibold leading-tight mb-1">{title}</h1>
+            <h1 class="text-2xl font-bold leading-normal mb-1">{title}</h1>
             <div class="py-1 flex items-center justify-between">
               <TagList>
                 {category && <Tag name={category} isCategory />}

--- a/src/layouts/Tags.astro
+++ b/src/layouts/Tags.astro
@@ -25,7 +25,7 @@ const sortedTags = tags.sort((a, b) => a.name.localeCompare(b.name));
     <BaseHead title={SITE_TITLE} description={''} />
   </head>
 
-  <body class="font-base bg-default">
+  <body class="font-base bg-default text-default">
     <Header showDescription />
 
     <MainContainer>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -14,7 +14,7 @@ import MainContainer from '../components/MainContainer.astro';
       description="お探しのページは見つかりませんでした。"
     />
   </head>
-  <body class="font-base bg-default">
+  <body class="font-base bg-default text-default">
     <Header />
     <MainContainer>
       <div class="flex flex-col items-center justify-center py-16 px-4">

--- a/src/pages/kitchen-sink.astro
+++ b/src/pages/kitchen-sink.astro
@@ -28,7 +28,7 @@ const isUpdated = last_edited_time && isAfterDate(last_edited_time, created_time
     ) : null}
   </head>
 
-  <body class="font-base bg-default">
+  <body class="font-base bg-default text-default">
     <Header class="" />
 
     <MainContainer>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -74,7 +74,7 @@
 
 @layer components {
   .markdown-body {
-    @apply font-base leading-loose;
+    @apply font-base leading-[1.8] md:leading-loose;
 
     & > *:first-child {
       @apply mt-0;
@@ -89,16 +89,16 @@
     h4,
     h5,
     h6 {
-      @apply mt-6 mb-4 font-semibold leading-tight;
+      @apply mt-4 mb-3 md:mt-6 md:mb-4 font-semibold leading-tight;
     }
     h1 {
-      @apply text-3xl pb-[.3em] border-b border-solid border-b-gray-200;
+      @apply text-2xl md:text-3xl pb-[.3em] border-b border-solid border-b-gray-200;
     }
     h2 {
-      @apply text-2xl pb-[.3em] border-b border-solid border-b-gray-200;
+      @apply text-[22px] md:text-2xl pb-[.3em] border-b border-solid border-b-gray-200;
     }
     h3 {
-      @apply text-xl;
+      @apply text-[19px] md:text-xl;
     }
     h4 {
       @apply text-lg;
@@ -119,7 +119,7 @@
     pre,
     details,
     figure {
-      @apply mt-0 mb-4;
+      @apply mt-0 mb-3 md:mb-4;
     }
 
     details {
@@ -147,7 +147,7 @@
 
     ul,
     ol {
-      @apply pl-8;
+      @apply pl-6 md:pl-8;
       list-style: revert;
 
       ul,


### PR DESCRIPTION
## Summary
- Zenn/dev.toの実測CSS値を基準に、モバイル表示を全面的に最適化
- モバイルで全幅白背景レイアウト（カード+影+角丸はmd以上のみ）
- タイポグラフィをZenn基準に調整（タイトル24px/bold, 本文16px/LH1.8, 見出し縮小）
- 全ページでテキスト色を`text-default`(`#24292f`)に統一
- ShareButtonsをアイコンのみ丸ボタンに変更（40pxタッチターゲット）
- PostNavigationをボーダースタイルに変更
- Header/Footer/MainContainerのモバイル余白を統一

## Test plan
- [ ] モバイル(375px): ヘッダー（タイトル左寄せ+アイコンナビ）、コンテンツ全幅、フッター幅統一
- [ ] タブレット(768px): カード+影+角丸に切り替わること、Tagsテキスト表示
- [ ] デスクトップ(1280px): タイトル中央寄せ、Description表示、従来レイアウト維持
- [ ] シェアボタン: アイコンのみ丸ボタン、タッチターゲット40px、全リンク動作
- [ ] 前後記事ナビ: ボーダースタイル、ホバーで背景色変化
- [ ] 記事一覧・タグ一覧ページでレイアウト破綻がないこと