### PR TITLE
fix(ci): renovate PRにnon-renovateコミット追加時はcode-reviewに切り替え

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,20 +6,21 @@ name: CI
 #   ┌─ classify ─→ content-review (needs: classify)
 #   │             → code-review    (needs: classify)
 #   ├─ CI jobs (build, lint, format, test, notion-sync-dry-run)
-#   ├─ renovate-review (独立、classifyに依存しない)
+#   ├─ renovate-review (needs: classify, non-renovateコミットがなければ実行)
 #   ↓
 #   ok (alls-green gate, 唯一のrequired check)
 #   ↓
 #   auto-merge
 #
 # レビュー条件 (排他ではない。code+content PRでは両方実行される):
-#   - renovate-review: author == renovate[bot]
+#   - renovate-review: author == renovate[bot] かつ non-renovateコミットなし
 #   - content-review:  content_changed && author != renovate[bot]
-#   - code-review:     code_changed && author != renovate[bot]
+#   - code-review:     code_changed && (author != renovate[bot] or non-renovateコミットあり)
 #
 # 自動マージ条件:
 #   ok成功 かつ (renovate-review成功 or (content-review成功 かつ code-review未実行))
 #   → code変更を含むPRは手動マージ
+#   → renovate PR + non-renovateコミット → code-review実行, auto-merge対象外, 手動マージ
 #
 # draft PR:
 #   - CI jobsのみ実行
@@ -45,6 +46,7 @@ jobs:
     outputs:
       code_changed: ${{ !github.event.pull_request.draft && steps.code-paths.outputs.code == 'true' }}
       content_changed: ${{ !github.event.pull_request.draft && steps.content-paths.outputs.content == 'true' }}
+      has_non_renovate_commits: ${{ steps.non-renovate-commits.outputs.has_non_renovate_commits == 'true' }}
     steps:
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: content-paths
@@ -65,6 +67,22 @@ jobs:
               - '!src/content/**'
               - '!public/images/**'
               - '!manifest.json'
+
+      - name: Check for non-renovate commits
+        id: non-renovate-commits
+        if: github.event.pull_request.user.login == 'renovate[bot]'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          NON_RENOVATE=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/commits" --paginate --jq '[.[].author.login // empty] | .[]' | grep -v 'renovate\[bot\]' | head -1 || true)
+          if [[ -n "$NON_RENOVATE" ]]; then
+            echo "has_non_renovate_commits=true" >> "$GITHUB_OUTPUT"
+            echo "Non-renovate commits detected by: $NON_RENOVATE"
+          else
+            echo "has_non_renovate_commits=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Verify classification
         if: ${{ !github.event.pull_request.draft }}
@@ -166,7 +184,10 @@ jobs:
   # === Reviews (standard interface: outputs.approved) ===
 
   renovate-review:
-    if: github.event.pull_request.user.login == 'renovate[bot]'
+    needs: classify
+    if: >-
+      github.event.pull_request.user.login == 'renovate[bot]' &&
+      needs.classify.outputs.has_non_renovate_commits != 'true'
     runs-on: ubuntu-latest
     outputs:
       approved: ${{ steps.gate.outputs.approved }}
@@ -302,7 +323,7 @@ jobs:
     needs: classify
     if: >-
       needs.classify.outputs.code_changed == 'true' &&
-      github.event.pull_request.user.login != 'renovate[bot]'
+      (github.event.pull_request.user.login != 'renovate[bot]' || needs.classify.outputs.has_non_renovate_commits == 'true')
     runs-on: ubuntu-latest
     outputs:
       approved: ${{ steps.gate.outputs.approved }}


### PR DESCRIPTION
## Summary
- classifyジョブでrenovate PR上のnon-renovateコミットを検出
- non-renovateコミットがある場合: renovate-reviewをスキップし、code-reviewを実行
- non-renovateコミットがない場合: 従来通りrenovate-reviewを実行

## 背景
renovate PRに手動でコミットを追加した場合、PR authorはrenovate[bot]のままのため、
renovate-reviewが走り続けてcode-reviewが実行されない。
renovate-reviewがneeds-manual-migrationを返すとokがfailし、マージ不可能になっていた。

Closes #1419

## ci.yml変更PRの制約
claude-code-actionはワークフローファイルがmainと同一であることを検証するため、
ci.yml変更PRではcode-reviewが動作しません（Workflow validation failed）。
ローカルでcode-criticによるレビュー済み。

## Test plan
- [ ] renovate PR（ボットコミットのみ）: renovate-review実行、code-reviewスキップ
- [ ] renovate PR（non-renovateコミット追加）: renovate-reviewスキップ、code-review実行
- [ ] 通常PR: renovate-reviewスキップ、code-review実行（変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)