### PR TITLE
chore: add notion-sync-migration skill

### DIFF
--- a/.claude/skills/notion-sync-migration/SKILL.md
+++ b/.claude/skills/notion-sync-migration/SKILL.md
@@ -41,10 +41,11 @@ grep "notion-sync" package.json
 npm view @lacolaco/notion-sync version
 ```
 
-未公開の場合、バックグラウンドで30秒間隔でポーリングする。
+未公開の場合、バックグラウンドで30秒間隔・最大10分でポーリングする。
 
 ```bash
-while true; do
+DEADLINE=$((SECONDS + 600))
+while [ $SECONDS -lt $DEADLINE ]; do
   version=$(npm view @lacolaco/notion-sync version 2>/dev/null)
   if [[ "$version" == <target-major>.* ]]; then
     echo "published: $version"
@@ -52,6 +53,10 @@ while true; do
   fi
   sleep 30
 done
+if [ $SECONDS -ge $DEADLINE ]; then
+  echo "Timeout: version not published within 10 minutes"
+  exit 1
+fi
 ```
 
 ### 3. インストール

--- a/.claude/skills/notion-sync-migration/SKILL.md
+++ b/.claude/skills/notion-sync-migration/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: notion-sync-migration
+description: "@lacolaco/notion-syncのメジャーバージョンアップを実行する。notion-syncのアップグレード、マイグレーション、バージョンアップと言われた時に使用する。新バージョンが未公開の場合はポーリングで待機する。"
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - Bash(pnpm add:*)
+  - Bash(pnpm lint:*)
+  - Bash(pnpm build:*)
+  - Bash(pnpm notion-sync:*)
+  - Bash(npm view:*)
+  - Bash(git:*)
+  - Bash(gh:*)
+  - Bash(sleep:*)
+---
+
+# notion-sync Migration
+
+`@lacolaco/notion-sync`のメジャーバージョンアップを安全に実行する。
+
+## 原則
+
+**旧バージョンの知識を全て捨てろ。** 新バージョンのCHANGELOGとREADMEを全文読むまで、コード変更を一切行うな。
+
+## 手順
+
+### 1. 現状確認
+
+```bash
+grep "notion-sync" package.json
+```
+
+現在のバージョンと、対象バージョンを特定する。
+
+### 2. 新バージョンの取得
+
+対象バージョンがnpmに公開済みか確認する。
+
+```bash
+npm view @lacolaco/notion-sync version
+```
+
+未公開の場合、バックグラウンドで30秒間隔でポーリングする。
+
+```bash
+while true; do
+  version=$(npm view @lacolaco/notion-sync version 2>/dev/null)
+  if [[ "$version" == <target-major>.* ]]; then
+    echo "published: $version"
+    break
+  fi
+  sleep 30
+done
+```
+
+### 3. インストール
+
+```bash
+pnpm add @lacolaco/notion-sync@<version>
+```
+
+### 4. ドキュメント精読（省略禁止）
+
+インストール後、以下を**全文Read**する。grepでの部分検索は精読の代替にならない。
+
+1. `node_modules/@lacolaco/notion-sync/CHANGELOG.md` — Breaking Changesを全て把握
+2. `node_modules/@lacolaco/notion-sync/README.md` — 新APIの仕様とMigration Guideを把握
+
+Breaking Changesの一覧を列挙し、現在のコード（`tools/notion-sync/main.ts`）への影響を対応付けてからコード変更に着手する。
+
+### 5. コード変更
+
+`tools/notion-sync/main.ts`を修正する。
+
+変更時の注意:
+- Migration Guideの Before/After に従う
+- 型パラメータの追加など、Breaking Change以外の改善も適用する
+- 不要になった型アサーション（`as`キャスト）は削除する
+
+### 6. 検証
+
+以下を全て通過させる。
+
+```bash
+pnpm lint
+pnpm notion-sync -- --dry-run
+pnpm build
+```
+
+dry-runの出力を確認し、queryFilterやpropertyOutputsが正しく動作していることを検証する。
+
+### 7. コミット・PR
+
+通常のpr-lifecycleスキルに従う。


### PR DESCRIPTION
notion-syncのメジャーバージョンアップ手順をスキル化。ドキュメント精読→Breaking Changes対応付け→コード変更→検証の手順を強制する。