### PR TITLE
chore(deps): migrate notion-sync to v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@eslint/js": "^10.0.1",
     "@iconify/json": "^2.2.161",
     "@iconify/tailwind": "^1.0.0",
-    "@lacolaco/notion-sync": "^9.0.0",
+    "@lacolaco/notion-sync": "^10.0.0",
     "@tailwindcss/vite": "^4.1.4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         specifier: ^1.0.0
         version: 1.2.0
       '@lacolaco/notion-sync':
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^10.0.0
+        version: 10.0.0
       '@tailwindcss/vite':
         specifier: ^4.1.4
         version: 4.2.2(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -983,8 +983,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lacolaco/notion-sync@9.0.0':
-    resolution: {integrity: sha512-KU0r1gIPRVHX79lHcxR+O+T5oZWI5xTw32jNQNdSiFW0zayD51Nwxbbq+AIWuLRVDE9UlzYuWrqqKQ6NnuLQJg==, tarball: https://npm.pkg.github.com/download/@lacolaco/notion-sync/9.0.0/4793d89d9865de340255d03ebebec3682769f591}
+  '@lacolaco/notion-sync@10.0.0':
+    resolution: {integrity: sha512-VKwicb3wdDLGDw9QVAkL2wtug2NqvivaiTixsfo2tIS6NOI+k5L3JY37Xr7zRV7i3a2WRPyb3ZZUNLJHarBUIA==, tarball: https://npm.pkg.github.com/download/@lacolaco/notion-sync/10.0.0/6a81484450b167b5084c5f0b54507792f201c3bb}
 
   '@mermaid-js/parser@1.1.0':
     resolution: {integrity: sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==}
@@ -5073,7 +5073,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lacolaco/notion-sync@9.0.0':
+  '@lacolaco/notion-sync@10.0.0':
     dependencies:
       '@notionhq/client': 5.15.0
       cli-progress: 3.12.0

--- a/tools/notion-sync/main.ts
+++ b/tools/notion-sync/main.ts
@@ -1,10 +1,21 @@
-import { syncNotionDatasource, type PostMetadata, type RenderContext } from '@lacolaco/notion-sync';
+import { syncNotionDatasource, extractProperty, type PostMetadata, type RenderContext } from '@lacolaco/notion-sync';
 import { createHash } from 'node:crypto';
 import * as path from 'node:path';
 import { parseArgs } from 'node:util';
 
 // このdatasourceのextractMetadataが返すメタデータ型
-type BlogPostMetadata = PostMetadata & { icon: string; channels: string[] };
+// v10でPostMetadataからpassthroughフィールドが削除されたため、必要なフィールドを自前で定義
+type BlogPostMetadata = PostMetadata & {
+  icon: string;
+  channels: string[];
+  locale: string;
+  source_url: string;
+  category?: string;
+  tags: string[];
+  canonical_url: string | null;
+  created_time: string;
+  last_edited_time: string;
+};
 
 // features検出用の型定義
 type FeatureState = {
@@ -12,17 +23,6 @@ type FeatureState = {
   hasKatex?: boolean;
   hasTweet?: boolean;
 };
-
-// Notion APIのpropertiesからmulti_selectの名前配列を安全に取得する
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return */
-function extractMultiSelectNames(properties: object, key: string): string[] {
-  if (!(key in properties)) return [];
-  const prop = (properties as any)[key];
-  if (prop == null || typeof prop !== 'object' || prop.type !== 'multi_select') return [];
-  if (!Array.isArray(prop.multi_select)) return [];
-  return prop.multi_select.map((item: { name: string }) => item.name);
-}
-/* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return */
 
 const { NOTION_AUTH_TOKEN } = process.env;
 if (!NOTION_AUTH_TOKEN) {
@@ -84,19 +84,19 @@ const result = await syncNotionDatasource<BlogPostMetadata>({
   extractMetadata: (page, defaultExtractor) => {
     const metadata = defaultExtractor(page);
     const icon = page.icon && page.icon.type === 'emoji' ? page.icon.emoji : '';
-
-    // channels マルチセレクトの読み取り
-    let channels: string[] = [];
-    try {
-      channels = extractMultiSelectNames(page.properties, 'channels');
-    } catch {
-      // channelsプロパティが存在しない場合は空配列
-    }
+    const updatedAt = extractProperty<string>(page, 'updated_at');
 
     return {
       ...metadata,
       icon,
-      channels,
+      channels: extractProperty<string[]>(page, 'channels') ?? [],
+      locale: extractProperty<string>(page, 'locale') ?? 'ja',
+      source_url: page.url,
+      category: extractProperty<string>(page, 'category'),
+      tags: extractProperty<string[]>(page, 'tags') ?? [],
+      canonical_url: extractProperty<string>(page, 'canonical_url') ?? null,
+      created_time: metadata.date.toISOString(),
+      last_edited_time: new Date(updatedAt ?? page.last_edited_time).toISOString(),
     };
   },
   renderMarkdown: {
@@ -177,16 +177,20 @@ const result = await syncNotionDatasource<BlogPostMetadata>({
         return defaultRenderer(block);
       },
     },
-    generateFrontmatter: (baseFields, metadata, renderContext: RenderContext<FeatureState>) => {
-      const { source_url, title, slug, ...rest } = baseFields as Record<string, unknown>;
-
+    generateFrontmatter: (_baseFields, metadata, renderContext: RenderContext<FeatureState>) => {
       return {
-        title,
-        slug,
+        title: metadata.title,
+        slug: metadata.slug,
         icon: metadata.icon,
-        ...rest,
+        created_time: metadata.created_time,
+        last_edited_time: metadata.last_edited_time,
+        tags: metadata.tags,
+        published: true,
+        locale: metadata.locale,
+        category: metadata.category,
+        canonical_url: metadata.canonical_url ?? undefined,
         channels: metadata.channels.length > 0 ? metadata.channels : undefined,
-        notion_url: source_url,
+        notion_url: metadata.source_url,
         features: {
           katex: renderContext.state.hasKatex ?? false,
           mermaid: renderContext.state.hasMermaid ?? false,


### PR DESCRIPTION
## Summary

- `@lacolaco/notion-sync` v9 → v10
- v10でPostMetadataから削除されたpassthroughフィールド（locale, tags, category, source_url, canonical_url, created_time, last_edited_time）を`extractProperty`ユーティリティで自前抽出
- `extractMultiSelectNames`ヘルパーを削除し`extractProperty<string[]>`で代替
- `generateFrontmatter`で全フィールドを明示的に構築（`...rest`スプレッド廃止）
- frontmatterの出力形式は既存と同一を維持

## Test plan

- [x] `pnpm lint` 通過
- [x] `pnpm test:tools` 全82テスト通過
- [x] `pnpm notion-sync -- --dry-run` 成功
- [x] `pnpm notion-sync -- --dry-run --mode all` 336ページ取得、12ページ処理成功
- [x] `pnpm build` 成功