### PR TITLE
feat(infra): bring Cloud Workflow under Terraform (Phase 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,7 @@ jobs:
           filters: |
             terraform:
               - 'infra/terraform/**'
+              - 'infra/workflows/**'
 
       - name: Google Auth
         if: steps.tf-paths.outputs.terraform == 'true'

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -51,21 +51,14 @@ jobs:
 
       # --- Infra deploy (前段: 失敗時にCloud Runデプロイをブロックし split failure を回避) ---
 
-      - name: Deploy Cloud Workflows
-        run: |
-          gcloud workflows deploy likes-export \
-            --source=infra/workflows/likes-export.yaml \
-            --location=asia-northeast1 \
-            --project=blog-lacolaco-net \
-            --service-account=likes-export-workflow@blog-lacolaco-net.iam.gserviceaccount.com
-
       - name: Check Terraform changes
         id: tf-changed
         run: |
           # workflow_dispatch（手動起動）時は設定ドリフト修復用途として常にapply対象
+          # infra/workflows/ 配下の yaml は workflow.tf の file() で参照されるため変更検知に含める
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
-          elif git diff --name-only HEAD^ HEAD | grep -q '^infra/terraform/'; then
+          elif git diff --name-only HEAD^ HEAD | grep -qE '^infra/(terraform|workflows)/'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/infra/README.md
+++ b/infra/README.md
@@ -28,6 +28,7 @@ BigQuery
 - **likes-export** (`infra/workflows/likes-export.yaml`)
   - Firestore `post_likes`コレクション全件取得→BigQuery挿入
   - サービスアカウント: `likes-export-workflow@blog-lacolaco-net.iam.gserviceaccount.com`（datastore.viewer + bigquery.dataEditor + logging.logWriter）
+  - Terraform 管理下（`infra/terraform/workflow.tf`）。YAML本体は `infra/workflows/likes-export.yaml` を `file()` で参照
 
 ### Cloud Scheduler
 

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -13,6 +13,7 @@ Phase 1 の最小構成: Cloud Scheduler のみ。
 | リソース | 定義ファイル |
 |---|---|
 | `google_cloud_scheduler_job.likes_export_daily` | `scheduler.tf` |
+| `google_workflows_workflow.likes_export` | `workflow.tf` |
 
 ## Apply 方法
 
@@ -45,5 +46,4 @@ terraform import \
 
 ## 拡張予定（別 phase）
 
-- Phase 3: Cloud Workflow (`likes-export`) の Terraform 化
 - Phase 4: IAM binding + SA の Terraform 化

--- a/infra/terraform/workflow.tf
+++ b/infra/terraform/workflow.tf
@@ -1,0 +1,7 @@
+resource "google_workflows_workflow" "likes_export" {
+  name            = "likes-export"
+  region          = "asia-northeast1"
+  source_contents = file("${path.module}/../workflows/likes-export.yaml")
+  # TODO(Phase 4): SA自体をTerraform管理に取り込んだら google_service_account.likes_export_workflow.email に変更
+  service_account = "projects/blog-lacolaco-net/serviceAccounts/likes-export-workflow@blog-lacolaco-net.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
## Summary

段階的 IaC 化 Phase 3。Cloud Workflow \`likes-export\` を Terraform 管理下に移行。

## 移行手順（実施済み）

\`google_workflows_workflow\` は provider v7 時点で **import 非対応**（[公式ドキュメント](https://github.com/hashicorp/terraform-provider-google/blob/v7.28.0/website/docs/r/workflows_workflow.html.markdown) に明記）のため、以下の手順で移行済み:

1. \`gcloud workflows delete likes-export\` で既存 workflow 削除
2. \`terraform apply\` で Terraform が workflow 新規作成
3. \`terraform plan\` で 0 diff 確認
4. \`gcloud workflows describe\` で state: ACTIVE、SA 同一を確認

Scheduler 実行窓（03:00 JST / 18:00 UTC）を避けた時間に実施。削除〜作成は約15秒。

## コード変更

- \`infra/terraform/workflow.tf\`: 新規。YAML 本体は \`file("${path.module}/../workflows/likes-export.yaml")\` で読み込み
- \`.github/workflows/deploy-production.yml\`: 
  - \`Deploy Cloud Workflows\` の gcloud step を削除（Terraform が管理するため）
  - Terraform 変更検知の path filter に \`infra/workflows/**\` を追加
- \`.github/workflows/ci.yml\`: 同じく path filter に \`infra/workflows/**\` を追加
- \`infra/README.md\` / \`infra/terraform/README.md\`: Phase 3 完了を反映

## 今後

- Phase 4: IAM binding + SA の Terraform 化

## Test plan

- [x] \`terraform plan\` 0 diff
- [x] \`terraform fmt / validate\` pass
- [x] \`gcloud workflows describe\` で state: ACTIVE 確認
- [ ] merge 後の deploy-production で terraform apply が発火しない（差分なしのため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)