### PR TITLE
fix(infra): correct retry block placement in Cloud Workflows YAML

### DIFF
--- a/infra/workflows/likes-export.yaml
+++ b/infra/workflows/likes-export.yaml
@@ -29,13 +29,13 @@ main:
             auth:
               type: OAuth2
           result: list_response
-          retry:
-            predicate: ${http.default_retry_predicate}
-            max_retries: 3
-            backoff:
-              initial_delay: 2
-              max_delay: 60
-              multiplier: 2
+        retry:
+          predicate: ${http.default_retry_predicate}
+          max_retries: 3
+          backoff:
+            initial_delay: 2
+            max_delay: 60
+            multiplier: 2
         except:
           as: e
           raise: '${"Firestore list failed: " + json.encode_to_string(e)}'
@@ -137,13 +137,13 @@ insert_batch:
             body:
               rows: ${rows}
           result: bq_response
-          retry:
-            predicate: ${http.default_retry_predicate}
-            max_retries: 3
-            backoff:
-              initial_delay: 2
-              max_delay: 60
-              multiplier: 2
+        retry:
+          predicate: ${http.default_retry_predicate}
+          max_retries: 3
+          backoff:
+            initial_delay: 2
+            max_delay: 60
+            multiplier: 2
         except:
           as: e
           raise: '${"BigQuery insert failed: " + json.encode_to_string(e)}'


### PR DESCRIPTION
## Summary

Cloud Workflows YAML の `retry` ブロック配置を修正し、2026-04-08の導入以来
78回連続で失敗していた deploy-production.yml の Deploy Cloud Workflows 
ステップを復旧する。

## 背景

\`gcloud workflows deploy\` が以下のパースエラーで失敗していた:

\`\`\`
main.yaml:32:11: parse error: in workflow 'main', step 'list_documents': 
  unexpected entry 'retry'
main.yaml:140:11: parse error: in workflow 'insert_batch', step 'call_bq': 
  unexpected entry 'retry'
\`\`\`

Cloud Workflows の try/except 構文では \`retry\` は \`try:\` の**外側**で
\`try:\` と同階層に配置する必要があるが、現状のYAMLは \`try:\` の内側に
記述していたため構文エラーになっていた。

**影響範囲**: Cloud Run本体のデプロイは成功しているためブログは正常稼働。
likes-export Cloud Workflow（likes の BI 集計）が2026-04-08以降更新されて
いなかったのみ。

## 修正

\`list_documents\` と \`call_bq\` の2箇所で \`retry:\` を \`try:\` の外側へ移動。

## 検証

ローカルから \`gcloud workflows deploy\` を実行し \`state: ACTIVE\` を確認済み。
本PR merge 後の deploy-production.yml 実行で CI 上でも再現することを確認する。

## Test plan

- [x] \`gcloud workflows deploy likes-export\` が成功することをローカルで確認
- [ ] merge 後の deploy-production.yml が成功する

🤖 Generated with [Claude Code](https://claude.com/claude-code)