### PR TITLE
fix(infra): disable pnpm package manager auto-tracking to prevent lockfile churn

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 shamefully-hoist=true
+manage-package-manager-versions=false
 @lacolaco:registry=https://npm.pkg.github.com


### PR DESCRIPTION
## Summary

- pnpm 10.16+ の `manage-package-manager-versions`（default: true）が原因で、`pnpm install --frozen-lockfile` 後の `pnpm exec` / `pnpm run` 実行時に `pnpm-lock.yaml` に `packageManagerDependencies` セクションが自動書き戻される
- #1558 で `sync-with-notion.yml` に `--frozen-lockfile` を付与したが、後続ステップ（`pnpm astro sync` / `notion-sync` / `r2-sync`）の自動書き戻しは止められず、PR #1538 等の同期PRで lockfile churn が継続していた
- `.npmrc` に `manage-package-manager-versions=false` を追加し、自動追跡を無効化する
- pnpm バージョンは GitHub Actions の `pnpm/action-setup` で明示的にインストールしているため、この機能は不要

## Test plan

- [x] ローカルで `pnpm install --frozen-lockfile` 実行 → lockfile 変更なし
- [x] ローカルで `pnpm astro sync` 実行 → lockfile 変更なし（修正前は churn 発生していた）
- [ ] マージ後、`sync-with-notion` ワークフロー再実行で PR #1538 から `pnpm-lock.yaml` 差分が消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)