### PR TITLE
fix(notion-sync): replace category filter with channels filter

### DIFF
--- a/tools/notion-sync/main.ts
+++ b/tools/notion-sync/main.ts
@@ -69,7 +69,6 @@ const result = await syncNotionDatasource({
   metadataFilePath: `${rootDir}/src/content/post/notion/metadata.json`,
   propertyOutputs: {
     tags: path.resolve(rootDir, 'src/content/post/notion/tags.json'),
-    category: path.resolve(rootDir, 'src/content/post/notion/categories.json'),
   },
   verbose: true,
   mode,


### PR DESCRIPTION
## Summary

- `filterPost`の条件を`!!metadata.category`から`channels.length > 0`に変更
- `BlogPostMetadata`型を定義し、filterPostとgenerateFrontmatterのキャストを統一

## Root Cause

廃止済みのcategory条件がfilterPostに残っており、category未設定の新記事がsyncされなかった。

## Test plan

- [x] lint, format, build pass
- [ ] sync-with-notion workflowで新記事のPRが作成されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)