### PR TITLE
fix(infra): use UNNEST(event_params) for page_location in GA4 BQ query

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -66,7 +66,10 @@ WITH latest_likes AS (
 ),
 page_views AS (
   SELECT
-    REGEXP_EXTRACT(page_location, r'/posts/([^/?#]+)') AS slug,
+    REGEXP_EXTRACT(
+      (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'),
+      r'/posts/([^/?#]+)'
+    ) AS slug,
     COUNT(*) AS pv_count
   FROM `blog-lacolaco-net.analytics_266351853.events_*`
   WHERE event_name = 'page_view'


### PR DESCRIPTION
## Summary

infra/README.md に記載されている「PV×いいね相関」のカスタムクエリが
BigQuery/Looker Studio で \`Unrecognized name: page_location at [8:20]\`
エラーになる問題を修正。

## 背景

GA4 BigQuery export schema では \`page_location\` は直接カラムではなく
\`event_params\` 配列内のパラメータとして格納される。
直接参照するとエラーになる。

## 修正

\`\`\`sql
-- Before
REGEXP_EXTRACT(page_location, r'/posts/([^/?#]+)') AS slug,

-- After
REGEXP_EXTRACT(
  (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'),
  r'/posts/([^/?#]+)'
) AS slug,
\`\`\`

## 検証

\`bq query\` で実行し、like_count / pv_30d / slug の3カラムが正しく
取得できることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)