### PR TITLE
fix: bot PR対応とnotion-sync channels抽出の堅牢化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,7 @@ jobs:
         uses: anthropics/claude-code-action@6062f3709600659be5e47fcddf2cf76993c235c2 # v1.0.76
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'lacolaco-actions-worker[bot]'
           prompt: |
             このPRに含まれるブログ記事コンテンツの変更をレビューしてください。
             `gh pr diff ${{ github.event.pull_request.number }}` でdiffを取得し、コンテンツファイル（src/content/**, public/images/**）の変更のみを対象に文面チェックを行ってください。
@@ -320,6 +321,7 @@ jobs:
         uses: anthropics/claude-code-action@6062f3709600659be5e47fcddf2cf76993c235c2 # v1.0.76
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'lacolaco-actions-worker[bot]'
           prompt: |
             このPRのコード変更をレビューしてください。
             `gh pr diff ${{ github.event.pull_request.number }}` でdiffを取得し、コードファイルの変更のみを対象にレビューを行ってください。

--- a/tools/notion-sync/main.ts
+++ b/tools/notion-sync/main.ts
@@ -77,7 +77,12 @@ const result = await syncNotionBlog({
     const icon = page.icon && page.icon.type === 'emoji' ? page.icon.emoji : '';
 
     // channels マルチセレクトの読み取り
-    const channels: string[] = extractMultiSelectNames(page.properties, 'channels');
+    let channels: string[] = [];
+    try {
+      channels = extractMultiSelectNames(page.properties, 'channels');
+    } catch {
+      // channelsプロパティが存在しない場合は空配列
+    }
 
     // category=diaryかつslugがページID（空デフォルト）の場合、作成日時をslugとする
     let slug = metadata.slug;


### PR DESCRIPTION
## Summary
- content-review/code-review: `lacolaco-actions-worker[bot]` をスキップ対象に追加。notion-sync PRはbot生成のため、claude-code-actionレビューが権限エラーで失敗していた
- notion-sync: channels抽出をtry-catchで保護（notion-sync-dry-run失敗防止）

## 背景
#1376 (notion-sync PR) のCIが2箇所で失敗:
1. `content-review`: bot PRでclaude-code-actionが権限エラー
2. `notion-sync-dry-run`: channels抽出のランタイムエラー

https://claude.ai/code/session_01Kzdqksm8Q9rpF9yPQSVRyz