### PR TITLE
fix: channel別記事リストでChannelBadgeを非表示にする

### DIFF
--- a/src/layouts/List.astro
+++ b/src/layouts/List.astro
@@ -15,9 +15,10 @@ import type { CollectionEntry } from 'astro:content';
 type Props = {
   posts: Array<CollectionEntry<'posts'>>;
   feedUrl: string;
+  showChannels?: boolean;
 };
 
-const { posts, feedUrl } = Astro.props;
+const { posts, feedUrl, showChannels = false } = Astro.props;
 const postsByYear = Array.from(
   posts
     .reduce((acc, post) => {
@@ -82,7 +83,7 @@ const postsByYear = Array.from(
                                 🌐{' '}{post.data.locale}
                               </span>
                             )}
-                            {getChannels(post).map((ch) => (
+                            {showChannels && getChannels(post).map((ch) => (
                               <ChannelBadge name={ch} />
                             ))}
                           </TagList>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,6 @@ import List from '../layouts/List.astro';
 const posts = await queryAvailablePosts();
 ---
 
-<List posts={posts} feedUrl="/index.xml">
+<List posts={posts} feedUrl="/index.xml" showChannels>
   <ChannelNav slot="title" activePath="/" />
 </List>


### PR DESCRIPTION
## Summary

- channel別ページ（`/channels/[channel]`）で記事リストにChannelBadgeを表示していたが、既にフィルタされたリストなので冗長
- `List.astro`に`showChannels`プロップを追加（デフォルト: false）
- トップページ（`/`）のみ`showChannels`を渡してChannelBadgeを表示

## Test plan

- [x] トップページ（`/`）でChannelBadge表示を確認
- [x] チャネル別ページ（`/channels/code`）でChannelBadge非表示を確認
- [x] `pnpm lint` pass
- [x] `pnpm build` pass
- [ ] CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)