### PR TITLE
docs: add learnings from v10/v11 migration retrospectives

### DIFF
--- a/.claude/skills/notion-sync-migration/SKILL.md
+++ b/.claude/skills/notion-sync-migration/SKILL.md
@@ -82,6 +82,7 @@ Breaking Changesの一覧を列挙し、現在のコード（`tools/notion-sync/
 - Migration Guideの Before/After に従う
 - 型パラメータの追加など、Breaking Change以外の改善も適用する
 - 不要になった型アサーション（`as`キャスト）は削除する
+- 外部入力からの型変換（`new Date(string)`等）は変換結果のバリデーションとフォールバックを必ず実装する
 
 ### 6. 検証
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ pnpm test:libs    # library tests
 - NEVER `git reset --hard` with uncommitted changes you need
 - **push前に`git fetch origin main`してブランチがmainの最新に追従しているか確認せよ**。outdatedなブランチをpushするな
 - pushするとCIは再実行される。古いCI watchの結果は無効
-- push後は必ず `gh pr checks --watch` をバックグラウンドで新たに開始せよ。完了したらユーザーに報告すること
+- push後は必ず `gh pr checks --watch` をバックグラウンドで新たに開始せよ。完了したらユーザーに報告すること。CIの開始にはラグがあるため `sleep 15 &&` を前置する
 
 ### Tool Usage Priority
 1. mcp__ide__getDiagnostics (for errors)


### PR DESCRIPTION
## Summary

- notion-sync-migrationスキルに外部入力のバリデーションルールを追加
- CI watchの開始ラグ対策（`sleep 15`前置）をCLAUDE.mdに追加