### PR TITLE
feat: @lacolaco/notion-sync v6.0.0にアップデート

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@aws-sdk/client-s3": "^3.967.0",
     "@iconify/json": "^2.2.161",
     "@iconify/tailwind": "^1.0.0",
-    "@lacolaco/notion-sync": "^4.0.0",
+    "@lacolaco/notion-sync": "^6.0.0",
     "@notionhq/client": "5.15.0",
     "@tailwindcss/vite": "^4.1.4",
     "@types/dom-chromium-ai": "^0.0.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ importers:
         specifier: ^1.0.0
         version: 1.2.0
       '@lacolaco/notion-sync':
-        specifier: ^4.0.0
-        version: 4.0.0
+        specifier: ^6.0.0
+        version: 6.0.0
       '@notionhq/client':
         specifier: 5.15.0
         version: 5.15.0
@@ -900,8 +900,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lacolaco/notion-sync@4.0.0':
-    resolution: {integrity: sha512-lpU2b8g8LV834SFfT2TMjlKJcw7QVsDOhGkfrUZ99yMNhclmV6F1vuyhDSXC2CSTx9kxyli/6lkmqEC6zfABHw==, tarball: https://npm.pkg.github.com/download/@lacolaco/notion-sync/4.0.0/31d2cde6470530b99d456e149f7ef0db6a64a8fb}
+  '@lacolaco/notion-sync@6.0.0':
+    resolution: {integrity: sha512-1VJ+vP3YGzG64KXLXFZwjqeNf8Cb1LpGmbcQETFEdiohWaXR/fG0pkeZlRTDe++vdYhFVRCzXvgoE+lIQBtAIw==, tarball: https://npm.pkg.github.com/download/@lacolaco/notion-sync/6.0.0/44a8b84aac2a3e0a8a64822e9f95745b3106baaa}
 
   '@mermaid-js/parser@1.0.1':
     resolution: {integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==}
@@ -4853,7 +4853,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lacolaco/notion-sync@4.0.0':
+  '@lacolaco/notion-sync@6.0.0':
     dependencies:
       '@notionhq/client': 5.15.0
       cli-progress: 3.12.0

--- a/tools/notion-sync/main.ts
+++ b/tools/notion-sync/main.ts
@@ -62,17 +62,17 @@ const result = await syncNotionBlog({
   notionToken: NOTION_AUTH_TOKEN,
   datasourceId: 'a902ee6d-dc94-4301-b772-fa5fb8decc0c',
   distribution: 'blog.lacolaco.net',
-  postsDir: `${rootDir}/src/content/post/notion`,
   manifestPath: `${rootDir}/manifest.json`,
+  metadataFilePath: `${rootDir}/src/content/post/notion/metadata.json`,
+  propertyOutputs: {
+    tags: path.resolve(rootDir, 'src/content/post/notion/tags.json'),
+    category: path.resolve(rootDir, 'src/content/post/notion/categories.json'),
+  },
   verbose: true,
   mode,
   force,
   dryRun,
   filterPost: (metadata) => metadata.published && !!metadata.category,
-  postPathResolver: (metadata) => {
-    const localeSuffix = metadata.locale === 'en' ? '.en' : '';
-    return `${metadata.slug}${localeSuffix}.md`;
-  },
   extractMetadata: (page, defaultExtractor) => {
     const metadata = defaultExtractor(page);
     const icon = page.icon && page.icon.type === 'emoji' ? page.icon.emoji : '';
@@ -100,6 +100,12 @@ const result = await syncNotionBlog({
     };
   },
   renderMarkdown: {
+    getPageOutput: (metadata) => {
+      const localeSuffix = metadata.locale === 'en' ? '.en' : '';
+      return {
+        filePath: path.resolve(rootDir, 'src/content/post/notion', `${metadata.slug}${localeSuffix}.md`),
+      };
+    },
     getImageOutput: (image, metadata) => {
       // Notion URLからファイル名を抽出し、URLデコード→NFC正規化
       const rawSegment = image.url.split('?')[0].split('#')[0].split('/').pop() ?? '';


### PR DESCRIPTION
## Summary

- `@lacolaco/notion-sync` v4→v6へアップデート（v5はmetadataBaseDir問題でスキップ）
- `postsDir` + `postPathResolver` → `renderMarkdown.getPageOutput` に移行
- `propertyOutputs`で`tags.json`/`categories.json`の出力先を明示指定
- `metadataFilePath`で`metadata.json`の出力先を明示指定

## Test plan

- [x] `pnpm lint` pass
- [x] `pnpm build` pass
- [x] `pnpm run notion-sync --dry-run` でmetadata/tags/categoriesが正しいパスに出力されることを確認
- [ ] CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)