### PR TITLE
chore(deps): migrate notion-sync to v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@eslint/js": "^10.0.1",
     "@iconify/json": "^2.2.161",
     "@iconify/tailwind": "^1.0.0",
-    "@lacolaco/notion-sync": "^10.0.0",
+    "@lacolaco/notion-sync": "^11.0.0",
     "@tailwindcss/vite": "^4.1.4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         specifier: ^1.0.0
         version: 1.2.0
       '@lacolaco/notion-sync':
-        specifier: ^10.0.0
-        version: 10.0.0
+        specifier: ^11.0.0
+        version: 11.0.0
       '@tailwindcss/vite':
         specifier: ^4.1.4
         version: 4.2.2(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -983,8 +983,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lacolaco/notion-sync@10.0.0':
-    resolution: {integrity: sha512-VKwicb3wdDLGDw9QVAkL2wtug2NqvivaiTixsfo2tIS6NOI+k5L3JY37Xr7zRV7i3a2WRPyb3ZZUNLJHarBUIA==, tarball: https://npm.pkg.github.com/download/@lacolaco/notion-sync/10.0.0/6a81484450b167b5084c5f0b54507792f201c3bb}
+  '@lacolaco/notion-sync@11.0.0':
+    resolution: {integrity: sha512-1GQ59EYNPly3ZdBHyZXrWVB2Pu5mjQjx5pp70vQ4HuKqmfMj1+6U8OAa18tAhUeC5LnUSyfwLmQcROv0ZlH0VA==, tarball: https://npm.pkg.github.com/download/@lacolaco/notion-sync/11.0.0/3ac0d0a3bfd5b0494e7ea55fc68013e8705c5153}
 
   '@mermaid-js/parser@1.1.0':
     resolution: {integrity: sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==}
@@ -5073,7 +5073,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lacolaco/notion-sync@10.0.0':
+  '@lacolaco/notion-sync@11.0.0':
     dependencies:
       '@notionhq/client': 5.15.0
       cli-progress: 3.12.0

--- a/tools/notion-sync/main.ts
+++ b/tools/notion-sync/main.ts
@@ -87,7 +87,8 @@ const result = await syncNotionDatasource<BlogPostMetadata>({
     const updatedAt = extractProperty<string>(page, 'updated_at');
     // v11でextractDate()がcreated_at_overrideを見なくなったため、自前でオーバーライドする
     const createdAtOverride = extractProperty<string>(page, 'created_at_override');
-    const date = createdAtOverride ? new Date(createdAtOverride) : metadata.date;
+    const createdAtDate = createdAtOverride ? new Date(createdAtOverride) : null;
+    const date = createdAtDate && !isNaN(createdAtDate.getTime()) ? createdAtDate : metadata.date;
 
     return {
       ...metadata,

--- a/tools/notion-sync/main.ts
+++ b/tools/notion-sync/main.ts
@@ -85,9 +85,13 @@ const result = await syncNotionDatasource<BlogPostMetadata>({
     const metadata = defaultExtractor(page);
     const icon = page.icon && page.icon.type === 'emoji' ? page.icon.emoji : '';
     const updatedAt = extractProperty<string>(page, 'updated_at');
+    // v11でextractDate()がcreated_at_overrideを見なくなったため、自前でオーバーライドする
+    const createdAtOverride = extractProperty<string>(page, 'created_at_override');
+    const date = createdAtOverride ? new Date(createdAtOverride) : metadata.date;
 
     return {
       ...metadata,
+      date,
       icon,
       channels: extractProperty<string[]>(page, 'channels') ?? [],
       locale: extractProperty<string>(page, 'locale') ?? 'ja',
@@ -95,7 +99,7 @@ const result = await syncNotionDatasource<BlogPostMetadata>({
       category: extractProperty<string>(page, 'category'),
       tags: extractProperty<string[]>(page, 'tags') ?? [],
       canonical_url: extractProperty<string>(page, 'canonical_url') ?? null,
-      created_time: metadata.date.toISOString(),
+      created_time: date.toISOString(),
       last_edited_time: new Date(updatedAt ?? page.last_edited_time).toISOString(),
     };
   },


### PR DESCRIPTION
## Summary

- `@lacolaco/notion-sync` v10 → v11
- v11で`extractDate()`が`created_at_override`プロパティを参照しなくなったため、`extractMetadata`内で自前取得してdateを上書き

## Test plan

- [x] `pnpm lint` 通過
- [x] `pnpm notion-sync -- --dry-run` 成功
- [x] `pnpm build` 成功