### PR TITLE
fix(ci): use --frozen-lockfile in sync-with-notion to prevent lockfile churn

### DIFF
--- a/.github/workflows/sync-with-notion.yml
+++ b/.github/workflows/sync-with-notion.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           app-id: ${{ secrets.WORKER_APP_ID }}
           private-key: ${{ secrets.WORKER_APP_PRIVATE_KEY }}
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm astro sync


### PR DESCRIPTION
## Summary

\`sync-with-notion.yml\` のみ素の \`pnpm install\` を実行していたため、Notion sync PR (例: #1538) に余計な \`pnpm-lock.yaml\` 差分が混入していた問題を修正。

## 原因

\`package.json\` に \`packageManager: pnpm@10.33.0\` が設定されている状態で素の \`pnpm install\` を実行すると、pnpm 10.33.0 が \`@pnpm/exe\` と各プラットフォーム binary のメタデータを \`pnpm-lock.yaml\` 先頭に自動追加する（pnpm 10 系の \`manage-package-manager-versions\` 挙動）。

\`peter-evans/create-pull-request\` がワーキングツリーの全変更を取り込むため、この自動追加が sync PR に commit されていた。

renovate 系 PR は \`--frozen-lockfile\` で install するためこの追加が起きず、renovate PR がマージされる度に sync PR の差分が「巻き戻されたように」見えていた。

## 修正

\`ci.yml\` / \`deploy-production.yml\` / \`deploy-preview.yml\` と同様に \`pnpm install\` → \`pnpm install --frozen-lockfile\` に統一。

## 検証

- 該当 install line のみの最小修正
- 他のスクリプト動作には影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)