### PR TITLE
chore(deps): upgrade @lacolaco/notion-sync to v14

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,1388 +1,1388 @@
 {
   "5abcd25b-9466-4e91-a124-bb3a3026bc78": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "use-ionic-components-as-web-components-in-angular.md"
+    "filePath": "src/content/post/notion/use-ionic-components-as-web-components-in-angular.md"
   },
   "e34eeccc-4c1e-4aeb-a1c4-eb3381c58440": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "ng4-feature-ngif.md"
+    "filePath": "src/content/post/notion/ng4-feature-ngif.md"
   },
   "2b73521b-014a-801c-b1d9-da3027e1e221": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "spinoza-ethics.md"
+    "filePath": "src/content/post/notion/spinoza-ethics.md"
   },
   "2a13521b-014a-80d5-bbb8-ebacad6b3a3c": {
     "lastModified": "2026-03-28T07:55:00.000Z",
-    "filePath": "selling-the-vision.md"
+    "filePath": "src/content/post/notion/selling-the-vision.md"
   },
   "83efd4c0-a070-498b-add9-149d96ab564f": {
     "lastModified": "2026-03-28T07:10:00.000Z",
-    "filePath": "business-and-engineering-3-way-handshake.md"
+    "filePath": "src/content/post/notion/business-and-engineering-3-way-handshake.md"
   },
   "28c3521b-014a-8055-ae27-e56dcf158ee3": {
     "lastModified": "2026-03-28T07:24:00.000Z",
-    "filePath": "csp-for-npm-supply-chain-attacks.md"
+    "filePath": "src/content/post/notion/csp-for-npm-supply-chain-attacks.md"
   },
   "2883521b-014a-80a0-a116-f5365064060d": {
     "lastModified": "2026-03-28T06:54:00.000Z",
-    "filePath": "2025-10-10.md"
+    "filePath": "src/content/post/notion/2025-10-10.md"
   },
   "2873521b-014a-809b-9010-e60a892ed141": {
     "lastModified": "2026-03-28T06:55:00.000Z",
-    "filePath": "agent-communication-language.md"
+    "filePath": "src/content/post/notion/agent-communication-language.md"
   },
   "27d3521b-014a-8069-a238-d1bf5090621d": {
     "lastModified": "2026-03-28T06:55:00.000Z",
-    "filePath": "ai-session-retrospective.md"
+    "filePath": "src/content/post/notion/ai-session-retrospective.md"
   },
   "2713521b-014a-800c-b4dd-ed9150c0dc1c": {
     "lastModified": "2026-03-28T16:15:00.000Z",
-    "filePath": "angular-ai-forward.md"
+    "filePath": "src/content/post/notion/angular-ai-forward.md"
   },
   "2703521b-014a-8096-9603-e3c924fece24": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "london-trip-2025.md"
+    "filePath": "src/content/post/notion/london-trip-2025.md"
   },
   "23c3521b-014a-8036-9152-cc3d38813adf": {
     "lastModified": "2026-03-28T16:15:00.000Z",
-    "filePath": "angular-animations-enter-leave.md"
+    "filePath": "src/content/post/notion/angular-animations-enter-leave.md"
   },
   "e51abef4-1d47-44c9-8078-4e13059e6506": {
     "lastModified": "2026-03-28T07:54:00.000Z",
-    "filePath": "output-your-experiences.md"
+    "filePath": "src/content/post/notion/output-your-experiences.md"
   },
   "2353521b-014a-8036-8960-d57494b84243": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "technocrat-failure.md"
+    "filePath": "src/content/post/notion/technocrat-failure.md"
   },
   "2303521b-014a-8086-af98-d4b2b9cf0763": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "trust-and-trustworthy.md"
+    "filePath": "src/content/post/notion/trust-and-trustworthy.md"
   },
   "21d3521b-014a-80e0-a40b-cb6943377b34": {
     "lastModified": "2026-03-28T16:22:00.000Z",
-    "filePath": "angular-unit-testing-runner-v20.md"
+    "filePath": "src/content/post/notion/angular-unit-testing-runner-v20.md"
   },
   "2163521b-014a-807a-b53a-e340ba3c84c3": {
     "lastModified": "2026-03-28T07:24:00.000Z",
-    "filePath": "carta-tech-assessment.md"
+    "filePath": "src/content/post/notion/carta-tech-assessment.md"
   },
   "2153521b-014a-80c3-bea6-d437b0ab1e42": {
     "lastModified": "2026-03-28T16:15:00.000Z",
-    "filePath": "ai-markdown-translator-with-gemini-textlint.md"
+    "filePath": "src/content/post/notion/ai-markdown-translator-with-gemini-textlint.md"
   },
   "ff3c7f84-3d40-43a5-8696-b65f32a068bd": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-gde.md"
+    "filePath": "src/content/post/notion/angular-gde.md"
   },
   "77445eb2-1395-4715-a3c2-d8ee7888b4bb": {
     "lastModified": "2026-03-28T06:55:00.000Z",
-    "filePath": "344dd234430d.md"
+    "filePath": "src/content/post/notion/344dd234430d.md"
   },
   "573f8d31-890d-4722-9f51-8f67a6f18a75": {
     "lastModified": "2026-03-28T07:25:00.000Z",
-    "filePath": "fb3588de30bb.md"
+    "filePath": "src/content/post/notion/fb3588de30bb.md"
   },
   "1f4bd4af-7cbd-4178-92c0-c0b24f702aed": {
     "lastModified": "2026-03-28T07:25:00.000Z",
-    "filePath": "f1122f25c01a.md"
+    "filePath": "src/content/post/notion/f1122f25c01a.md"
   },
   "10f3521b-014a-80c9-9fa3-fba715751ea4": {
     "lastModified": "2026-03-28T16:37:00.000Z",
-    "filePath": "f0c70b7fbba8.md"
+    "filePath": "src/content/post/notion/f0c70b7fbba8.md"
   },
   "86b6e95a-21b6-49e0-b865-871a62030d47": {
     "lastModified": "2026-03-28T07:24:00.000Z",
-    "filePath": "eb64b9996e3f.md"
+    "filePath": "src/content/post/notion/eb64b9996e3f.md"
   },
   "31126469-c4ae-49fd-b636-fd2442e818e3": {
     "lastModified": "2026-03-28T07:24:00.000Z",
-    "filePath": "e030fe9ff885.md"
+    "filePath": "src/content/post/notion/e030fe9ff885.md"
   },
   "d0a077fb-608b-42d7-ad52-32bbb9c37d0d": {
     "lastModified": "2026-03-28T16:37:00.000Z",
-    "filePath": "e6b3bd69debc.md"
+    "filePath": "src/content/post/notion/e6b3bd69debc.md"
   },
   "fccb4121-4c61-46ba-8da5-248ef87d0691": {
     "lastModified": "2026-03-28T07:24:00.000Z",
-    "filePath": "d9839f1915dd.md"
+    "filePath": "src/content/post/notion/d9839f1915dd.md"
   },
   "d477099b-de00-4870-ae5a-26bb66ae3f78": {
     "lastModified": "2026-03-28T07:24:00.000Z",
-    "filePath": "d12f0da2f01e.md"
+    "filePath": "src/content/post/notion/d12f0da2f01e.md"
   },
   "e0167abb-2961-4742-8e08-66be20024ad1": {
     "lastModified": "2026-03-28T07:24:00.000Z",
-    "filePath": "cfdbe43959bd.md"
+    "filePath": "src/content/post/notion/cfdbe43959bd.md"
   },
   "9d30853a-e23f-4fa5-921a-8a3132749585": {
     "lastModified": "2026-03-28T16:23:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/c8ad24ffd513.md"
+    "filePath": "src/content/post/notion/c8ad24ffd513.md"
   },
   "c70e219e-1959-4986-8de8-b7d2b68e8907": {
     "lastModified": "2026-03-28T07:24:00.000Z",
-    "filePath": "c5e0f640a7aa.md"
+    "filePath": "src/content/post/notion/c5e0f640a7aa.md"
   },
   "998b6066-78f0-4f24-b5dd-6f882a6ce4e1": {
     "lastModified": "2026-03-28T16:23:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/be8d2cf9a69e.md"
+    "filePath": "src/content/post/notion/be8d2cf9a69e.md"
   },
   "a1bb976f-7cd0-4fd0-a892-7a6ada485f97": {
     "lastModified": "2026-03-28T06:55:00.000Z",
-    "filePath": "8892acbcdb0e.md"
+    "filePath": "src/content/post/notion/8892acbcdb0e.md"
   },
   "fc400db0-92a7-4c5e-9870-0965e1b94264": {
     "lastModified": "2026-03-28T06:55:00.000Z",
-    "filePath": "703efacd5399.md"
+    "filePath": "src/content/post/notion/703efacd5399.md"
   },
   "f2915bdd-b7a5-4468-b295-cd685099ce5f": {
     "lastModified": "2026-03-28T16:15:00.000Z",
-    "filePath": "9b110500fe16.md"
+    "filePath": "src/content/post/notion/9b110500fe16.md"
   },
   "c83872a6-c28f-4a5e-a3cc-7ce763967a79": {
     "lastModified": "2026-03-28T06:55:00.000Z",
-    "filePath": "5fb0998c46b0.md"
+    "filePath": "src/content/post/notion/5fb0998c46b0.md"
   },
   "2a91295f-0262-4f84-9efb-02129b3b0458": {
     "lastModified": "2026-03-28T06:55:00.000Z",
-    "filePath": "4cd43ac4122b.md"
+    "filePath": "src/content/post/notion/4cd43ac4122b.md"
   },
   "70f287eb-ebb9-4dfa-bd97-7f00afdb50ed": {
     "lastModified": "2026-03-28T06:55:00.000Z",
-    "filePath": "4aa12fe7f756.md"
+    "filePath": "src/content/post/notion/4aa12fe7f756.md"
   },
   "715fc199-23d9-41de-bc9f-c6ade96d65a4": {
     "lastModified": "2026-03-28T06:55:00.000Z",
-    "filePath": "2b66719bbf39.md"
+    "filePath": "src/content/post/notion/2b66719bbf39.md"
   },
   "83577cc5-bb18-4442-a0af-7636350d9064": {
     "lastModified": "2026-03-28T16:15:00.000Z",
-    "filePath": "2af7bdf042a9.md"
+    "filePath": "src/content/post/notion/2af7bdf042a9.md"
   },
   "fd46ec62-6df1-4bdc-9f4a-050456e6d8b8": {
     "lastModified": "2026-03-28T06:54:00.000Z",
-    "filePath": "1e35376391fe.md"
+    "filePath": "src/content/post/notion/1e35376391fe.md"
   },
   "1373521b-014a-808e-9d87-ee16aa5e6c6d": {
     "lastModified": "2026-03-28T06:54:00.000Z",
-    "filePath": "1e2cf439b3c2.md"
+    "filePath": "src/content/post/notion/1e2cf439b3c2.md"
   },
   "2083521b-014a-8078-b103-c38f323bef11": {
     "lastModified": "2026-03-28T16:23:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/book-review-looks-good-to-me.md"
+    "filePath": "src/content/post/notion/book-review-looks-good-to-me.md"
   },
   "2033521b-014a-80d9-8b70-f882faed196e": {
     "lastModified": "2026-03-28T13:22:00.000Z",
-    "filePath": "tskaigi-2025-explain.md"
+    "filePath": "src/content/post/notion/tskaigi-2025-explain.md"
   },
   "1ff3521b-014a-80ce-ac20-c9e6e608bc43": {
     "lastModified": "2026-03-28T07:24:00.000Z",
-    "filePath": "deck-markdown-to-google-slides.md"
+    "filePath": "src/content/post/notion/deck-markdown-to-google-slides.md"
   },
   "1fc3521b-014a-806e-b1b8-e154f6b3507a": {
     "lastModified": "2026-03-28T13:22:00.000Z",
-    "filePath": "tskaigi-2025-slide.md"
+    "filePath": "src/content/post/notion/tskaigi-2025-slide.md"
   },
   "1e23521b-014a-80ee-a293-c9a03f195b00": {
     "lastModified": "2026-03-28T07:39:00.000Z",
-    "filePath": "issueops-by-github-command-action.md"
+    "filePath": "src/content/post/notion/issueops-by-github-command-action.md"
   },
   "1d03521b-014a-8070-af87-dfbe63ce9c9a": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-selectorless-is-coming.md"
+    "filePath": "src/content/post/notion/angular-selectorless-is-coming.md"
   },
   "1d03521b-014a-80be-ae58-f852f4628521": {
     "lastModified": "2026-03-28T17:07:00.000Z",
-    "filePath": "weekly-commits-on-angular-2025-04-09.md"
+    "filePath": "src/content/post/notion/weekly-commits-on-angular-2025-04-09.md"
   },
   "1c93521b-014a-80bf-b779-eb623edab9e1": {
     "lastModified": "2026-03-28T16:52:00.000Z",
-    "filePath": "read-books-2025-q1.md"
+    "filePath": "src/content/post/notion/read-books-2025-q1.md"
   },
   "1c23521b-014a-8006-826d-f570a3e9e91c": {
     "lastModified": "2026-03-28T16:22:00.000Z",
-    "filePath": "angular-using-web-worker-through-resource.md"
+    "filePath": "src/content/post/notion/angular-using-web-worker-through-resource.md"
   },
   "1bb3521b-014a-80de-aa71-c45e578737b9": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "weekly-commits-on-angular-2025-03-19.md"
+    "filePath": "src/content/post/notion/weekly-commits-on-angular-2025-03-19.md"
   },
   "1ad3521b-014a-80e5-bde2-e61a84634c57": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "weekly-commits-on-angular-2025-03-12.md"
+    "filePath": "src/content/post/notion/weekly-commits-on-angular-2025-03-12.md"
   },
   "1b43521b-014a-8044-8298-efca294f5fde": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "weekly-commits-on-angular-2025-03-05.md"
+    "filePath": "src/content/post/notion/weekly-commits-on-angular-2025-03-05.md"
   },
   "1ab3521b-014a-80fb-b2b3-edfd08438071": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "v-tokyo-22-pre.md"
+    "filePath": "src/content/post/notion/v-tokyo-22-pre.md"
   },
   "1a63521b-014a-808f-9266-e92dc6f86dfc": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "weekly-commits-on-angular-2025-02-26.md"
+    "filePath": "src/content/post/notion/weekly-commits-on-angular-2025-02-26.md"
   },
   "1983521b-014a-80d0-8a7c-c09020dd3420": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-http-resource-quick-overview.md"
+    "filePath": "src/content/post/notion/angular-http-resource-quick-overview.md"
   },
   "1913521b-014a-80f0-9c8a-f2b4dde093d1": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-cdk-overlay-with-animations.md"
+    "filePath": "src/content/post/notion/angular-cdk-overlay-with-animations.md"
   },
   "18e3521b-014a-80d9-af62-f945ecfa18f3": {
     "lastModified": "2026-03-28T16:22:00.000Z",
-    "filePath": "angular-tailwind-css-4-setup.md"
+    "filePath": "src/content/post/notion/angular-tailwind-css-4-setup.md"
   },
   "1803521b-014a-8061-ac65-d2a070fe5d09": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-prototyping-afternextchange-for-signals.md"
+    "filePath": "src/content/post/notion/angular-prototyping-afternextchange-for-signals.md"
   },
   "1763521b-014a-80ca-916d-d87cfc630eca": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-let-tailwindcss-intellisense.md"
+    "filePath": "src/content/post/notion/angular-let-tailwindcss-intellisense.md"
   },
   "14d3521b-014a-803e-a815-c7030c8e4287": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-signal-forms-prototype.md"
+    "filePath": "src/content/post/notion/angular-signal-forms-prototype.md"
   },
   "1603521b-014a-8027-8694-dcc8096690a8": {
     "lastModified": "2026-03-28T16:23:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/books-of-the-year-2024.md"
+    "filePath": "src/content/post/notion/books-of-the-year-2024.md"
   },
   "1523521b-014a-80af-9ba3-c39c2a20e510": {
     "lastModified": "2026-03-28T07:10:00.000Z",
-    "filePath": "bookstore-2024.md"
+    "filePath": "src/content/post/notion/bookstore-2024.md"
   },
   "1443521b-014a-80f2-a3c9-e4a8873c3171": {
     "lastModified": "2026-03-28T07:24:00.000Z",
-    "filePath": "contribution-by-mention.md"
+    "filePath": "src/content/post/notion/contribution-by-mention.md"
   },
   "1403521b-014a-8021-ba2c-e240f1d439e8": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-idea-resource-factory.en.md"
+    "filePath": "src/content/post/notion/angular-idea-resource-factory.en.md"
   },
   "1293521b-014a-8073-bb02-e294780424be": {
     "lastModified": "2026-03-28T07:10:00.000Z",
-    "filePath": "bookstore-at-devfest-tokyo-2024.md"
+    "filePath": "src/content/post/notion/bookstore-at-devfest-tokyo-2024.md"
   },
   "12e3521b-014a-80da-a5a9-ed157e6bc9b1": {
     "lastModified": "2026-03-28T16:23:00.000Z",
-    "filePath": "angular-v19-resource.md"
+    "filePath": "src/content/post/notion/angular-v19-resource.md"
   },
   "12d3521b-014a-80f3-95ff-d9c289dd689e": {
     "lastModified": "2026-03-28T16:23:00.000Z",
-    "filePath": "angular-v19-linked-signal.md"
+    "filePath": "src/content/post/notion/angular-v19-linked-signal.md"
   },
   "11a3521b-014a-8026-b45e-fb2c2fc99ee0": {
     "lastModified": "2026-03-28T16:22:00.000Z",
-    "filePath": "angular-v19-effect-changes.md"
+    "filePath": "src/content/post/notion/angular-v19-effect-changes.md"
   },
   "1133521b-014a-8051-8a7a-ce579b5f9413": {
     "lastModified": "2026-03-28T07:39:00.000Z",
-    "filePath": "lacolaco-user-voice.md"
+    "filePath": "src/content/post/notion/lacolaco-user-voice.md"
   },
   "1123521b-014a-8007-a56e-ea4e916ca7f4": {
     "lastModified": "2026-03-28T16:52:00.000Z",
-    "filePath": "read-books-2024-q3.md"
+    "filePath": "src/content/post/notion/read-books-2024-q3.md"
   },
   "d98c0b65-806e-4a10-a239-b329958ab674": {
     "lastModified": "2026-03-28T16:23:00.000Z",
-    "filePath": "angular-v19-prerendering.md"
+    "filePath": "src/content/post/notion/angular-v19-prerendering.md"
   },
   "52edeabe-72e3-44cc-9edd-d2ccf9148002": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-material-disabled-interactive.md"
+    "filePath": "src/content/post/notion/angular-material-disabled-interactive.md"
   },
   "4518985f-136b-4811-8aef-e72b464720a4": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-basic-ui-components.md"
+    "filePath": "src/content/post/notion/angular-basic-ui-components.md"
   },
   "50321da1-64af-4987-8a8f-24041e7761af": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-defer-scheduled-view.md"
+    "filePath": "src/content/post/notion/angular-defer-scheduled-view.md"
   },
   "c981b185-000b-427e-b15e-561f0a881bf5": {
     "lastModified": "2026-03-28T07:24:00.000Z",
-    "filePath": "drunkdeer-a75-pro.md"
+    "filePath": "src/content/post/notion/drunkdeer-a75-pro.md"
   },
   "6d1b50f2-cb24-42fb-94d8-7a1fc04688b6": {
     "lastModified": "2026-03-28T07:24:00.000Z",
-    "filePath": "cloudflare-image-transform-for-image-optimization.md"
+    "filePath": "src/content/post/notion/cloudflare-image-transform-for-image-optimization.md"
   },
   "23ca8249-09bf-4218-879b-45f6cdcd9ca9": {
     "lastModified": "2026-03-28T16:52:00.000Z",
-    "filePath": "read-books-2024-q2.md"
+    "filePath": "src/content/post/notion/read-books-2024-q2.md"
   },
   "6de8867a-9891-4c24-b26c-b45aeb3f3e32": {
     "lastModified": "2026-03-28T16:22:00.000Z",
-    "filePath": "angular-v18-let-syntax.md"
+    "filePath": "src/content/post/notion/angular-v18-let-syntax.md"
   },
   "1add2e31-b222-4912-bd32-2faab675cc5d": {
     "lastModified": "2026-03-28T07:54:00.000Z",
-    "filePath": "poc-trace-via-service-worker.md"
+    "filePath": "src/content/post/notion/poc-trace-via-service-worker.md"
   },
   "9be76b98-4879-43be-8422-fa29fd0a884a": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-rendering-effects-and-business-effects.md"
+    "filePath": "src/content/post/notion/angular-rendering-effects-and-business-effects.md"
   },
   "7b14ed47-6933-4797-8ef0-c29e83922a49": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "testing-angular-applications-with-vitest.md"
+    "filePath": "src/content/post/notion/testing-angular-applications-with-vitest.md"
   },
   "cef457cd-75d5-4eaa-a22d-7824fd3cbfdb": {
     "lastModified": "2026-03-28T07:54:00.000Z",
-    "filePath": "order-by-objective.md"
+    "filePath": "src/content/post/notion/order-by-objective.md"
   },
   "3a28e81c-63c8-4670-af97-d9e6218e2db8": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-cva-signals.md"
+    "filePath": "src/content/post/notion/angular-cva-signals.md"
   },
   "a2c74ee0-85a2-4950-90f5-f4a968192faf": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "firebase-app-hosting-angular-ssr-tryout.md"
+    "filePath": "src/content/post/notion/firebase-app-hosting-angular-ssr-tryout.md"
   },
   "1a5a4c7e-a784-4aca-8cf5-ef394fe0564c": {
     "lastModified": "2026-03-28T07:54:00.000Z",
-    "filePath": "opentelemetry-js-repository-walkthrough.md"
+    "filePath": "src/content/post/notion/opentelemetry-js-repository-walkthrough.md"
   },
   "6b94501f-9bf4-457b-8080-ee4e007b2f55": {
     "lastModified": "2026-03-28T13:22:00.000Z",
-    "filePath": "ya8-2024.md"
+    "filePath": "src/content/post/notion/ya8-2024.md"
   },
   "fc06702a-e32a-483e-a546-4ed5b9c3b702": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-model-inputs.md"
+    "filePath": "src/content/post/notion/angular-model-inputs.md"
   },
   "ca3bf239-647a-4d90-ad2a-e9c42c8e46b3": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "the-rules-of-programming-book-review.md"
+    "filePath": "src/content/post/notion/the-rules-of-programming-book-review.md"
   },
   "94d2bdf2-cdf7-42f3-b988-539639f95d27": {
     "lastModified": "2026-03-28T16:23:00.000Z",
-    "filePath": "angular-with-assertion-in-production.md"
+    "filePath": "src/content/post/notion/angular-with-assertion-in-production.md"
   },
   "61a8dc12-72fb-4e08-abc3-40051de4f75f": {
     "lastModified": "2026-03-28T07:39:00.000Z",
-    "filePath": "functionality-of-patterns.md"
+    "filePath": "src/content/post/notion/functionality-of-patterns.md"
   },
   "190478da-4fdf-4db6-a71f-4942d2011d2a": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-signal-inputs.md"
+    "filePath": "src/content/post/notion/angular-signal-inputs.md"
   },
   "9ab0d5bb-9796-4cd8-bd90-0d06170682ff": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-learning-costs.md"
+    "filePath": "src/content/post/notion/angular-learning-costs.md"
   },
   "252e8627-540a-4d33-a6f9-a3852e0c41d4": {
     "lastModified": "2026-03-28T07:39:00.000Z",
-    "filePath": "initial.md"
+    "filePath": "src/content/post/notion/initial.md"
   },
   "6b7d57ea-b6c9-48d9-8a5a-c7d374d32343": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "try-angular-2-aot-compilation.md"
+    "filePath": "src/content/post/notion/try-angular-2-aot-compilation.md"
   },
   "a2178d0a-2210-4f9b-9dfc-7fca9a317c9a": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "translation-view-children-and-content-children-in-angular-2.md"
+    "filePath": "src/content/post/notion/translation-view-children-and-content-children-in-angular-2.md"
   },
   "3f8c4b9e-8542-45a2-b428-a333076afb0a": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "translation-template-driven-form-in-angular-2.md"
+    "filePath": "src/content/post/notion/translation-template-driven-form-in-angular-2.md"
   },
   "44848909-3c08-4dc8-986a-050b8741eaff": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "translation-angular-2-component-styles.md"
+    "filePath": "src/content/post/notion/translation-angular-2-component-styles.md"
   },
   "6a6d79b6-ae74-4c49-82a9-5804cc0b5e0f": {
     "lastModified": "2026-03-28T13:21:00.000Z",
-    "filePath": "translation-angular-2-change-detection-explained.md"
+    "filePath": "src/content/post/notion/translation-angular-2-change-detection-explained.md"
   },
   "8d9ba74a-f57a-443d-b493-69454c9916c8": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "template-syntax-in-angular-2.md"
+    "filePath": "src/content/post/notion/template-syntax-in-angular-2.md"
   },
   "ba94cfed-9b64-41d3-862b-55c25fe0cea7": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "setting-up-angular-2-testing-environment-with-karma-and-webpack.md"
+    "filePath": "src/content/post/notion/setting-up-angular-2-testing-environment-with-karma-and-webpack.md"
   },
   "5ae80d32-0b24-4a6b-b01b-7ffa6feb932a": {
     "lastModified": "2026-03-28T16:39:00.000Z",
-    "filePath": "platform-prividers-of-angular-2.md"
+    "filePath": "src/content/post/notion/platform-prividers-of-angular-2.md"
   },
   "fe6eb6f9-2534-4204-b31c-a32dbec371ba": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "ng4-feature-meta-service.md"
+    "filePath": "src/content/post/notion/ng4-feature-meta-service.md"
   },
   "aa3078a5-d0bb-4538-aa41-5008ca903a52": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "ng4-feature-libs-update.md"
+    "filePath": "src/content/post/notion/ng4-feature-libs-update.md"
   },
   "e87dce04-7a32-43d2-b14b-e546a741e9d9": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "ng4-feature-forms-update.md"
+    "filePath": "src/content/post/notion/ng4-feature-forms-update.md"
   },
   "de7ff9bc-e847-4322-bc47-d3f686b88db6": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "ng4-feature-core-update.md"
+    "filePath": "src/content/post/notion/ng4-feature-core-update.md"
   },
   "5b8306d1-a3ce-4927-8181-888a10c958eb": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "ng-conf-2017-day-3-note.md"
+    "filePath": "src/content/post/notion/ng-conf-2017-day-3-note.md"
   },
   "b0f5f2b3-0601-4805-b6f3-32feed870c3c": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "ng-conf-2017-day-1-note.md"
+    "filePath": "src/content/post/notion/ng-conf-2017-day-1-note.md"
   },
   "eb888a6f-797f-4562-907a-2adb7ea9d36a": {
     "lastModified": "2026-03-28T07:40:00.000Z",
-    "filePath": "merging-objects-with-partial-type.md"
+    "filePath": "src/content/post/notion/merging-objects-with-partial-type.md"
   },
   "5d985bb5-3b53-41d8-b097-d2f5cf8ddb57": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "local-variables-and-exportas-of-angular-2.md"
+    "filePath": "src/content/post/notion/local-variables-and-exportas-of-angular-2.md"
   },
   "fce69b90-8ffc-4369-a68b-b56f02e16320": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "how-to-use-angular-2-nightly-builds.md"
+    "filePath": "src/content/post/notion/how-to-use-angular-2-nightly-builds.md"
   },
   "b423a3ed-d0c9-4e59-9e12-35e08c72bc64": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "forget-compile-in-angular-2.md"
+    "filePath": "src/content/post/notion/forget-compile-in-angular-2.md"
   },
   "3af033c8-da56-47f1-9adf-4eef3310067f": {
     "lastModified": "2026-03-28T16:37:00.000Z",
-    "filePath": "event-broadcasting-in-angular-2.md"
+    "filePath": "src/content/post/notion/event-broadcasting-in-angular-2.md"
   },
   "655c55b5-69cc-4063-8608-44d8f10ec88b": {
     "lastModified": "2026-03-28T16:23:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/aot-compilation-with-webpack.md"
+    "filePath": "src/content/post/notion/aot-compilation-with-webpack.md"
   },
   "5f9d3b12-aa0a-4be9-92e5-c8c9e4f6f53b": {
     "lastModified": "2026-03-28T16:23:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/angular2-view-encapsulation-fallback.md"
+    "filePath": "src/content/post/notion/angular2-view-encapsulation-fallback.md"
   },
   "5004a8f6-78b3-4281-9b4a-f575cdb1871b": {
     "lastModified": "2026-03-28T16:15:00.000Z",
-    "filePath": "angular-2-how-detect-object-changes.md"
+    "filePath": "src/content/post/notion/angular-2-how-detect-object-changes.md"
   },
   "5fa5bd2c-24b5-494a-984c-d234f8fab462": {
     "lastModified": "2026-03-28T16:15:00.000Z",
-    "filePath": "access-to-global-variables-in-angular-2.md"
+    "filePath": "src/content/post/notion/access-to-global-variables-in-angular-2.md"
   },
   "b5de8f33-06b2-4e58-bb12-009345948aa7": {
     "lastModified": "2026-03-28T17:07:00.000Z",
-    "filePath": "why-angularjs-needs-http-service.md"
+    "filePath": "src/content/post/notion/why-angularjs-needs-http-service.md"
   },
   "de2f47a3-3dcc-4621-8f6c-f56dc1b57062": {
     "lastModified": "2026-03-28T13:21:00.000Z",
-    "filePath": "state-management-library.md"
+    "filePath": "src/content/post/notion/state-management-library.md"
   },
   "f6bcdb70-96ae-42f1-84bf-94651422e9b7": {
     "lastModified": "2026-03-28T16:52:00.000Z",
-    "filePath": "read-ivy-design-doc-separate-compilation.md"
+    "filePath": "src/content/post/notion/read-ivy-design-doc-separate-compilation.md"
   },
   "281f136b-6bbe-4581-b7da-ae8db0af3c61": {
     "lastModified": "2026-03-28T07:54:00.000Z",
-    "filePath": "npm-new-package-name-rules.md"
+    "filePath": "src/content/post/notion/npm-new-package-name-rules.md"
   },
   "cada7ee0-19fd-4cc1-b74d-399d78d01d80": {
     "lastModified": "2026-03-28T07:40:00.000Z",
-    "filePath": "modular-graphql-schema-documentation.md"
+    "filePath": "src/content/post/notion/modular-graphql-schema-documentation.md"
   },
   "9dab9594-a41d-4af6-9f35-36e029edd915": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "migrate-angular-cli-from-1-7-to-6-0.md"
+    "filePath": "src/content/post/notion/migrate-angular-cli-from-1-7-to-6-0.md"
   },
   "bc3234bd-380a-4b3b-9f5a-d78c9b784cbe": {
     "lastModified": "2026-03-28T07:40:00.000Z",
-    "filePath": "merge-graphql-schemas.md"
+    "filePath": "src/content/post/notion/merge-graphql-schemas.md"
   },
   "acc37019-8652-4e0a-812f-1496941ec93a": {
     "lastModified": "2026-03-28T07:39:00.000Z",
-    "filePath": "graphql-schema-thought.md"
+    "filePath": "src/content/post/notion/graphql-schema-thought.md"
   },
   "c4159f8a-2131-4c7a-bd1f-fc0bdec1a71b": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "for-sustainable-angular-development.md"
+    "filePath": "src/content/post/notion/for-sustainable-angular-development.md"
   },
   "5a42f600-d919-4260-a6a8-94cfdc3fbe3d": {
     "lastModified": "2026-03-28T07:24:00.000Z",
-    "filePath": "custom-elements-event-target.md"
+    "filePath": "src/content/post/notion/custom-elements-event-target.md"
   },
   "6bbc2bc0-5d0f-4e2e-adfb-010e6d45fa4b": {
     "lastModified": "2026-03-28T16:23:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/bloc-design-pattern-with-angular.md"
+    "filePath": "src/content/post/notion/bloc-design-pattern-with-angular.md"
   },
   "73231349-3482-40fc-a317-e3cd68e612a3": {
     "lastModified": "2026-03-28T16:23:00.000Z",
-    "filePath": "angular-v6-tree-shakable-di.md"
+    "filePath": "src/content/post/notion/angular-v6-tree-shakable-di.md"
   },
   "ecaa239c-f616-409c-80b8-26b507a161f6": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-ivy-experimental-note.md"
+    "filePath": "src/content/post/notion/angular-ivy-experimental-note.md"
   },
   "e6735cdf-159e-4c34-be00-a20927cdb7a1": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-http-with-axios.md"
+    "filePath": "src/content/post/notion/angular-http-with-axios.md"
   },
   "e3968f95-daba-42a8-88ff-f3cc92b3e661": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-common-pattern-part-1.md"
+    "filePath": "src/content/post/notion/angular-common-pattern-part-1.md"
   },
   "ca90e008-8109-41f6-a4bb-889503419f3b": {
     "lastModified": "2026-03-28T06:54:00.000Z",
-    "filePath": "20-lines-simple-store-with-rxjs.md"
+    "filePath": "src/content/post/notion/20-lines-simple-store-with-rxjs.md"
   },
   "105a0b80-ef80-4a6d-ada0-2ab40f4e36ef": {
     "lastModified": "2026-03-28T07:24:00.000Z",
-    "filePath": "design-and-equilibration.md"
+    "filePath": "src/content/post/notion/design-and-equilibration.md"
   },
   "dd51c920-26ab-47ba-8982-23ae64a2a1f0": {
     "lastModified": "2026-03-28T17:07:00.000Z",
-    "filePath": "why-angular-has-not-static-site-generators.md"
+    "filePath": "src/content/post/notion/why-angular-has-not-static-site-generators.md"
   },
   "9e5898a6-59e0-4315-9846-fe94baa9a101": {
     "lastModified": "2026-03-28T07:55:00.000Z",
-    "filePath": "rxjs-and-webworker.md"
+    "filePath": "src/content/post/notion/rxjs-and-webworker.md"
   },
   "b0a11245-2091-4ae6-a17a-7291930e0970": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "list-component-design.md"
+    "filePath": "src/content/post/notion/list-component-design.md"
   },
   "4812cf7d-681e-4a7a-a2ce-b9091267791b": {
     "lastModified": "2026-03-28T07:40:00.000Z",
-    "filePath": "learn-ngrx.md"
+    "filePath": "src/content/post/notion/learn-ngrx.md"
   },
   "7c05b97b-52b2-4509-a119-9c3f5fedd229": {
     "lastModified": "2026-03-28T07:39:00.000Z",
-    "filePath": "introducing-contributors-img-keep-contributors-in-readme-md.md"
+    "filePath": "src/content/post/notion/introducing-contributors-img-keep-contributors-in-readme-md.md"
   },
   "5116a5ea-ca93-4e2c-8c5d-3e492a935c1c": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "introduce-router-scroller-in-angular-v6-1.md"
+    "filePath": "src/content/post/notion/introduce-router-scroller-in-angular-v6-1.md"
   },
   "a3993f7d-b21f-4b38-a87e-6c15cb98c825": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "introduce-angular-cdk-dnd.md"
+    "filePath": "src/content/post/notion/introduce-angular-cdk-dnd.md"
   },
   "b3355b6f-a9f9-4b0d-a35d-23b772427c5b": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "how-to-try-angular-cli-with-bazel.md"
+    "filePath": "src/content/post/notion/how-to-try-angular-cli-with-bazel.md"
   },
   "d55bc2a7-4dc7-4431-9924-7ff1d5610666": {
     "lastModified": "2026-03-28T07:39:00.000Z",
-    "filePath": "graphql-and-restful-backend.md"
+    "filePath": "src/content/post/notion/graphql-and-restful-backend.md"
   },
   "d98e8a7e-9853-4346-b12b-cc4bec8a0cb7": {
     "lastModified": "2026-03-28T16:37:00.000Z",
-    "filePath": "enjoyable-webworkers-in-angular.md"
+    "filePath": "src/content/post/notion/enjoyable-webworkers-in-angular.md"
   },
   "4218a5a9-be5f-46b9-b852-033819cb87da": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-loading-with-cdk-portal.md"
+    "filePath": "src/content/post/notion/angular-loading-with-cdk-portal.md"
   },
   "5423020e-64c0-46c3-918a-7c026b580ed2": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-how-to-use-action-creator-introduced-in-ngrx-v7-4-ja.md"
+    "filePath": "src/content/post/notion/angular-how-to-use-action-creator-introduced-in-ngrx-v7-4-ja.md"
   },
   "20719d16-1ba0-45e9-8926-4d36f993b77e": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-flex-layout-flexbox-and-grid-layout-for-angular-component.md"
+    "filePath": "src/content/post/notion/angular-flex-layout-flexbox-and-grid-layout-for-angular-component.md"
   },
   "d3b13513-d4e3-4d4a-bccf-1f286f55a32b": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-dynamic-importing-large-libraries.md"
+    "filePath": "src/content/post/notion/angular-dynamic-importing-large-libraries.md"
   },
   "8db2b4c6-9abe-4f39-94f1-e1bf70d145ed": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-component-style-with-emotion.md"
+    "filePath": "src/content/post/notion/angular-component-style-with-emotion.md"
   },
   "4a2c1ab7-cb28-4e92-a201-925dee868227": {
     "lastModified": "2026-03-28T07:25:00.000Z",
-    "filePath": "esmodule-export-import.md"
+    "filePath": "src/content/post/notion/esmodule-export-import.md"
   },
   "f798bd04-a39e-46d2-a75a-6266c2ee468d": {
     "lastModified": "2026-03-28T16:22:00.000Z",
-    "filePath": "angular-strict-property-initialization-best-practice.md"
+    "filePath": "src/content/post/notion/angular-strict-property-initialization-best-practice.md"
   },
   "71059486-37d1-4723-b844-5a3349f49a11": {
     "lastModified": "2026-03-28T13:21:00.000Z",
-    "filePath": "system-design-and-philosophical-thinking.md"
+    "filePath": "src/content/post/notion/system-design-and-philosophical-thinking.md"
   },
   "dd7d97b9-2132-4c44-96a6-7a423853cfcc": {
     "lastModified": "2026-03-28T07:39:00.000Z",
-    "filePath": "inner-speech.md"
+    "filePath": "src/content/post/notion/inner-speech.md"
   },
   "56463883-d920-4375-a2f4-f76b6fcf3c88": {
     "lastModified": "2026-03-28T17:07:00.000Z",
-    "filePath": "why-entrycomponents-will-be-deprecated.md"
+    "filePath": "src/content/post/notion/why-entrycomponents-will-be-deprecated.md"
   },
   "71bd2be8-bc25-4bf6-92ae-57848af085ef": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "webbundles-with-angular.md"
+    "filePath": "src/content/post/notion/webbundles-with-angular.md"
   },
   "f19ec171-8d0c-4245-becb-ad06777044f5": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "upgrading-angularjs-app-with-angular-elements.md"
+    "filePath": "src/content/post/notion/upgrading-angularjs-app-with-angular-elements.md"
   },
   "7de35a8f-b66b-43c2-ac9a-f009f211efd1": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "trusted-types-and-angular-security.md"
+    "filePath": "src/content/post/notion/trusted-types-and-angular-security.md"
   },
   "e4ec3823-e1e4-48d7-a390-0387a87e3095": {
     "lastModified": "2026-03-28T16:52:00.000Z",
-    "filePath": "proposal-angular-partial-form-injection-pattern.md"
+    "filePath": "src/content/post/notion/proposal-angular-partial-form-injection-pattern.md"
   },
   "6c416ea1-7a9c-4a04-8435-2c68031918af": {
     "lastModified": "2026-03-28T16:39:00.000Z",
-    "filePath": "perspective-of-angular-in-2020.md"
+    "filePath": "src/content/post/notion/perspective-of-angular-in-2020.md"
   },
   "4cdbdec6-e74c-4ea4-86e2-6c899e5369af": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "network-aware-preloading-strategy-for-angular-lazy-loading.en.md"
+    "filePath": "src/content/post/notion/network-aware-preloading-strategy-for-angular-lazy-loading.en.md"
   },
   "b989169b-f9a4-470a-9aae-9eb49a823e4a": {
     "lastModified": "2026-03-28T07:40:00.000Z",
-    "filePath": "migrate-circleci-to-github-actions.md"
+    "filePath": "src/content/post/notion/migrate-circleci-to-github-actions.md"
   },
   "aa9c6eae-0193-468f-8855-ea5a38f72e0d": {
     "lastModified": "2026-03-28T07:40:00.000Z",
-    "filePath": "managing-key-value-constants-in-typescript.md"
+    "filePath": "src/content/post/notion/managing-key-value-constants-in-typescript.md"
   },
   "f6c7a5b1-0d5c-495c-90b2-924d788cb3c2": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "leaning-curve-and-angular-app-architecture.md"
+    "filePath": "src/content/post/notion/leaning-curve-and-angular-app-architecture.md"
   },
   "70f6f715-a71d-47ad-adc0-8aca8916c1c7": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "how-to-trace-angular.md"
+    "filePath": "src/content/post/notion/how-to-trace-angular.md"
   },
   "d4fdf732-3192-45b8-b5d9-1ed9f6c4c062": {
     "lastModified": "2026-03-28T16:23:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/differential-loading-a-new-feature-of-angular-cli-v8.en.md"
+    "filePath": "src/content/post/notion/differential-loading-a-new-feature-of-angular-cli-v8.en.md"
   },
   "f1218e5c-5190-4cf5-b6e1-c27896a9862a": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-single-state-stream-pattern.md"
+    "filePath": "src/content/post/notion/angular-single-state-stream-pattern.md"
   },
   "30d898e5-e62d-4967-a938-79622e2f9730": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-ngmodule-and-directories.md"
+    "filePath": "src/content/post/notion/angular-ngmodule-and-directories.md"
   },
   "acbf55ee-e651-42b5-8132-04835b8fdab1": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-how-to-use-action-creator-introduced-in-ngrx-v7-4.md"
+    "filePath": "src/content/post/notion/angular-how-to-use-action-creator-introduced-in-ngrx-v7-4.md"
   },
   "544a0dd6-6f0b-4c7d-ae3e-7f5ba21a6320": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-atomic-design-and-ngmodule.md"
+    "filePath": "src/content/post/notion/angular-atomic-design-and-ngmodule.md"
   },
   "079d51b6-a4d3-4a1a-ab62-245e97797984": {
     "lastModified": "2026-03-28T07:54:00.000Z",
-    "filePath": "professional-and-expert.md"
+    "filePath": "src/content/post/notion/professional-and-expert.md"
   },
   "7908eb7e-5234-42c7-a940-b1615464cdfe": {
     "lastModified": "2026-03-28T07:54:00.000Z",
-    "filePath": "pre-order-jsprimer.md"
+    "filePath": "src/content/post/notion/pre-order-jsprimer.md"
   },
   "eb5832c4-1909-4ad1-9bfa-d5ed2f86a16b": {
     "lastModified": "2026-03-28T16:39:00.000Z",
-    "filePath": "nx-dockerize-angular-nest-app.md"
+    "filePath": "src/content/post/notion/nx-dockerize-angular-nest-app.md"
   },
   "696576eb-42b4-4c26-8344-2a1ef14f2515": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "ngconf2020-day3-note.md"
+    "filePath": "src/content/post/notion/ngconf2020-day3-note.md"
   },
   "35867cc9-ff22-4107-88d8-cafe3e17f010": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "ngconf2020-day2-note.md"
+    "filePath": "src/content/post/notion/ngconf2020-day2-note.md"
   },
   "e1cd81aa-c8d3-4ccd-8eb9-01261b18f7fd": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "ngconf2020-day1-note.md"
+    "filePath": "src/content/post/notion/ngconf2020-day1-note.md"
   },
   "f6287c72-68f9-4adc-be24-70f401207886": {
     "lastModified": "2026-03-28T07:25:00.000Z",
-    "filePath": "firebase-hosting-production-staging-with-targets.md"
+    "filePath": "src/content/post/notion/firebase-hosting-production-staging-with-targets.md"
   },
   "4d172266-5b4b-488d-8049-bf2ac4fee642": {
     "lastModified": "2026-03-28T16:23:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/deep-dive-angular-components-mat-divider.en.md"
+    "filePath": "src/content/post/notion/deep-dive-angular-components-mat-divider.en.md"
   },
   "289a7964-b989-4c20-818f-45f429907bd1": {
     "lastModified": "2026-03-28T16:23:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/async-pipe-initial-null-problem.md"
+    "filePath": "src/content/post/notion/async-pipe-initial-null-problem.md"
   },
   "618c54c9-8689-4e02-a3ef-4db0ac7ab530": {
     "lastModified": "2026-03-28T16:23:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/async-pipe-initial-null-problem.en.md"
+    "filePath": "src/content/post/notion/async-pipe-initial-null-problem.en.md"
   },
   "8e70c8ca-2d56-49b0-94b0-02c8332db5c5": {
     "lastModified": "2026-03-28T16:23:00.000Z",
-    "filePath": "angular-zoneless-router-activation.en.md"
+    "filePath": "src/content/post/notion/angular-zoneless-router-activation.en.md"
   },
   "66159df0-e348-42f1-9a27-5319c346cdc3": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-lightweight-injection-token-overview.md"
+    "filePath": "src/content/post/notion/angular-lightweight-injection-token-overview.md"
   },
   "eb942520-a359-4704-83d7-c4ba864b7ce8": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-elements-composable-definition-pattern.en.md"
+    "filePath": "src/content/post/notion/angular-elements-composable-definition-pattern.en.md"
   },
   "09047f7d-f09e-48ec-b004-a98745ede141": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-content-projection-101.md"
+    "filePath": "src/content/post/notion/angular-content-projection-101.md"
   },
   "e2c2dfec-0816-45ec-91da-8e3b41c704ad": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-app-reactiveness.en.md"
+    "filePath": "src/content/post/notion/angular-app-reactiveness.en.md"
   },
   "4552fa97-268f-4c15-b088-766732b2f74c": {
     "lastModified": "2026-03-28T13:21:00.000Z",
-    "filePath": "theory-of-state-01.md"
+    "filePath": "src/content/post/notion/theory-of-state-01.md"
   },
   "5214f4b0-5e70-4ac6-9b8e-bc77871a6b14": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "translation-crunchbase-and-angular-why-we-made-the-transition.md"
+    "filePath": "src/content/post/notion/translation-crunchbase-and-angular-why-we-made-the-transition.md"
   },
   "c3927100-7462-4b3e-acb7-75d58b6b9652": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "state-of-angular-elements-2020-summer.md"
+    "filePath": "src/content/post/notion/state-of-angular-elements-2020-summer.md"
   },
   "69bb91a6-ecf3-453f-bfcd-5c2e6354033a": {
     "lastModified": "2026-03-28T16:22:00.000Z",
-    "filePath": "angular-tailwindcss-styling-thoughts.md"
+    "filePath": "src/content/post/notion/angular-tailwindcss-styling-thoughts.md"
   },
   "2d6a637a-1d09-4e33-b181-28d0f15c450e": {
     "lastModified": "2026-03-28T16:22:00.000Z",
-    "filePath": "angular-state-of-linting-2020.md"
+    "filePath": "src/content/post/notion/angular-state-of-linting-2020.md"
   },
   "6de3a8dd-12c3-4893-8a53-0fd4e5789e65": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-ivy-library-compilation-design-in-depth.md"
+    "filePath": "src/content/post/notion/angular-ivy-library-compilation-design-in-depth.md"
   },
   "8f425a78-a2da-4952-9537-29fca1cdd4ff": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-ivy-library-compilation-design-in-depth.en.md"
+    "filePath": "src/content/post/notion/angular-ivy-library-compilation-design-in-depth.en.md"
   },
   "ab8e4521-25df-4704-bcc7-aa3da401391d": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-eliminate-render-blocking-requests.md"
+    "filePath": "src/content/post/notion/angular-eliminate-render-blocking-requests.md"
   },
   "a78e0e2c-f3cc-478d-ac9b-7ae6825d66c6": {
     "lastModified": "2026-03-28T16:22:00.000Z",
-    "filePath": "angular-trusted-types.md"
+    "filePath": "src/content/post/notion/angular-trusted-types.md"
   },
   "0bbe31d5-b26e-4cc9-802d-80dd2ff17ecb": {
     "lastModified": "2026-03-28T16:22:00.000Z",
-    "filePath": "angular-using-ngrx-with-redux-toolkit.md"
+    "filePath": "src/content/post/notion/angular-using-ngrx-with-redux-toolkit.md"
   },
   "5cc18604-33a5-43dc-bd1b-5787bd0c978b": {
     "lastModified": "2026-03-28T13:22:00.000Z",
-    "filePath": "why-i-dont-humblebrag.md"
+    "filePath": "src/content/post/notion/why-i-dont-humblebrag.md"
   },
   "7bdac4fe-30d9-4ae2-a780-81cbbb21b3c7": {
     "lastModified": "2026-03-28T16:52:00.000Z",
-    "filePath": "renovate-config-for-angular-cli.md"
+    "filePath": "src/content/post/notion/renovate-config-for-angular-cli.md"
   },
   "387ce9b4-8670-4771-9be1-dbcc920250f6": {
     "lastModified": "2026-03-28T07:39:00.000Z",
-    "filePath": "github-actions-yarn-cache.md"
+    "filePath": "src/content/post/notion/github-actions-yarn-cache.md"
   },
   "1247081c-70a7-4563-886a-056d3778a33f": {
     "lastModified": "2026-03-28T16:37:00.000Z",
-    "filePath": "enjoyable-webworkers-in-angular.ja.md"
+    "filePath": "src/content/post/notion/enjoyable-webworkers-in-angular.ja.md"
   },
   "bdddec22-7b87-4801-80bd-0660353509c9": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-property-binding-atttribute-binding.md"
+    "filePath": "src/content/post/notion/angular-property-binding-atttribute-binding.md"
   },
   "1ed8c3e3-8fee-458b-81fe-67202edc5a1c": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-jest-setup.md"
+    "filePath": "src/content/post/notion/angular-jest-setup.md"
   },
   "49b8a626-10b5-40be-869b-0a39ab002ff9": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-component-testing-declarations.md"
+    "filePath": "src/content/post/notion/angular-component-testing-declarations.md"
   },
   "f73568f5-3267-474d-bbe8-410a46000a9c": {
     "lastModified": "2026-03-28T07:39:00.000Z",
-    "filePath": "gravity-of-knowledge.md"
+    "filePath": "src/content/post/notion/gravity-of-knowledge.md"
   },
   "10032eb7-7733-4b78-a146-7bacbd58a9ae": {
     "lastModified": "2026-03-28T07:09:00.000Z",
-    "filePath": "ask-than-wish.md"
+    "filePath": "src/content/post/notion/ask-than-wish.md"
   },
   "e2d773ef-b710-4713-96b4-0f35e263f0f6": {
     "lastModified": "2026-03-28T13:21:00.000Z",
-    "filePath": "there-is-no-problem.md"
+    "filePath": "src/content/post/notion/there-is-no-problem.md"
   },
   "b81b02a5-843e-43c7-8a20-4f020179061f": {
     "lastModified": "2026-03-28T13:22:00.000Z",
-    "filePath": "write-better-code.md"
+    "filePath": "src/content/post/notion/write-better-code.md"
   },
   "af9e064d-fecb-4dd3-98dc-268f54ef4089": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-router-title-strategy.md"
+    "filePath": "src/content/post/notion/angular-router-title-strategy.md"
   },
   "48a52b05-59eb-43a5-b904-6e66f64550ce": {
     "lastModified": "2026-03-28T07:55:00.000Z",
-    "filePath": "rust-wasm-svg-rendering.md"
+    "filePath": "src/content/post/notion/rust-wasm-svg-rendering.md"
   },
   "47d8a289-80af-4cd7-a943-2091d4335b30": {
     "lastModified": "2026-03-28T07:54:00.000Z",
-    "filePath": "notion-headless-cms-3.md"
+    "filePath": "src/content/post/notion/notion-headless-cms-3.md"
   },
   "4047b3f1-3e88-4bca-b275-7dd81a6eef99": {
     "lastModified": "2026-03-28T07:54:00.000Z",
-    "filePath": "notion-headless-cms-2.md"
+    "filePath": "src/content/post/notion/notion-headless-cms-2.md"
   },
   "0d887003-a8d1-457f-a6be-c484dfcb2346": {
     "lastModified": "2026-03-28T07:54:00.000Z",
-    "filePath": "notion-headless-cms-1.md"
+    "filePath": "src/content/post/notion/notion-headless-cms-1.md"
   },
   "2d15afb8-8527-4cc4-8b69-30a395588112": {
     "lastModified": "2026-03-28T13:22:00.000Z",
-    "filePath": "webpack-esm-import-assertions.md"
+    "filePath": "src/content/post/notion/webpack-esm-import-assertions.md"
   },
   "7513b1f4-e7e6-4b10-ba15-e54411a3deb6": {
     "lastModified": "2026-03-28T16:52:00.000Z",
-    "filePath": "read-books-2022-q2.md"
+    "filePath": "src/content/post/notion/read-books-2022-q2.md"
   },
   "2f780bc5-4f7d-42d7-89fd-8149884d8233": {
     "lastModified": "2026-03-28T07:39:00.000Z",
-    "filePath": "github-actions-oidc-google-cloud.md"
+    "filePath": "src/content/post/notion/github-actions-oidc-google-cloud.md"
   },
   "6ede1797-c024-4d72-aea3-05528ed253b1": {
     "lastModified": "2026-03-28T13:22:00.000Z",
-    "filePath": "two-sides-of-tailwindcss.md"
+    "filePath": "src/content/post/notion/two-sides-of-tailwindcss.md"
   },
   "49cd00ee-40f0-44ec-a73c-43f946510dff": {
     "lastModified": "2026-03-28T16:18:00.000Z",
-    "filePath": "angular-state-management-patterns.md"
+    "filePath": "src/content/post/notion/angular-state-management-patterns.md"
   },
   "b6a71163-583d-42c6-99e8-09fdf5b64f4e": {
     "lastModified": "2026-03-28T07:55:00.000Z",
-    "filePath": "reverse-conways-law.md"
+    "filePath": "src/content/post/notion/reverse-conways-law.md"
   },
   "50dc0b15-6bb8-4b89-9b51-f142e115f8ed": {
     "lastModified": "2026-03-28T16:37:00.000Z",
-    "filePath": "engineering-manager-job-book-review.md"
+    "filePath": "src/content/post/notion/engineering-manager-job-book-review.md"
   },
   "613bc5dd-c46c-4c0a-8e30-b0f0dc1b8d4d": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-provider-function-pattern.md"
+    "filePath": "src/content/post/notion/angular-provider-function-pattern.md"
   },
   "48d047d8-4383-4029-a49a-35e649f01a9d": {
     "lastModified": "2026-03-28T16:39:00.000Z",
-    "filePath": "presentation-angular-standalone-based-app.md"
+    "filePath": "src/content/post/notion/presentation-angular-standalone-based-app.md"
   },
   "06291552-322a-4152-9379-de518e857222": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-component-visual-testing-with-cypress.md"
+    "filePath": "src/content/post/notion/angular-component-visual-testing-with-cypress.md"
   },
   "1934ffc5-baff-4477-a766-1e34e8dd45f7": {
     "lastModified": "2026-03-28T07:39:00.000Z",
-    "filePath": "github-actions-setup-node-engines.md"
+    "filePath": "src/content/post/notion/github-actions-setup-node-engines.md"
   },
   "5d1a14f0-328a-4165-a2e5-80e75aefe9ec": {
     "lastModified": "2026-03-28T16:22:00.000Z",
-    "filePath": "angular-v15-optin-browserslist.md"
+    "filePath": "src/content/post/notion/angular-v15-optin-browserslist.md"
   },
   "df74379c-5f80-4dff-9fb8-16ae978af4a8": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-new-provide-router-api.md"
+    "filePath": "src/content/post/notion/angular-new-provide-router-api.md"
   },
   "72dc7816-6db0-4536-a947-d93054f9386e": {
     "lastModified": "2026-03-28T16:37:00.000Z",
-    "filePath": "dokken-2022-winter-application.md"
+    "filePath": "src/content/post/notion/dokken-2022-winter-application.md"
   },
   "e7898e37-3304-4482-8657-dff38ca1f349": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "rx-angular-component-state-management.md"
+    "filePath": "src/content/post/notion/rx-angular-component-state-management.md"
   },
   "8921bbca-9dc2-4312-8119-845110ae380e": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-host-directives-observer-directive.md"
+    "filePath": "src/content/post/notion/angular-host-directives-observer-directive.md"
   },
   "93f70a4b-f638-4352-93b2-376076d9a62c": {
     "lastModified": "2026-03-28T16:37:00.000Z",
-    "filePath": "dokken-2022-winter-success.md"
+    "filePath": "src/content/post/notion/dokken-2022-winter-success.md"
   },
   "52c3af16-edb2-431f-9cc6-bba494864a53": {
     "lastModified": "2026-03-28T17:07:00.000Z",
-    "filePath": "yapc-kyoto-2023.md"
+    "filePath": "src/content/post/notion/yapc-kyoto-2023.md"
   },
   "aa5b1283-87fb-4b2f-bc91-6ec77c9f5d2a": {
     "lastModified": "2026-03-28T16:15:00.000Z",
-    "filePath": "angular-16-jest.md"
+    "filePath": "src/content/post/notion/angular-16-jest.md"
   },
   "23c54aef-56ff-4d4c-99b0-35e052b80056": {
     "lastModified": "2026-03-28T17:07:00.000Z",
-    "filePath": "why-inject-function-wins.md"
+    "filePath": "src/content/post/notion/why-inject-function-wins.md"
   },
   "02ff5a35-36af-4d69-9609-1ea3f818ad95": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-inputs-stream-pattern.md"
+    "filePath": "src/content/post/notion/angular-inputs-stream-pattern.md"
   },
   "c30c4744-b390-4755-8495-a126d32ad0d9": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-ngif-composing-feature-toggle.md"
+    "filePath": "src/content/post/notion/angular-ngif-composing-feature-toggle.md"
   },
   "bfac9356-b695-446d-b543-1bd67d943a16": {
     "lastModified": "2026-03-28T07:24:00.000Z",
-    "filePath": "change-blog-title-2023.md"
+    "filePath": "src/content/post/notion/change-blog-title-2023.md"
   },
   "03ccefe8-3594-4857-a531-ae0beceb1622": {
     "lastModified": "2026-03-28T07:39:00.000Z",
-    "filePath": "jsprimer-2nd.md"
+    "filePath": "src/content/post/notion/jsprimer-2nd.md"
   },
   "d8b87746-62dd-48f6-97ad-06ffb2a76604": {
     "lastModified": "2026-03-28T16:52:00.000Z",
-    "filePath": "presentation-what-is-signals.md"
+    "filePath": "src/content/post/notion/presentation-what-is-signals.md"
   },
   "83989f98-b8c5-470d-b414-90f097702ea3": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "signals-memo-20230621.md"
+    "filePath": "src/content/post/notion/signals-memo-20230621.md"
   },
   "d23a2cfd-5a46-47f6-a430-0533e00371a6": {
     "lastModified": "2026-03-28T07:10:00.000Z",
-    "filePath": "astro-satori-og-image-generation.md"
+    "filePath": "src/content/post/notion/astro-satori-og-image-generation.md"
   },
   "c0a2a317-2b8f-47ef-821d-9ef5e602c5f9": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-signals-component-design-patterns.md"
+    "filePath": "src/content/post/notion/angular-signals-component-design-patterns.md"
   },
   "09878dcc-7052-432c-ad3f-89c3b30ced25": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "io2023-angular-summary.md"
+    "filePath": "src/content/post/notion/io2023-angular-summary.md"
   },
   "2131694e-dc7e-4221-ad63-e13b749d4fc0": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-new-input-transforms.md"
+    "filePath": "src/content/post/notion/angular-new-input-transforms.md"
   },
   "4e8bcf7e-4c2c-4d31-806b-ff592edf4232": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "rethink-template-driven-forms.md"
+    "filePath": "src/content/post/notion/rethink-template-driven-forms.md"
   },
   "b32d2012-806c-4c34-8ecc-004f9385e1c0": {
     "lastModified": "2026-03-28T07:54:00.000Z",
-    "filePath": "notion-ai-slug-auto-generation.md"
+    "filePath": "src/content/post/notion/notion-ai-slug-auto-generation.md"
   },
   "c591feb7-e9d0-4b8b-9e1e-0fca8d07b690": {
     "lastModified": "2026-03-28T07:54:00.000Z",
-    "filePath": "presentation-phpconfuk-testing-dom.md"
+    "filePath": "src/content/post/notion/presentation-phpconfuk-testing-dom.md"
   },
   "00edd736-25bd-4fca-be5b-fa414a75b745": {
     "lastModified": "2026-03-28T16:39:00.000Z",
-    "filePath": "php-conference-fukuoka-2023.md"
+    "filePath": "src/content/post/notion/php-conference-fukuoka-2023.md"
   },
   "5d0c0a4d-96f7-4b24-8d84-a5250d5224bd": {
     "lastModified": "2026-03-28T16:39:00.000Z",
-    "filePath": "presentation-new-in-angular-io2023jp.md"
+    "filePath": "src/content/post/notion/presentation-new-in-angular-io2023jp.md"
   },
   "501bc994-5fe4-4360-8a6d-c49898bfdb91": {
     "lastModified": "2026-03-28T16:52:00.000Z",
-    "filePath": "read-books-2023-q2.md"
+    "filePath": "src/content/post/notion/read-books-2023-q2.md"
   },
   "1f3c7b97-cba3-4bbd-9d57-3b53c9b5aa4f": {
     "lastModified": "2026-03-28T13:21:00.000Z",
-    "filePath": "thoughts-about-gathering.md"
+    "filePath": "src/content/post/notion/thoughts-about-gathering.md"
   },
   "98e52895-d1b5-4fb1-8efb-80a8b35ce940": {
     "lastModified": "2026-03-28T13:22:00.000Z",
-    "filePath": "what-is-a-small-release.md"
+    "filePath": "src/content/post/notion/what-is-a-small-release.md"
   },
   "e6e80b9f-4a39-4d25-905f-4b4711f09f37": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-signal-equal-option.md"
+    "filePath": "src/content/post/notion/angular-signal-equal-option.md"
   },
   "9de77b78-554f-4e23-b970-c8ff5a57d2ce": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-signals-and-component-communication.md"
+    "filePath": "src/content/post/notion/angular-signals-and-component-communication.md"
   },
   "01bcb5d2-a0e1-4ced-8760-bbf17db18b2f": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "trace-based-testing.md"
+    "filePath": "src/content/post/notion/trace-based-testing.md"
   },
   "012e0360-1748-49d6-bdbf-141976e33385": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "typograms.md"
+    "filePath": "src/content/post/notion/typograms.md"
   },
   "5aaa4170-7374-407f-8295-9b48fc9da5e7": {
     "lastModified": "2026-03-28T16:23:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/books-20230811.md"
+    "filePath": "src/content/post/notion/books-20230811.md"
   },
   "be0af076-3ae9-4a80-9531-f1dafbaeb541": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "finish-plato-series.md"
+    "filePath": "src/content/post/notion/finish-plato-series.md"
   },
   "faa94324-1ab4-4608-a94d-ccbee6328928": {
     "lastModified": "2026-03-28T13:21:00.000Z",
-    "filePath": "team-level-and-objective.md"
+    "filePath": "src/content/post/notion/team-level-and-objective.md"
   },
   "4a9df5fd-86fa-43de-838c-f962af587ebe": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-signal-as-a-dependency.md"
+    "filePath": "src/content/post/notion/angular-signal-as-a-dependency.md"
   },
   "4b13c6c0-76da-42c3-81d1-81affb15f518": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-host-element-with-tailwindcss-classes.md"
+    "filePath": "src/content/post/notion/angular-host-element-with-tailwindcss-classes.md"
   },
   "e735baab-fe9f-4ecb-9944-f340b479572a": {
     "lastModified": "2026-03-28T07:24:00.000Z",
-    "filePath": "button-and-link.md"
+    "filePath": "src/content/post/notion/button-and-link.md"
   },
   "579ff1ec-a68c-4fbe-9fa6-7d7c59f1698d": {
     "lastModified": "2026-03-28T13:22:00.000Z",
-    "filePath": "vitest-in-source-testing.md"
+    "filePath": "src/content/post/notion/vitest-in-source-testing.md"
   },
   "d857b4c4-fa8b-4086-8a78-2f2b4ab3fbf0": {
     "lastModified": "2026-03-28T07:54:00.000Z",
-    "filePath": "notion-ai-bookmark-summarize.md"
+    "filePath": "src/content/post/notion/notion-ai-bookmark-summarize.md"
   },
   "69879d3d-0144-4aa2-9d3b-128b15689a53": {
     "lastModified": "2026-03-28T07:39:00.000Z",
-    "filePath": "inside-laco-feed.md"
+    "filePath": "src/content/post/notion/inside-laco-feed.md"
   },
   "3d881d0f-dcf4-4c19-ada8-6ceb05f8e874": {
     "lastModified": "2026-03-28T16:15:00.000Z",
-    "filePath": "angular-app-initializer-and-effect.md"
+    "filePath": "src/content/post/notion/angular-app-initializer-and-effect.md"
   },
   "636cb161-ad90-4d9b-acf1-aab96a58416d": {
     "lastModified": "2026-03-28T16:53:00.000Z",
-    "filePath": "slo-book-review.md"
+    "filePath": "src/content/post/notion/slo-book-review.md"
   },
   "41e326de-5455-488c-b731-732e45de6e0e": {
     "lastModified": "2026-03-28T07:24:00.000Z",
-    "filePath": "discord-bot-cfworkers-hono.md"
+    "filePath": "src/content/post/notion/discord-bot-cfworkers-hono.md"
   },
   "331292ed-743a-41ca-a3d7-5e039b9af412": {
     "lastModified": "2026-03-28T17:07:00.000Z",
-    "filePath": "why-angular-is-not-popular.md"
+    "filePath": "src/content/post/notion/why-angular-is-not-popular.md"
   },
   "7b9d8d5b-6552-4cdc-96fd-3dc21a708147": {
     "lastModified": "2026-03-28T16:52:00.000Z",
-    "filePath": "read-books-2023-q3.md"
+    "filePath": "src/content/post/notion/read-books-2023-q3.md"
   },
   "ffaa7744-5abc-4ec5-b2a3-9965065d0268": {
     "lastModified": "2026-03-28T13:21:00.000Z",
-    "filePath": "todo-should-be-unpleasant.md"
+    "filePath": "src/content/post/notion/todo-should-be-unpleasant.md"
   },
   "2d01249d-63fb-4dbf-96e9-0f56b8662c93": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "management-learning-book-review.md"
+    "filePath": "src/content/post/notion/management-learning-book-review.md"
   },
   "40f4e1df-5de5-45b9-b837-f96a36605ba9": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-mat-suffix-show-only-when-focused.md"
+    "filePath": "src/content/post/notion/angular-mat-suffix-show-only-when-focused.md"
   },
   "8c030420-0157-4f74-9397-6b60a0814c15": {
     "lastModified": "2026-03-28T07:40:00.000Z",
-    "filePath": "make-icon-badge.md"
+    "filePath": "src/content/post/notion/make-icon-badge.md"
   },
   "b6496dfc-5594-4dd8-b714-eb1e65ec3180": {
     "lastModified": "2026-03-28T13:21:00.000Z",
-    "filePath": "team-as-object.md"
+    "filePath": "src/content/post/notion/team-as-object.md"
   },
   "ee8cd85b-3e4f-48dd-b84d-b63d473cc5d7": {
     "lastModified": "2026-03-28T16:18:00.000Z",
-    "filePath": "angular-ssr-docker.md"
+    "filePath": "src/content/post/notion/angular-ssr-docker.md"
   },
   "d840388c-2dbd-406f-a01f-14ebff50dc7e": {
     "lastModified": "2026-03-28T13:23:00.000Z",
-    "filePath": "yurugengo-advent-calendar-2023.md"
+    "filePath": "src/content/post/notion/yurugengo-advent-calendar-2023.md"
   },
   "119f8e2c-8fc7-40f4-aa76-755373a0b009": {
     "lastModified": "2026-03-28T16:15:00.000Z",
-    "filePath": "angular-advent-calendar-2023.md"
+    "filePath": "src/content/post/notion/angular-advent-calendar-2023.md"
   },
   "a2f898eb-84e7-4ee8-b7da-7413c1e8902b": {
     "lastModified": "2026-03-28T16:39:00.000Z",
-    "filePath": "presentation-new-in-angular-devfest2023.md"
+    "filePath": "src/content/post/notion/presentation-new-in-angular-devfest2023.md"
   },
   "b28b8ef4-ebdb-495f-a2b5-1c0e89c9cded": {
     "lastModified": "2026-03-28T07:39:00.000Z",
-    "filePath": "gha-advent-calendar-2023.md"
+    "filePath": "src/content/post/notion/gha-advent-calendar-2023.md"
   },
   "2baf74e5-4ee0-4629-bba3-e69952099c3d": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-expansion-directive.en.md"
+    "filePath": "src/content/post/notion/angular-expansion-directive.en.md"
   },
   "5cd15f39-e63e-48b7-828e-af1224f8d884": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-expansion-directive.md"
+    "filePath": "src/content/post/notion/angular-expansion-directive.md"
   },
   "5ad67d6f-9feb-4970-a107-105bb88d8023": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-input-transforms-for-arrays-in-query-params.en.md"
+    "filePath": "src/content/post/notion/angular-input-transforms-for-arrays-in-query-params.en.md"
   },
   "b01d0937-931d-4a74-8ff3-1a416346feab": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-input-transforms-for-arrays-in-query-params.md"
+    "filePath": "src/content/post/notion/angular-input-transforms-for-arrays-in-query-params.md"
   },
   "2bb3521b-014a-80b8-8b48-d68bef7324ce": {
     "lastModified": "2026-03-28T07:24:00.000Z",
-    "filePath": "conventional-comments.md"
+    "filePath": "src/content/post/notion/conventional-comments.md"
   },
   "15c3521b-014a-8049-92ef-d7d6da2cf925": {
     "lastModified": "2026-03-28T16:15:00.000Z",
-    "filePath": "064fb0cc6577.md"
+    "filePath": "src/content/post/notion/064fb0cc6577.md"
   },
   "92bf97dd-802c-4b39-b752-7a50b5875273": {
     "lastModified": "2026-03-28T16:37:00.000Z",
-    "filePath": "dirty-checking-misunderstanding.md"
+    "filePath": "src/content/post/notion/dirty-checking-misunderstanding.md"
   },
   "5be92ed1-16af-4773-ab1d-19300a72928c": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-basic-terms-change-detection.md"
+    "filePath": "src/content/post/notion/angular-basic-terms-change-detection.md"
   },
   "2c53521b-014a-80d9-8279-f5c01f43773b": {
     "lastModified": "2026-03-28T16:15:00.000Z",
-    "filePath": "angular-animations-with-motion.md"
+    "filePath": "src/content/post/notion/angular-animations-with-motion.md"
   },
   "2ce3521b-014a-808a-9084-edc59dade0d3": {
     "lastModified": "2026-03-28T13:21:00.000Z",
-    "filePath": "the-bet-on-juniors-just-got-better.md"
+    "filePath": "src/content/post/notion/the-bet-on-juniors-just-got-better.md"
   },
   "2ce3521b-014a-808e-b8f3-d67bff9a22d9": {
     "lastModified": "2026-04-23T12:07:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/20251219225400.md",
+    "filePath": "src/content/post/notion/20251219225400.md",
     "imagePaths": [
-      "/Users/lacolaco/works/blog.lacolaco.net/public/images/20251219225400/image.a985adf8f0740225.png",
-      "/Users/lacolaco/works/blog.lacolaco.net/public/images/20251219225400/d3675f71-e6f4-48f2-a64c-86878e6a9c6d.c3736cb412de8eaa.png",
-      "/Users/lacolaco/works/blog.lacolaco.net/public/images/20251219225400/image.ce3175f60fe86e35.png"
+      "public/images/20251219225400/image.a985adf8f0740225.png",
+      "public/images/20251219225400/d3675f71-e6f4-48f2-a64c-86878e6a9c6d.c3736cb412de8eaa.png",
+      "public/images/20251219225400/image.ce3175f60fe86e35.png"
     ]
   },
   "2cf3521b-014a-8037-9804-cfe9b0bb82e0": {
     "lastModified": "2026-03-28T16:15:00.000Z",
-    "filePath": "angular-animations-with-motion.en.md"
+    "filePath": "src/content/post/notion/angular-animations-with-motion.en.md"
   },
   "2d33521b-014a-80b6-b3ae-d7578424fcc0": {
     "lastModified": "2026-03-28T16:17:00.000Z",
-    "filePath": "angular-provide-http-client-by-default.md"
+    "filePath": "src/content/post/notion/angular-provide-http-client-by-default.md"
   },
   "2d83521b-014a-80c0-8040-d5ad86a2b965": {
     "lastModified": "2026-03-28T07:39:00.000Z",
-    "filePath": "implement-view-as-markdown.md"
+    "filePath": "src/content/post/notion/implement-view-as-markdown.md"
   },
   "2d93521b-014a-809a-8b9a-cc91ed59efe2": {
     "lastModified": "2026-03-28T07:39:00.000Z",
-    "filePath": "implement-article-summary-feature.md"
+    "filePath": "src/content/post/notion/implement-article-summary-feature.md"
   },
   "2dd3521b-014a-80fc-ba47-f58bcf8d3238": {
     "lastModified": "2026-03-28T07:40:00.000Z",
-    "filePath": "learning-gleam.md"
+    "filePath": "src/content/post/notion/learning-gleam.md"
   },
   "2e03521b-014a-80e5-abcf-e16473464483": {
     "lastModified": "2026-04-23T12:07:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/20260106231700.md"
+    "filePath": "src/content/post/notion/20260106231700.md"
   },
   "b4bec4a6-3dfb-4ae4-9aa7-f59d1ce2b3de": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/b4bec4a6-3dfb-4ae4-9aa7-f59d1ce2b3de.md"
+    "filePath": "src/content/post/notion/b4bec4a6-3dfb-4ae4-9aa7-f59d1ce2b3de.md"
   },
   "c9a30880-5402-4497-8f21-143a011d4eb5": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/c9a30880-5402-4497-8f21-143a011d4eb5.md"
+    "filePath": "src/content/post/notion/c9a30880-5402-4497-8f21-143a011d4eb5.md"
   },
   "b3f4efdd-55fb-457d-a170-7f84efc85ed7": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/b3f4efdd-55fb-457d-a170-7f84efc85ed7.md"
+    "filePath": "src/content/post/notion/b3f4efdd-55fb-457d-a170-7f84efc85ed7.md"
   },
   "9f5dfac7-5c21-44d5-8815-b164a8faeb86": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/9f5dfac7-5c21-44d5-8815-b164a8faeb86.md"
+    "filePath": "src/content/post/notion/9f5dfac7-5c21-44d5-8815-b164a8faeb86.md"
   },
   "77cd7bfd-e4be-47db-99d5-74bcac833306": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/77cd7bfd-e4be-47db-99d5-74bcac833306.md",
+    "filePath": "src/content/post/notion/77cd7bfd-e4be-47db-99d5-74bcac833306.md",
     "imagePaths": [
-      "/Users/lacolaco/works/blog.lacolaco.net/public/images/77cd7bfd-e4be-47db-99d5-74bcac833306/image.abf78cc82b977245.png"
+      "public/images/77cd7bfd-e4be-47db-99d5-74bcac833306/image.abf78cc82b977245.png"
     ]
   },
   "0f6498ca-5e38-4b50-98e3-17c53a9f0839": {
     "lastModified": "2026-04-23T12:07:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/20220508151800.md"
+    "filePath": "src/content/post/notion/20220508151800.md"
   },
   "39f2e85d-7bea-4fa5-9b20-0511cabfd047": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/20220423222500.md"
+    "filePath": "src/content/post/notion/20220423222500.md"
   },
   "0130436c-887b-4cf5-ac53-b2bb027855a6": {
     "lastModified": "2026-04-23T12:07:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/0130436c-887b-4cf5-ac53-b2bb027855a6.md"
+    "filePath": "src/content/post/notion/0130436c-887b-4cf5-ac53-b2bb027855a6.md"
   },
   "99e1836a-a642-4c34-8e2b-10e0b197af43": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/99e1836a-a642-4c34-8e2b-10e0b197af43.md"
+    "filePath": "src/content/post/notion/99e1836a-a642-4c34-8e2b-10e0b197af43.md"
   },
   "aabd8345-c194-4ae6-8dec-a79ea75012e3": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/aabd8345-c194-4ae6-8dec-a79ea75012e3.md",
+    "filePath": "src/content/post/notion/aabd8345-c194-4ae6-8dec-a79ea75012e3.md",
     "imagePaths": [
-      "/Users/lacolaco/works/blog.lacolaco.net/public/images/aabd8345-c194-4ae6-8dec-a79ea75012e3/20211210121005.f47c65698f51aa98.png"
+      "public/images/aabd8345-c194-4ae6-8dec-a79ea75012e3/20211210121005.f47c65698f51aa98.png"
     ]
   },
   "910b561a-77a6-436c-aa12-98193a7cbe46": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/20211020104100.md"
+    "filePath": "src/content/post/notion/20211020104100.md"
   },
   "a7fd3687-7fde-4b43-b5a7-2eda9930c135": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/a7fd3687-7fde-4b43-b5a7-2eda9930c135.md"
+    "filePath": "src/content/post/notion/a7fd3687-7fde-4b43-b5a7-2eda9930c135.md"
   },
   "4bfd254b-bd38-404f-adce-c04cf4344f91": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/4bfd254b-bd38-404f-adce-c04cf4344f91.md"
+    "filePath": "src/content/post/notion/4bfd254b-bd38-404f-adce-c04cf4344f91.md"
   },
   "8326010a-d40f-4864-8d74-bf1293ff2eae": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/20210728213800.md"
+    "filePath": "src/content/post/notion/20210728213800.md"
   },
   "9f524b47-64ba-4679-88e2-a8eba1caca50": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/9f524b47-64ba-4679-88e2-a8eba1caca50.md"
+    "filePath": "src/content/post/notion/9f524b47-64ba-4679-88e2-a8eba1caca50.md"
   },
   "7b39e393-49d6-4903-8504-709ca9c2fc5f": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/20210205002200.md"
+    "filePath": "src/content/post/notion/20210205002200.md"
   },
   "c5cccf30-f38b-4892-a771-ff930fe597c1": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/20200811234800.md"
+    "filePath": "src/content/post/notion/20200811234800.md"
   },
   "6c265541-c4bb-49c3-9077-79b632ab2d82": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/20190820231400.md"
+    "filePath": "src/content/post/notion/20190820231400.md"
   },
   "f61ceebf-e81b-4fc9-ad5b-3cc4efd311e8": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/f61ceebf-e81b-4fc9-ad5b-3cc4efd311e8.md"
+    "filePath": "src/content/post/notion/f61ceebf-e81b-4fc9-ad5b-3cc4efd311e8.md"
   },
   "6f7880da-fb94-4f3e-9337-c4d6c5717386": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/20190614224400.md"
+    "filePath": "src/content/post/notion/20190614224400.md"
   },
   "27a2bbd6-86d1-4f73-b0da-da3019aeca45": {
     "lastModified": "2026-04-23T12:07:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/20190526000900.md"
+    "filePath": "src/content/post/notion/20190526000900.md"
   },
   "089162fc-e120-4d28-b477-a90dd3c2c82d": {
     "lastModified": "2026-04-23T12:07:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/20190507022300.md"
+    "filePath": "src/content/post/notion/20190507022300.md"
   },
   "356d6996-a7a0-4ccd-b4bb-edea5c616707": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/20190409224300.md"
+    "filePath": "src/content/post/notion/20190409224300.md"
   },
   "451ca852-65d6-4c1e-ac40-f442e2956b0d": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/20190322202600.md"
+    "filePath": "src/content/post/notion/20190322202600.md"
   },
   "249603ae-cd99-403f-840c-8123b9e68b66": {
     "lastModified": "2026-04-23T12:07:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/20190210220000.md"
+    "filePath": "src/content/post/notion/20190210220000.md"
   },
   "2e43521b-014a-8081-9f6d-e83cdbc8dc5d": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/20190114163100.md"
+    "filePath": "src/content/post/notion/20190114163100.md"
   },
   "2e43521b-014a-809b-beb7-c292c25b15ab": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/20180522143000.md"
+    "filePath": "src/content/post/notion/20180522143000.md"
   },
   "2e43521b-014a-8064-ac25-e722884cc60b": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/20180331231100.md"
+    "filePath": "src/content/post/notion/20180331231100.md"
   },
   "2e43521b-014a-80f6-94a6-e08bf845c8f9": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/20180416080000.md"
+    "filePath": "src/content/post/notion/20180416080000.md"
   },
   "2e53521b-014a-8098-9fc2-cb71d959a7db": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/20260111212600.md",
+    "filePath": "src/content/post/notion/20260111212600.md",
     "imagePaths": [
-      "/Users/lacolaco/works/blog.lacolaco.net/public/images/20260111212600/image.4c1e6fd370df0f54.png",
-      "/Users/lacolaco/works/blog.lacolaco.net/public/images/20260111212600/CleanShot_2026-01-11_at_21.23.052x.fbd8b176b6a47674.png"
+      "public/images/20260111212600/image.4c1e6fd370df0f54.png",
+      "public/images/20260111212600/CleanShot_2026-01-11_at_21.23.052x.fbd8b176b6a47674.png"
     ]
   },
   "2e63521b-014a-8017-9e50-e04f8a4e6e3b": {
     "lastModified": "2026-03-28T17:07:00.000Z",
-    "filePath": "wxt-angular-browser-extension.md"
+    "filePath": "src/content/post/notion/wxt-angular-browser-extension.md"
   },
   "fa0f4ae6-945f-4853-9c8d-155af151bdfc": {
     "lastModified": "2026-03-28T17:07:00.000Z",
-    "filePath": "wxt-angular-browser-extension.en.md"
+    "filePath": "src/content/post/notion/wxt-angular-browser-extension.en.md"
   },
   "2e73521b-014a-8038-809d-d55619eab15d": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/20260113221200.md"
+    "filePath": "src/content/post/notion/20260113221200.md"
   },
   "2ea3521b-014a-8043-90c3-de31672f18ea": {
     "lastModified": "2026-03-28T13:21:00.000Z",
-    "filePath": "survival-of-the-fittest-in-habits.md"
+    "filePath": "src/content/post/notion/survival-of-the-fittest-in-habits.md"
   },
   "2eb3521b-014a-80d4-a7cd-cd3b7a13445b": {
     "lastModified": "2026-04-23T12:08:00.000Z",
-    "filePath": "/Users/lacolaco/works/blog.lacolaco.net/src/content/post/notion/20260118004200.md",
+    "filePath": "src/content/post/notion/20260118004200.md",
     "imagePaths": [
-      "/Users/lacolaco/works/blog.lacolaco.net/public/images/20260118004200/image.15553b38a7f83a53.png",
-      "/Users/lacolaco/works/blog.lacolaco.net/public/images/20260118004200/1000008030.1b7294b226f11d68.jpg",
-      "/Users/lacolaco/works/blog.lacolaco.net/public/images/20260118004200/1000008033.1187df3932318021.jpg",
-      "/Users/lacolaco/works/blog.lacolaco.net/public/images/20260118004200/CleanShot_2026-01-17_at_18.32.042x.269693c6f35f6a67.png",
-      "/Users/lacolaco/works/blog.lacolaco.net/public/images/20260118004200/CleanShot_2026-01-17_at_19.24.062x.af75dfb8ec5d2e80.png",
-      "/Users/lacolaco/works/blog.lacolaco.net/public/images/20260118004200/image.5680e938687d90d6.png",
-      "/Users/lacolaco/works/blog.lacolaco.net/public/images/20260118004200/1000008028.a7c4409634b95122.jpg",
-      "/Users/lacolaco/works/blog.lacolaco.net/public/images/20260118004200/スクリーンショット_2026-01-17_193434.2c69ff5f298b1fa0.png",
-      "/Users/lacolaco/works/blog.lacolaco.net/public/images/20260118004200/スクリーンショット_2026-01-17_193629.c28ec72c2cd86d22.png"
+      "public/images/20260118004200/image.15553b38a7f83a53.png",
+      "public/images/20260118004200/1000008030.1b7294b226f11d68.jpg",
+      "public/images/20260118004200/1000008033.1187df3932318021.jpg",
+      "public/images/20260118004200/CleanShot_2026-01-17_at_18.32.042x.269693c6f35f6a67.png",
+      "public/images/20260118004200/CleanShot_2026-01-17_at_19.24.062x.af75dfb8ec5d2e80.png",
+      "public/images/20260118004200/image.5680e938687d90d6.png",
+      "public/images/20260118004200/1000008028.a7c4409634b95122.jpg",
+      "public/images/20260118004200/\u30b9\u30af\u30ea\u30fc\u30f3\u30b7\u30e7\u30c3\u30c8_2026-01-17_193434.2c69ff5f298b1fa0.png",
+      "public/images/20260118004200/\u30b9\u30af\u30ea\u30fc\u30f3\u30b7\u30e7\u30c3\u30c8_2026-01-17_193629.c28ec72c2cd86d22.png"
     ]
   },
   "2e93521b-014a-8057-9534-cd937331ad0b": {
     "lastModified": "2026-03-28T16:23:00.000Z",
-    "filePath": "angular-vitest-browser-mode-testing-library.md"
+    "filePath": "src/content/post/notion/angular-vitest-browser-mode-testing-library.md"
   },
   "3c1c45e4-096f-4bd2-98c2-09b07d7be73f": {
     "lastModified": "2026-03-28T16:16:00.000Z",
-    "filePath": "angular-firestore-resource-signal.md"
+    "filePath": "src/content/post/notion/angular-firestore-resource-signal.md"
   },
   "32d3521b-014a-806d-9707-ccc6367acef6": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "job-change-2020.md"
+    "filePath": "src/content/post/notion/job-change-2020.md"
   },
   "32d3521b-014a-8085-a87d-d649b3934cb4": {
     "lastModified": "2026-03-28T16:38:00.000Z",
-    "filePath": "job-change-2026.md"
+    "filePath": "src/content/post/notion/job-change-2026.md"
   },
   "348fed71-11b7-440e-b781-5b6139d27b4d": {
     "lastModified": "2026-04-01T00:17:00.000Z",
-    "filePath": "/home/runner/work/blog.lacolaco.net/blog.lacolaco.net/src/content/post/notion/problem-solving-bulldozer.md"
+    "filePath": "src/content/post/notion/problem-solving-bulldozer.md"
   },
   "ad093ae6-e556-4aeb-ac7e-9954364264c2": {
     "lastModified": "2026-04-07T07:13:00.000Z",
-    "filePath": "/home/runner/work/blog.lacolaco.net/blog.lacolaco.net/src/content/post/notion/trust-and-transparency.md"
+    "filePath": "src/content/post/notion/trust-and-transparency.md"
   },
   "3253521b-014a-8157-a3b6-d0d63eae2c6e": {
     "lastModified": "2026-04-08T23:08:00.000Z",
-    "filePath": "/home/runner/work/blog.lacolaco.net/blog.lacolaco.net/src/content/post/notion/angular-debounced-resource.md"
+    "filePath": "src/content/post/notion/angular-debounced-resource.md"
   },
   "33e3521b-014a-8067-8223-c389fd55f3bd": {
     "lastModified": "2026-04-11T01:19:00.000Z",
-    "filePath": "/home/runner/work/blog.lacolaco.net/blog.lacolaco.net/src/content/post/notion/productivity-addiction.md"
+    "filePath": "src/content/post/notion/productivity-addiction.md"
   },
   "3413521b-014a-800e-be9a-cfc0cefe26c7": {
     "lastModified": "2026-04-13T13:18:00.000Z",
-    "filePath": "/home/runner/work/blog.lacolaco.net/blog.lacolaco.net/src/content/post/notion/programmers-three-virtues-and-finitude.md"
+    "filePath": "src/content/post/notion/programmers-three-virtues-and-finitude.md"
   },
   "0a9d796f-9d15-43b0-a478-e7bc34212144": {
     "lastModified": "2026-04-14T00:38:00.000Z",
-    "filePath": "/home/runner/work/blog.lacolaco.net/blog.lacolaco.net/src/content/post/notion/minimum-questions-to-reflect.md"
+    "filePath": "src/content/post/notion/minimum-questions-to-reflect.md"
   },
   "34a3521b-014a-808f-9211-c3a1b715c44d": {
     "lastModified": "2026-04-22T14:44:00.000Z",
-    "filePath": "/home/runner/work/blog.lacolaco.net/blog.lacolaco.net/src/content/post/notion/angular-v22-onpush-by-default.md"
+    "filePath": "src/content/post/notion/angular-v22-onpush-by-default.md"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@eslint/js": "^10.0.1",
     "@iconify/json": "^2.2.161",
     "@iconify/tailwind": "^1.0.0",
-    "@lacolaco/notion-sync": "^13.0.0",
+    "@lacolaco/notion-sync": "^14.0.0",
     "@notionhq/client": "^5.20.0",
     "@tailwindcss/vite": "^4.1.4",
     "@testing-library/jest-dom": "^6.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         specifier: ^1.0.0
         version: 1.2.0
       '@lacolaco/notion-sync':
-        specifier: ^13.0.0
-        version: 13.0.0
+        specifier: ^14.0.0
+        version: 14.0.0
       '@notionhq/client':
         specifier: ^5.20.0
         version: 5.20.0
@@ -990,8 +990,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lacolaco/notion-sync@13.0.0':
-    resolution: {integrity: sha512-vI0isLcPFPtxLeKzjfZiCaMPaKHKAStACPbuJ6gWjhUBuDvPVWK5nuZmR5tJNx3vPrJxkkofnb7ndSe45F85/Q==, tarball: https://npm.pkg.github.com/download/@lacolaco/notion-sync/13.0.0/517bf8461b1bc77f714f1ca1c19319a93d149655}
+  '@lacolaco/notion-sync@14.0.0':
+    resolution: {integrity: sha512-cWxO1L11J2keEv0kBLODlmW4rTYrfyJ2E0GNQFCBAtLUOB+KwYXyivclqr9nTiFJKtzAlEvHqCbrT3/7W9QilA==, tarball: https://npm.pkg.github.com/download/@lacolaco/notion-sync/14.0.0/41ea83f282284ac221e009e1eefafe3ed255a4fc}
 
   '@mermaid-js/parser@1.1.0':
     resolution: {integrity: sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==}
@@ -5098,7 +5098,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lacolaco/notion-sync@13.0.0':
+  '@lacolaco/notion-sync@14.0.0':
     dependencies:
       '@notionhq/client': 5.20.0
       cli-progress: 3.12.0

--- a/tools/notion-sync/README.md
+++ b/tools/notion-sync/README.md
@@ -136,9 +136,13 @@ await syncNotionDatasource<BlogPostMetadata, BlogPostDatasource>({
   queryFilter: {
     and: [{ property: 'distribution', multi_select: { contains: 'blog.lacolaco.net' } }],
   },
+  // v14: cwd を設定すると getPageOutput / getImageOutput / propertyOutputs / manifestPath で
+  // 相対パスを返せる。manifest にもその相対パスがそのまま保存され、env-independent になる
+  cwd: rootDir,
+  manifestPath: 'manifest.json',
   propertyOutputs: {
-    tags: './src/content/post/notion/tags.json',
-    channels: './src/content/post/notion/channels.json',
+    tags: 'src/content/post/notion/tags.json',
+    channels: 'src/content/post/notion/channels.json',
   },
 
   // v13: (page, get)シグネチャ。getは型安全なプロパティアクセサ
@@ -152,11 +156,11 @@ await syncNotionDatasource<BlogPostMetadata, BlogPostDatasource>({
 
   renderMarkdown: {
     getPageOutput: (metadata) => ({
-      filePath: `./src/content/post/notion/${metadata.slug}.md`,
+      filePath: `src/content/post/notion/${metadata.slug}.md`,
     }),
     getImageOutput: (image, metadata) => ({
       src: `/images/${metadata.slug}/${image.blockId}.png`,
-      filePath: `./public/images/${metadata.slug}/${image.blockId}.png`,
+      filePath: `public/images/${metadata.slug}/${image.blockId}.png`,
     }),
     blockRenderers: {
       code: (block, context, defaultRenderer) => {

--- a/tools/notion-sync/main.ts
+++ b/tools/notion-sync/main.ts
@@ -159,10 +159,13 @@ const result = await syncNotionDatasource<BlogPostMetadata, BlogPostDatasource>(
       { property: 'channels', multi_select: { is_not_empty: true } },
     ],
   },
-  manifestPath: `${rootDir}/manifest.json`,
+  // v14: cwd を起点に getPageOutput / getImageOutput / propertyOutputs / manifestPath で
+  // 相対パスを返すと manifest にもその相対パスがそのまま保存される（env-independent）
+  cwd: rootDir,
+  manifestPath: 'manifest.json',
   propertyOutputs: {
-    tags: path.resolve(rootDir, 'src/content/post/notion/tags.json'),
-    channels: path.resolve(rootDir, 'src/content/post/notion/channels.json'),
+    tags: 'src/content/post/notion/tags.json',
+    channels: 'src/content/post/notion/channels.json',
   },
   verbose: true,
   mode,
@@ -217,7 +220,7 @@ const result = await syncNotionDatasource<BlogPostMetadata, BlogPostDatasource>(
     getPageOutput: (metadata) => {
       const localeSuffix = metadata.locale === 'en' ? '.en' : '';
       return {
-        filePath: path.resolve(rootDir, 'src/content/post/notion', `${metadata.slug}${localeSuffix}.md`),
+        filePath: path.join('src/content/post/notion', `${metadata.slug}${localeSuffix}.md`),
       };
     },
     getImageOutput: (image, metadata) => {
@@ -233,7 +236,7 @@ const result = await syncNotionDatasource<BlogPostMetadata, BlogPostDatasource>(
       const encodedFilename = `${encodeURIComponent(name)}.${hash}.${ext}`;
       return {
         src: `/images/${metadata.slug}/${encodedFilename}`,
-        filePath: path.resolve(rootDir, 'public/images', metadata.slug, diskFilename),
+        filePath: path.join('public/images', metadata.slug, diskFilename),
       };
     },
     blockRenderers: {


### PR DESCRIPTION
## Summary

\`@lacolaco/notion-sync\` を v13 → v14 にアップグレード。v14 で\`cwd\` オプションが path resolution に使われるようになり (closes [lacolaco/blog-contents#332](https://github.com/lacolaco/blog-contents/issues/332))、相対パスを返せるようになった。これにより manifest が env-independent になる。

## Changes

### Code (commit 1)

- \`syncNotionDatasource\` config に \`cwd: rootDir\` を追加
- \`manifestPath\` を \`'manifest.json'\` (相対) に
- \`propertyOutputs\` を相対パスに
- \`getPageOutput.filePath\` / \`getImageOutput.filePath\` を \`path.join(...)\` (相対) に
- README に v14 用例を反映

### Manifest normalization (commit 2)

ローカル script で manifest.json の filePath / imagePaths を全て repo 相対パスに正規化:

- 絶対パス \`/Users/lacolaco/.../src/content/post/notion/foo.md\` → \`src/content/post/notion/foo.md\`
- 絶対パス \`/home/runner/.../src/content/post/notion/foo.md\` → \`src/content/post/notion/foo.md\`
- legacy v12 相対パス \`foo.md\` → \`src/content/post/notion/foo.md\`

Notion API は叩かず、manifest.json のみ書き換え。

## v14 BREAKING CHANGE 対応

\`process.cwd()\` fallback が削除された。\`cwd\` か \`manifestPath\` のいずれかを必ず明示する必要がある。本コードでは両方とも明示しているため影響なし。

## Test plan

- [x] \`pnpm lint\` pass
- [x] \`pnpm build\` pass
- [x] \`pnpm notion-sync -- --dry-run\` で v14 が manifest を相対パス読み込みできることを確認
- [x] manifest.json: 全 340 件が relative path のみに正規化済み
- [ ] merge 後に CI 経由の sync で paths が env-dependent に戻らないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)