### PR TITLE
fix: run astro sync after pnpm install to generate types

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test:libs": "vitest run",
     "test": "pnpm test:tools && pnpm test:libs",
     "lint": "eslint .",
-    "prepare": "husky"
+    "prepare": "husky",
+    "postinstall": "astro sync"
   },
   "packageManager": "pnpm@10.33.0",
   "dependencies": {


### PR DESCRIPTION
Fixes #1447

Adds `"postinstall": "astro sync"` to package.json so that `.astro/types.d.ts` is generated after `pnpm install`, before the husky pre-commit hook runs ESLint in the notion-sync workflow.

Generated with [Claude Code](https://claude.ai/code)