### PR TITLE
fix: migrate-channels workflowにログ出力追加

### DIFF
--- a/.github/workflows/migrate-channels.yml
+++ b/.github/workflows/migrate-channels.yml
@@ -26,6 +26,15 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run migration
-        run: pnpm migrate-channels -- --apply 2>&1
+        run: |
+          set -o pipefail
+          pnpm migrate-channels -- --apply 2>&1 | tee /tmp/migrate-output.txt
         env:
           NOTION_AUTH_TOKEN: ${{ secrets.NOTION_AUTH_TOKEN }}
+      - name: Output logs to summary
+        if: always()
+        run: |
+          echo '## Migration Log' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          tail -100 /tmp/migrate-output.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
migrate-channels workflowの失敗原因が見えない。Step Summary出力を追加して次回実行時にログを確認可能にする。

https://claude.ai/code/session_01Kzdqksm8Q9rpF9yPQSVRyz