### PR TITLE
fix(ci): renovate PRにnon-renovateコミット追加時はcode-reviewに切り替え

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,10 @@ jobs:
         if: github.event.pull_request.user.login == 'renovate[bot]'
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          NON_RENOVATE=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits --jq '.[].author.login' | grep -v 'renovate\[bot\]' | head -1 || true)
+          NON_RENOVATE=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/commits" --paginate --jq '[.[].author.login // empty] | .[]' | grep -v 'renovate\[bot\]' | head -1 || true)
           if [[ -n "$NON_RENOVATE" ]]; then
             echo "has_non_renovate_commits=true" >> "$GITHUB_OUTPUT"
             echo "Non-renovate commits detected by: $NON_RENOVATE"


### PR DESCRIPTION
## Summary
- classifyジョブでrenovate PR上のnon-renovateコミットを検出
- non-renovateコミットがある場合: renovate-reviewをスキップし、code-reviewを実行
- non-renovateコミットがない場合: 従来通りrenovate-reviewを実行

## 背景
renovate PRに手動でコミットを追加した場合、PR authorはrenovate[bot]のままだが、
レビューはcode-reviewで行うべき。従来はPR authorだけで判定していたため、
renovate-reviewが走り続けてokがfailし、マージ不可能になっていた。

## Test plan
- [ ] renovate PR（ボットコミットのみ）: renovate-review実行、code-reviewスキップ
- [ ] renovate PR（non-renovateコミット追加）: renovate-reviewスキップ、code-review実行
- [ ] 通常PR: renovate-reviewスキップ、code-review実行（変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)