### PR TITLE
fix: CLAUDE.mdからGITHUB_TOKEN前提の記述を削除

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,6 @@ pnpm test:libs    # library tests
   curl -s "https://api.github.com/repos/lacolaco/blog.lacolaco.net/check-runs/{job_id}/annotations" \
     -H "Accept: application/vnd.github+json"
   ```
-- GITHUB_TOKENが環境変数に設定されていれば `gh run view --log` で直接ログ取得可能（#1386参照）
 - CIステップにデバッグ出力を追加した場合、修正完了後に必ず削除してci.ymlをmainと同一に戻せ
 
 ### Git Operations


### PR DESCRIPTION
CLAUDE.mdからGITHUB_TOKEN前提の記述を削除。Claude Code Web UIの環境変数は全ユーザーに表示されるため機密情報を設定すべきでない。

https://claude.ai/code/session_01Kzdqksm8Q9rpF9yPQSVRyz