### PR TITLE
fix(infra): hotfix BigQuery IAM after Phase 4 deploy failure

### DIFF
--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -77,15 +77,16 @@ terraform import \
 # Phase 3 注: google_workflows_workflow は provider v7 時点で import 非対応のため、
 # gcloud workflows delete → terraform apply で移行した。
 
-# Phase 4 注: google_bigquery_dataset_iam_member 2件 は今PRで新規作成のため import 不要。
-#   - likes_export_workflow_likes_analytics_editor
-#   - github_actions_likes_analytics_metadata_viewer
-#
-# これらに対応する旧 project-level の google_project_iam_member 2件
-# (likes_export_workflow_bigquery_data_editor, github_actions_bigquery_metadata_viewer) は、
-# 事前に terraform import で state に取り込んだ上で tf ファイルから削除している。
-# よって apply 実行で Terraform が GCP 側の旧 binding を destroy する。
-# 旧 binding の手動 gcloud 削除は不要。
+# Phase 4 hotfix: 元々 metadataViewer を予定していたが、
+# Terraform で dataset IAM を更新するには bigquery.datasets.setIamPolicy が必要なため
+# dataOwner に変更。手動 (bq update --source) で binding を作成後、import で state 取り込み。
+terraform import \
+  google_bigquery_dataset_iam_member.likes_export_workflow_likes_analytics_editor \
+  'projects/blog-lacolaco-net/datasets/likes_analytics roles/bigquery.dataEditor serviceAccount:likes-export-workflow@blog-lacolaco-net.iam.gserviceaccount.com'
+
+terraform import \
+  google_bigquery_dataset_iam_member.github_actions_likes_analytics_data_owner \
+  'projects/blog-lacolaco-net/datasets/likes_analytics roles/bigquery.dataOwner serviceAccount:github-actions@blog-lacolaco-net.iam.gserviceaccount.com'
 ```
 
 ## Cloud Scheduler の oauth_token SA

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -68,10 +68,12 @@ resource "google_bigquery_dataset_iam_member" "likes_export_workflow_likes_analy
   member     = "serviceAccount:${google_service_account.likes_export_workflow.email}"
 }
 
-# github-actions SA が data "google_bigquery_dataset" の read と
-# google_bigquery_dataset_iam_member の setIamPolicy の両方を実行できるよう
-# dataset-level の dataOwner を付与（minimum dataset-scoped privilege で
-# setIamPolicy / get / update を全てカバー）
+# github-actions SA が必要なのは bigquery.datasets.{get,getIamPolicy,setIamPolicy} のみだが、
+# 既定ロールには3つ全てを満たす dataset-scoped role が dataOwner しかない。
+# データ本体への read/write 権限も含むため過剰だが、現状以下の理由で許容:
+#   - dataset 内のテーブル/データは Terraform 管理外で運用上の機密性は低い
+#   - custom role 化はスコープ外（IaC運用の安定後に検討）
+# TODO: bigquery.datasets.{get,getIamPolicy,setIamPolicy} のみのカスタムロールへの置換を別途検討
 resource "google_bigquery_dataset_iam_member" "github_actions_likes_analytics_data_owner" {
   project    = data.google_project.current.project_id
   dataset_id = data.google_bigquery_dataset.likes_analytics.dataset_id

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -68,12 +68,14 @@ resource "google_bigquery_dataset_iam_member" "likes_export_workflow_likes_analy
   member     = "serviceAccount:${google_service_account.likes_export_workflow.email}"
 }
 
-# github-actions SA が data "google_bigquery_dataset" を読むために必要。
-# likes_analytics データセットのメタデータ read のみ（data 本体 read 不可）
-resource "google_bigquery_dataset_iam_member" "github_actions_likes_analytics_metadata_viewer" {
+# github-actions SA が data "google_bigquery_dataset" の read と
+# google_bigquery_dataset_iam_member の setIamPolicy の両方を実行できるよう
+# dataset-level の dataOwner を付与（minimum dataset-scoped privilege で
+# setIamPolicy / get / update を全てカバー）
+resource "google_bigquery_dataset_iam_member" "github_actions_likes_analytics_data_owner" {
   project    = data.google_project.current.project_id
   dataset_id = data.google_bigquery_dataset.likes_analytics.dataset_id
-  role       = "roles/bigquery.metadataViewer"
+  role       = "roles/bigquery.dataOwner"
   member     = "serviceAccount:${data.google_service_account.github_actions.email}"
 }
 

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -68,12 +68,20 @@ resource "google_bigquery_dataset_iam_member" "likes_export_workflow_likes_analy
   member     = "serviceAccount:${google_service_account.likes_export_workflow.email}"
 }
 
-# github-actions SA が必要なのは bigquery.datasets.{get,getIamPolicy,setIamPolicy} のみだが、
-# 既定ロールには3つ全てを満たす dataset-scoped role が dataOwner しかない。
-# データ本体への read/write 権限も含むため過剰だが、現状以下の理由で許容:
-#   - dataset 内のテーブル/データは Terraform 管理外で運用上の機密性は低い
-#   - custom role 化はスコープ外（IaC運用の安定後に検討）
-# TODO: bigquery.datasets.{get,getIamPolicy,setIamPolicy} のみのカスタムロールへの置換を別途検討
+# github-actions SA は CI 上で Terraform を実行するため、likes_analytics dataset に対して
+# 以下3つの API call を行う必要がある:
+#   - bigquery.datasets.get        : data "google_bigquery_dataset" の refresh
+#   - bigquery.datasets.getIamPolicy: google_bigquery_dataset_iam_member の plan/refresh
+#   - bigquery.datasets.setIamPolicy: google_bigquery_dataset_iam_member の apply
+#
+# これら3つの permission を同時に持つ既定ロールは dataset-scoped では dataOwner のみ。
+# dataOwner は dataset 内のテーブル/データへの read/write も含むため、API permission 単位では
+# 過剰権限。ただし以下の理由から custom role 化はせず dataOwner を採用する:
+#   - 当該 dataset に保存されているのは公開ブログの likes 集計（個人情報・機密性なし）
+#   - 当該 dataset に書き込むのは likes-export-workflow と CI 経由の Terraform のみで、
+#     CI が誤ってデータ操作する経路は実質ない（Terraform は IAM resource しか触らない）
+#   - custom role を導入するとロール定義の維持・変更時の影響範囲拡大があり、
+#     得られる security 改善（テーブルデータ read 制限のみ）と釣り合わない
 resource "google_bigquery_dataset_iam_member" "github_actions_likes_analytics_data_owner" {
   project    = data.google_project.current.project_id
   dataset_id = data.google_bigquery_dataset.likes_analytics.dataset_id


### PR DESCRIPTION
## Summary

PR #1549 (Phase 4) の deploy-production 失敗による本番影響の hotfix。

## 経緯

PR #1549 で BigQuery IAM をプロジェクトレベルからデータセットレベルへ
スコープダウンする変更を含めたが、deploy-production の terraform apply
で github-actions SA に \`bigquery.datasets.setIamPolicy\` 権限がなく、
dataset-level binding 作成が 403 で失敗。

一方で project-level binding の destroy が先行成功してしまい、結果として:
- likes-export-workflow SA: BigQuery 書き込み権限消失（3:00 JST scheduler 実行が
  blocker 状態）
- github-actions SA: BigQuery dataset アクセス権限消失

## 復旧手順（実施済）

1. \`bq update --source\` で dataset access に直接追加:
   - likes-export-workflow → roles/bigquery.dataEditor
   - github-actions → roles/bigquery.dataOwner
2. \`terraform import\` で state に取り込み

## コード変更

- \`iam.tf\`: \`github_actions_likes_analytics_metadata_viewer\` (metadataViewer) を
  \`github_actions_likes_analytics_data_owner\` (dataOwner) に置換
- README: hotfix 経緯の説明と import コマンドを追記

dataOwner は metadataViewer の superset で \`setIamPolicy\` も含むため、
今後は terraform 自身で dataset IAM を更新可能。

## 検証

- \`terraform plan\` で 0 diff 確認
- \`bq show likes_analytics\` で binding が正しく付与されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)