### PR TITLE
fix: migrate-channels workflowにworkflow_dispatch追加

### DIFF
--- a/.github/workflows/migrate-channels.yml
+++ b/.github/workflows/migrate-channels.yml
@@ -4,6 +4,7 @@ name: Migrate channels to Notion
 # マイグレーション完了後にこのファイルごと削除する。
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
     paths:
@@ -25,6 +26,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run migration
-        run: pnpm migrate-channels -- --apply
+        run: pnpm migrate-channels -- --apply 2>&1
         env:
           NOTION_AUTH_TOKEN: ${{ secrets.NOTION_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- migrate-channels workflowに`workflow_dispatch`トリガーを追加（手動再実行可能に）
- 初回自動実行が失敗したため、手動再実行で対応

## 背景
#1367 マージ時にmigrate-channels.ymlが自動実行されたが失敗。エラーログが取得できないため、workflow_dispatchを追加して手動再実行可能にする。

https://claude.ai/code/session_01Kzdqksm8Q9rpF9yPQSVRyz