### PR TITLE
feat(auto-translate): add proofreader (self-review) stage

### DIFF
--- a/tools/auto-translate/ast-utils.ts
+++ b/tools/auto-translate/ast-utils.ts
@@ -1,0 +1,13 @@
+// mdast/unist 共通の ast 判定ユーティリティ。
+// 複数モジュールで使う AST 判定はここに集約する
+
+import type { Parent } from 'unist';
+
+/**
+ * ノードが blockquote の子孫かどうか判定する。
+ * blockquote 内のコード/インラインコードは特殊扱い（プレースホルダ化対象外、
+ * 別経路で byte 一致検証）するため、複数モジュールで使う共通判定。
+ */
+export function hasBlockquoteAncestor(ancestors: readonly Parent[]): boolean {
+  return ancestors.some((a) => a.type === 'blockquote');
+}

--- a/tools/auto-translate/ast-utils.ts
+++ b/tools/auto-translate/ast-utils.ts
@@ -1,5 +1,5 @@
-// mdast/unist 共通の ast 判定ユーティリティ。
-// 複数モジュールで使う AST 判定はここに集約する
+// mdast/unist 共通の ast 判定ユーティリティ + 共通エラー文字列化。
+// 複数モジュールで使う AST 判定や定型処理はここに集約する
 
 import type { Parent } from 'unist';
 
@@ -10,4 +10,13 @@ import type { Parent } from 'unist';
  */
 export function hasBlockquoteAncestor(ancestors: readonly Parent[]): boolean {
   return ancestors.some((a) => a.type === 'blockquote');
+}
+
+/**
+ * catch (e) で受けた unknown 値から人間可読なメッセージを取り出す。
+ * Error インスタンスでない値（throw 'string' / throw {...} 等）にも対応する。
+ * (e as Error).message のキャストはランタイム値が Error でないと undefined を返すため使用しない
+ */
+export function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
 }

--- a/tools/auto-translate/code-extractor.spec.ts
+++ b/tools/auto-translate/code-extractor.spec.ts
@@ -61,6 +61,22 @@ describe('extractCode', () => {
     const { codeBlocks } = extractCode(md);
     assert.equal(codeBlocks[0], '```html\n<img src="x” />\n```');
   });
+
+  test('blockquote 内のコードブロックでも round-trip 可能', () => {
+    // 既存コードを引用しながら解説するパターン
+    const md = '前置き\n\n> ```ts\n> const x = 1;\n> ```\n\n後置き\n';
+    const { template, codeBlocks, inlineCodes } = extractCode(md);
+    // 抽出されたら復元で元に戻ることを確認（remark が blockquote 内の code を扱えるかに依存）
+    const restored = restoreCode(template, codeBlocks, inlineCodes);
+    assert.equal(restored, md);
+  });
+
+  test('blockquote 内のインラインコードでも round-trip 可能', () => {
+    const md = '> 引用文中の `foo` という識別子\n';
+    const { template, codeBlocks, inlineCodes } = extractCode(md);
+    const restored = restoreCode(template, codeBlocks, inlineCodes);
+    assert.equal(restored, md);
+  });
 });
 
 describe('restoreCode', () => {

--- a/tools/auto-translate/code-extractor.spec.ts
+++ b/tools/auto-translate/code-extractor.spec.ts
@@ -1,0 +1,95 @@
+import { strict as assert } from 'node:assert';
+import { test, describe } from 'node:test';
+import { extractCode, restoreCode } from './code-extractor.ts';
+
+describe('extractCode', () => {
+  test('コードブロックを ⟨⟨BLOCK_N⟩⟩ に置換する', () => {
+    const md = 'before\n\n```ts\nconst a = 1;\n```\n\nafter\n';
+    const { template, codeBlocks, inlineCodes } = extractCode(md);
+    assert.equal(codeBlocks.length, 1);
+    assert.equal(inlineCodes.length, 0);
+    assert.match(template, /⟨⟨BLOCK_0⟩⟩/);
+    assert.match(template, /^before/);
+    assert.match(template, /after\n$/);
+    assert.equal(codeBlocks[0], '```ts\nconst a = 1;\n```');
+  });
+
+  test('インラインコードを ⟨⟨INLINE_N⟩⟩ に置換する', () => {
+    const md = 'use `foo` and `bar` here\n';
+    const { template, inlineCodes } = extractCode(md);
+    assert.equal(inlineCodes.length, 2);
+    assert.equal(template, 'use ⟨⟨INLINE_0⟩⟩ and ⟨⟨INLINE_1⟩⟩ here\n');
+    assert.equal(inlineCodes[0], '`foo`');
+    assert.equal(inlineCodes[1], '`bar`');
+  });
+
+  test('コードブロック・インラインコードが混在', () => {
+    const md = 'use `foo`\n\n```\ncode\n```\n\nthen `bar`\n';
+    const { template, codeBlocks, inlineCodes } = extractCode(md);
+    assert.equal(codeBlocks.length, 1);
+    assert.equal(inlineCodes.length, 2);
+    assert.match(template, /⟨⟨INLINE_0⟩⟩/);
+    assert.match(template, /⟨⟨BLOCK_0⟩⟩/);
+    assert.match(template, /⟨⟨INLINE_1⟩⟩/);
+  });
+
+  test('複数コードブロックは順番に番号付け', () => {
+    const md = '```\nA\n```\n\ntext\n\n```\nB\n```\n';
+    const { template, codeBlocks } = extractCode(md);
+    assert.equal(codeBlocks.length, 2);
+    assert.equal(codeBlocks[0], '```\nA\n```');
+    assert.equal(codeBlocks[1], '```\nB\n```');
+    assert.match(template, /⟨⟨BLOCK_0⟩⟩[\s\S]*⟨⟨BLOCK_1⟩⟩/);
+  });
+
+  test('コードがないと codeBlocks/inlineCodes は空、template は元と同じ', () => {
+    const md = 'plain prose\n';
+    const { template, codeBlocks, inlineCodes } = extractCode(md);
+    assert.equal(codeBlocks.length, 0);
+    assert.equal(inlineCodes.length, 0);
+    assert.equal(template, md);
+  });
+
+  test('言語タグ付きコードブロックの fence (```ts) を保持', () => {
+    const md = '```typescript\nconst x = 1;\n```\n';
+    const { codeBlocks } = extractCode(md);
+    assert.equal(codeBlocks[0], '```typescript\nconst x = 1;\n```');
+  });
+
+  test('コードブロック内の引用符・特殊文字をそのまま保持', () => {
+    const md = '```html\n<img src="x” />\n```\n';
+    const { codeBlocks } = extractCode(md);
+    assert.equal(codeBlocks[0], '```html\n<img src="x” />\n```');
+  });
+});
+
+describe('restoreCode', () => {
+  test('プレースホルダを元の code で置換する', () => {
+    const template = 'use ⟨⟨INLINE_0⟩⟩\n\n⟨⟨BLOCK_0⟩⟩\n';
+    const result = restoreCode(template, ['```\nA\n```'], ['`foo`']);
+    assert.equal(result, 'use `foo`\n\n```\nA\n```\n');
+  });
+
+  test('複数プレースホルダを順番通りに置換', () => {
+    const template = '⟨⟨INLINE_0⟩⟩ and ⟨⟨INLINE_1⟩⟩';
+    const result = restoreCode(template, [], ['`a`', '`b`']);
+    assert.equal(result, '`a` and `b`');
+  });
+
+  test('extractCode → restoreCode が round-trip で元に戻る', () => {
+    const md = 'use `foo` and `bar`\n\n```ts\nconst a = 1;\n```\n\nthen ```inline``` ?\n';
+    const { template, codeBlocks, inlineCodes } = extractCode(md);
+    const restored = restoreCode(template, codeBlocks, inlineCodes);
+    assert.equal(restored, md);
+  });
+
+  test('プレースホルダが残っていたら throw（LLM が消失させた場合の検知）', () => {
+    const template = '⟨⟨INLINE_0⟩⟩'; // INLINE_0 だけだが inlineCodes には 2 個
+    assert.throws(() => restoreCode(template, [], ['`a`', '`b`']), /placeholder/i);
+  });
+
+  test('テンプレートに余分なプレースホルダがあれば throw（LLM が幻覚した場合の検知）', () => {
+    const template = '⟨⟨INLINE_0⟩⟩ ⟨⟨INLINE_5⟩⟩'; // INLINE_5 はそもそも extract されていない
+    assert.throws(() => restoreCode(template, [], ['`a`']), /placeholder/i);
+  });
+});

--- a/tools/auto-translate/code-extractor.spec.ts
+++ b/tools/auto-translate/code-extractor.spec.ts
@@ -92,4 +92,20 @@ describe('restoreCode', () => {
     const template = '⟨⟨INLINE_0⟩⟩ ⟨⟨INLINE_5⟩⟩'; // INLINE_5 はそもそも extract されていない
     assert.throws(() => restoreCode(template, [], ['`a`']), /placeholder/i);
   });
+
+  test('プレースホルダが重複していたら throw（LLM が duplicate した場合の検知）', () => {
+    // テンプレート内で ⟨⟨BLOCK_0⟩⟩ が 2 回出現 → コード重複挿入のリスク
+    const template = '⟨⟨BLOCK_0⟩⟩\n\n再掲: ⟨⟨BLOCK_0⟩⟩';
+    assert.throws(() => restoreCode(template, ['```\nA\n```'], []), /appears 2 times/i);
+  });
+
+  test('コードブロックの内容にプレースホルダ風の文字列が含まれても誤検知しない', () => {
+    // このシステム自体を解説する記事のように、コード内に ⟨⟨BLOCK_N⟩⟩ という文字列が
+    // 含まれる場合がある。restoreCode 後の result でプレースホルダパターンを検査すると
+    // 誤って throw してしまうため、このケースで正常に復元できることを保証する
+    const template = '解説: ⟨⟨BLOCK_0⟩⟩';
+    const codeWithPlaceholderText = '```ts\n// プレースホルダ ⟨⟨BLOCK_1⟩⟩ について\n```';
+    const result = restoreCode(template, [codeWithPlaceholderText], []);
+    assert.equal(result, '解説: ' + codeWithPlaceholderText);
+  });
 });

--- a/tools/auto-translate/code-extractor.spec.ts
+++ b/tools/auto-translate/code-extractor.spec.ts
@@ -56,6 +56,16 @@ describe('extractCode', () => {
     assert.equal(codeBlocks[0], '```typescript\nconst x = 1;\n```');
   });
 
+  test('チルダフェンス (~~~) でも抽出と round-trip が成立する', () => {
+    const md = 'before\n\n~~~ts\nconst x = 1;\n~~~\n\nafter\n';
+    const { template, codeBlocks, inlineCodes } = extractCode(md);
+    assert.equal(codeBlocks.length, 1);
+    assert.equal(codeBlocks[0], '~~~ts\nconst x = 1;\n~~~');
+    assert.match(template, /⟨⟨BLOCK_0⟩⟩/);
+    // round-trip
+    assert.equal(restoreCode(template, codeBlocks, inlineCodes), md);
+  });
+
   test('コードブロック内の引用符・特殊文字をそのまま保持', () => {
     const md = '```html\n<img src="x” />\n```\n';
     const { codeBlocks } = extractCode(md);

--- a/tools/auto-translate/code-extractor.spec.ts
+++ b/tools/auto-translate/code-extractor.spec.ts
@@ -155,6 +155,31 @@ describe('restoreCode', () => {
     assert.throws(() => restoreCode(template, ['```\nA\n```', '```\nB\n```'], []), /placeholder order mismatch/i);
   });
 
+  test('BLOCK と INLINE のクロス順序入れ替えを検出（expectedSequence 渡し）', () => {
+    // 元のドキュメント順: INLINE_0 → BLOCK_0
+    // LLM が反転: BLOCK_0 → INLINE_0
+    const md = 'use `foo`\n\n```\nA\n```\n';
+    const { codeBlocks, inlineCodes, placeholderSequence } = extractCode(md);
+    // template を意図的に反転させる
+    const swappedTemplate = '⟨⟨BLOCK_0⟩⟩\n\nuse ⟨⟨INLINE_0⟩⟩\n';
+    assert.throws(
+      () => restoreCode(swappedTemplate, codeBlocks, inlineCodes, placeholderSequence),
+      /placeholder order mismatch/i,
+    );
+  });
+
+  test('expectedSequence 通りの順序なら restoreCode 成功', () => {
+    const md = 'use `foo`\n\n```\nA\n```\n';
+    const extracted = extractCode(md);
+    const restored = restoreCode(
+      extracted.template,
+      extracted.codeBlocks,
+      extracted.inlineCodes,
+      extracted.placeholderSequence,
+    );
+    assert.equal(restored, md);
+  });
+
   test('プレースホルダが重複していたら throw（LLM が duplicate した場合の検知）', () => {
     // テンプレート内で ⟨⟨BLOCK_0⟩⟩ が 2 回出現 → コード重複挿入のリスク
     const template = '⟨⟨BLOCK_0⟩⟩\n\n再掲: ⟨⟨BLOCK_0⟩⟩';

--- a/tools/auto-translate/code-extractor.spec.ts
+++ b/tools/auto-translate/code-extractor.spec.ts
@@ -62,20 +62,34 @@ describe('extractCode', () => {
     assert.equal(codeBlocks[0], '```html\n<img src="x” />\n```');
   });
 
-  test('blockquote 内のコードブロックでも round-trip 可能', () => {
-    // 既存コードを引用しながら解説するパターン
+  test('blockquote 内のコードブロックは抽出対象外（template にそのまま残る、round-trip OK）', () => {
+    // remark は blockquote 内 code の position を `> ` プレフィックス混在の範囲として返すため、
+    // プレースホルダ化すると下流の translateCodeBlock の fence 検証が壊れて silent failure になる。
+    // よって code-extractor は blockquote 内 code を抽出対象外にし、template に残して LLM の prose 翻訳に委ねる
     const md = '前置き\n\n> ```ts\n> const x = 1;\n> ```\n\n後置き\n';
     const { template, codeBlocks, inlineCodes } = extractCode(md);
-    // 抽出されたら復元で元に戻ることを確認（remark が blockquote 内の code を扱えるかに依存）
-    const restored = restoreCode(template, codeBlocks, inlineCodes);
-    assert.equal(restored, md);
+    assert.equal(codeBlocks.length, 0);
+    assert.equal(inlineCodes.length, 0);
+    assert.equal(template, md);
+    // 念のため round-trip も確認
+    assert.equal(restoreCode(template, codeBlocks, inlineCodes), md);
   });
 
-  test('blockquote 内のインラインコードでも round-trip 可能', () => {
+  test('blockquote 内のインラインコードも抽出対象外', () => {
     const md = '> 引用文中の `foo` という識別子\n';
     const { template, codeBlocks, inlineCodes } = extractCode(md);
-    const restored = restoreCode(template, codeBlocks, inlineCodes);
-    assert.equal(restored, md);
+    assert.equal(codeBlocks.length, 0);
+    assert.equal(inlineCodes.length, 0);
+    assert.equal(template, md);
+  });
+
+  test('blockquote 外の code と blockquote 内 code が混在 → 外側のみ抽出される', () => {
+    const md = '```ts\nconst a = 1;\n```\n\n> ```ts\n> const b = 2;\n> ```\n';
+    const { template, codeBlocks } = extractCode(md);
+    assert.equal(codeBlocks.length, 1);
+    assert.equal(codeBlocks[0], '```ts\nconst a = 1;\n```');
+    // template に blockquote 内のコードはそのまま残る
+    assert.match(template, /> ```ts\n> const b = 2;\n> ```/);
   });
 });
 

--- a/tools/auto-translate/code-extractor.spec.ts
+++ b/tools/auto-translate/code-extractor.spec.ts
@@ -149,6 +149,12 @@ describe('restoreCode', () => {
     assert.throws(() => restoreCode(template, [], ['`a`']), /placeholder/i);
   });
 
+  test('プレースホルダの順序が入れ替わっていたら throw（LLM が swap した場合の検知）', () => {
+    // template 内で BLOCK_1 が BLOCK_0 より先に現れる順序入れ替えケース
+    const template = '前置き ⟨⟨BLOCK_1⟩⟩\n\n後置き ⟨⟨BLOCK_0⟩⟩';
+    assert.throws(() => restoreCode(template, ['```\nA\n```', '```\nB\n```'], []), /placeholder order mismatch/i);
+  });
+
   test('プレースホルダが重複していたら throw（LLM が duplicate した場合の検知）', () => {
     // テンプレート内で ⟨⟨BLOCK_0⟩⟩ が 2 回出現 → コード重複挿入のリスク
     const template = '⟨⟨BLOCK_0⟩⟩\n\n再掲: ⟨⟨BLOCK_0⟩⟩';

--- a/tools/auto-translate/code-extractor.spec.ts
+++ b/tools/auto-translate/code-extractor.spec.ts
@@ -93,6 +93,22 @@ describe('extractCode', () => {
     assert.equal(template, md);
   });
 
+  test('prose 中にプレースホルダ風文字列があっても衝突しない（escape による退避）', () => {
+    // このシステム自体を解説する記事を想定: prose 中で「⟨⟨BLOCK_0⟩⟩」を文字列として参照
+    const md = '解説: ⟨⟨BLOCK_0⟩⟩ という記法を使う。\n\n```ts\nconst x = 1;\n```\n';
+    const { template, codeBlocks, inlineCodes } = extractCode(md);
+    // template には実際のプレースホルダだけが exactly 1 回だけ出現する
+    assert.equal(codeBlocks.length, 1);
+    // round-trip で元に戻る
+    const restored = restoreCode(template, codeBlocks, inlineCodes);
+    assert.equal(restored, md);
+  });
+
+  test('escape 文字 ⟪⟪ または ⟫⟫ が markdown に既に含まれていたら throw（silent corruption 防止）', () => {
+    const mdWithReserved = 'text ⟪⟪ marker\n\n```\nfoo\n```\n';
+    assert.throws(() => extractCode(mdWithReserved), /reserved escape sequence/);
+  });
+
   test('blockquote 外の code と blockquote 内 code が混在 → 外側のみ抽出される', () => {
     const md = '```ts\nconst a = 1;\n```\n\n> ```ts\n> const b = 2;\n> ```\n';
     const { template, codeBlocks } = extractCode(md);

--- a/tools/auto-translate/code-extractor.ts
+++ b/tools/auto-translate/code-extractor.ts
@@ -13,6 +13,28 @@ const BLOCK_PLACEHOLDER = (i: number) => `⟨⟨BLOCK_${i}⟩⟩`;
 const INLINE_PLACEHOLDER = (i: number) => `⟨⟨INLINE_${i}⟩⟩`;
 const PLACEHOLDER_PATTERN = /⟨⟨(BLOCK|INLINE)_(\d+)⟩⟩/g;
 
+// prose 中に文字列として ⟨⟨ や ⟩⟩ が現れる場合（このシステム自体を解説する記事等）に、
+// extractCode が生成するプレースホルダと衝突しないよう一旦別文字に escape する。
+// 復元はちょうど逆順に: restoreCode 内で escape を解いて元の文字列に戻す。
+// U+27EA / U+27EB（mathematical double angle brackets）を使う: ⟨ U+27E8 と類似だが別 codepoint
+const ESCAPED_OPEN = '⟪⟪'; // ⟪⟪
+const ESCAPED_CLOSE = '⟫⟫'; // ⟫⟫
+
+function escapeBareMarkers(s: string): string {
+  // escape 文字も markdown に既に存在すると unescape で誤戻しするため、衝突時は throw する。
+  // ⟪⟪ や ⟫⟫ は極稀なので実害はほぼないが、明示的に失敗させて silent corruption を防ぐ
+  if (s.includes(ESCAPED_OPEN) || s.includes(ESCAPED_CLOSE)) {
+    throw new Error(
+      `Source contains reserved escape sequence (${ESCAPED_OPEN} or ${ESCAPED_CLOSE}); cannot extract code safely`,
+    );
+  }
+  return s.split('⟨⟨').join(ESCAPED_OPEN).split('⟩⟩').join(ESCAPED_CLOSE);
+}
+
+function unescapeBareMarkers(s: string): string {
+  return s.split(ESCAPED_OPEN).join('⟨⟨').split(ESCAPED_CLOSE).join('⟩⟩');
+}
+
 export interface ExtractedCode {
   /** プレースホルダで code を置換した markdown。LLM にはこれを渡す */
   template: string;
@@ -30,7 +52,11 @@ function hasBlockquoteAncestor(ancestors: readonly Parent[]): boolean {
 }
 
 export function extractCode(markdown: string): ExtractedCode {
-  const tree = remarkProcessor.parse(markdown);
+  // markdown 全体の ⟨⟨ ⟩⟩ を別文字に escape してからパース。
+  // これによりプレースホルダ ⟨⟨BLOCK_N⟩⟩ と prose 中の同名文字列の衝突を回避する。
+  // 文字置換は同じ文字数（BMP 内 1 unit → 1 unit）なので mdast の position offset は変わらない
+  const escapedMarkdown = escapeBareMarkers(markdown);
+  const tree = remarkProcessor.parse(escapedMarkdown);
   const replacements: { start: number; end: number; replacement: string }[] = [];
   const codeBlocks: string[] = [];
   const inlineCodes: string[] = [];
@@ -45,18 +71,19 @@ export function extractCode(markdown: string): ExtractedCode {
 
     if (node.type === 'code') {
       const idx = codeBlocks.length;
-      codeBlocks.push(markdown.slice(start, end));
+      // codeBlocks には escape された状態で保持。restoreCode の最後で全体を unescape する
+      codeBlocks.push(escapedMarkdown.slice(start, end));
       replacements.push({ start, end, replacement: BLOCK_PLACEHOLDER(idx) });
     } else if (node.type === 'inlineCode') {
       const idx = inlineCodes.length;
-      inlineCodes.push(markdown.slice(start, end));
+      inlineCodes.push(escapedMarkdown.slice(start, end));
       replacements.push({ start, end, replacement: INLINE_PLACEHOLDER(idx) });
     }
   });
 
   // 右から左へ置換することでオフセットがズレないようにする
   replacements.sort((a, b) => b.start - a.start);
-  let template = markdown;
+  let template = escapedMarkdown;
   for (const r of replacements) {
     template = template.slice(0, r.start) + r.replacement + template.slice(r.end);
   }
@@ -97,7 +124,7 @@ export function restoreCode(template: string, codeBlocks: string[], inlineCodes:
 
   // テンプレート内のプレースホルダを順序通りに置換。
   // String#replace のコールバック形式を使い、$ を含む code が special replacement として誤解釈されないようにする
-  return template.replace(PLACEHOLDER_PATTERN, (_match, kind: string, idxStr: string) => {
+  const restored = template.replace(PLACEHOLDER_PATTERN, (_match, kind: string, idxStr: string) => {
     const idx = Number(idxStr);
     if (kind === 'BLOCK') {
       if (idx >= codeBlocks.length) {
@@ -111,4 +138,7 @@ export function restoreCode(template: string, codeBlocks: string[], inlineCodes:
     }
     return inlineCodes[idx];
   });
+
+  // extractCode で escape した ⟪⟪ ⟫⟫ を元の ⟨⟨ ⟩⟩ に戻す（prose 中・code 内容両方に適用）
+  return unescapeBareMarkers(restored);
 }

--- a/tools/auto-translate/code-extractor.ts
+++ b/tools/auto-translate/code-extractor.ts
@@ -38,6 +38,11 @@ function unescapeBareMarkers(s: string): string {
   return s.split(ESCAPED_OPEN).join('⟨⟨').split(ESCAPED_CLOSE).join('⟩⟩');
 }
 
+export interface PlaceholderRef {
+  kind: 'BLOCK' | 'INLINE';
+  idx: number;
+}
+
 export interface ExtractedCode {
   /**
    * プレースホルダで code を置換した markdown。LLM にはこれを渡す。
@@ -56,6 +61,11 @@ export interface ExtractedCode {
    * codeBlocks と同様に escape 処理済みのテキストである点に注意
    */
   inlineCodes: string[];
+  /**
+   * BLOCK と INLINE の出現順序（ドキュメント順、左→右）。
+   * restoreCode の検証で「LLM が BLOCK と INLINE のクロス順序を入れ替えた」を検出するために使う
+   */
+  placeholderSequence: PlaceholderRef[];
 }
 
 // 注意: blockquote 内の code/inlineCode は markdown.slice() が "> " プレフィックス混在の文字列を返すため、
@@ -70,6 +80,8 @@ export function extractCode(markdown: string): ExtractedCode {
   const replacements: { start: number; end: number; replacement: string }[] = [];
   const codeBlocks: string[] = [];
   const inlineCodes: string[] = [];
+  // ドキュメント順（visit 順 = 左→右出現順）の placeholder 列。クロス型の順序検証に使う
+  const placeholderSequence: PlaceholderRef[] = [];
 
   visitParents(tree, (node: Node, ancestors: Parent[]) => {
     const pos = node.position;
@@ -84,10 +96,12 @@ export function extractCode(markdown: string): ExtractedCode {
       // codeBlocks には escape された状態で保持。restoreCode の最後で全体を unescape する
       codeBlocks.push(escapedMarkdown.slice(start, end));
       replacements.push({ start, end, replacement: BLOCK_PLACEHOLDER(idx) });
+      placeholderSequence.push({ kind: 'BLOCK', idx });
     } else if (node.type === 'inlineCode') {
       const idx = inlineCodes.length;
       inlineCodes.push(escapedMarkdown.slice(start, end));
       replacements.push({ start, end, replacement: INLINE_PLACEHOLDER(idx) });
+      placeholderSequence.push({ kind: 'INLINE', idx });
     }
   });
 
@@ -97,7 +111,7 @@ export function extractCode(markdown: string): ExtractedCode {
   for (const r of replacements) {
     template = template.slice(0, r.start) + r.replacement + template.slice(r.end);
   }
-  return { template, codeBlocks, inlineCodes };
+  return { template, codeBlocks, inlineCodes, placeholderSequence };
 }
 
 function countOccurrences(haystack: string, needle: string): number {
@@ -105,39 +119,50 @@ function countOccurrences(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1;
 }
 
-// テンプレート内のプレースホルダが extractCode で付与した番号順（0, 1, 2, ...）通りに
-// 左→右で並んでいることを検証する。LLM がブロック順序を入れ替えた場合に検出する
-// （順序入れ替えは記事の意味的構造を壊すため拒否する）
-function validatePlaceholderOrder(template: string): { ok: boolean; reason?: string } {
+// テンプレート内のプレースホルダ列が expected（extractCode の visit 順、ドキュメント順）と
+// 完全一致することを検証する。BLOCK 同士・INLINE 同士の番号順だけでなく、
+// BLOCK と INLINE のクロス順序入れ替えも検出する。
+// 順序入れ替えは記事の意味的構造を壊すため拒否する
+function validatePlaceholderOrder(
+  template: string,
+  expected: readonly PlaceholderRef[],
+): { ok: boolean; reason?: string } {
   const re = new RegExp(PLACEHOLDER_PATTERN_SOURCE, 'g');
-  let blockExpected = 0;
-  let inlineExpected = 0;
+  let i = 0;
   let m: RegExpExecArray | null;
   while ((m = re.exec(template)) !== null) {
-    const kind = m[1];
-    const idx = parseInt(m[2], 10);
-    if (kind === 'BLOCK') {
-      if (idx !== blockExpected) {
-        return {
-          ok: false,
-          reason: `placeholder order mismatch: expected ⟨⟨BLOCK_${blockExpected}⟩⟩ but found ⟨⟨BLOCK_${idx}⟩⟩ (LLM may have swapped block order)`,
-        };
-      }
-      blockExpected++;
-    } else {
-      if (idx !== inlineExpected) {
-        return {
-          ok: false,
-          reason: `placeholder order mismatch: expected ⟨⟨INLINE_${inlineExpected}⟩⟩ but found ⟨⟨INLINE_${idx}⟩⟩ (LLM may have swapped inline order)`,
-        };
-      }
-      inlineExpected++;
+    if (i >= expected.length) {
+      return {
+        ok: false,
+        reason: `placeholder order mismatch: extra placeholder ⟨⟨${m[1]}_${m[2]}⟩⟩ at position ${i} (expected ${expected.length} placeholders total)`,
+      };
     }
+    const kind = m[1] as 'BLOCK' | 'INLINE';
+    const idx = parseInt(m[2], 10);
+    const want = expected[i];
+    if (kind !== want.kind || idx !== want.idx) {
+      return {
+        ok: false,
+        reason: `placeholder order mismatch at position ${i}: expected ⟨⟨${want.kind}_${want.idx}⟩⟩ but found ⟨⟨${kind}_${idx}⟩⟩ (LLM may have swapped placeholder order)`,
+      };
+    }
+    i++;
+  }
+  if (i < expected.length) {
+    return {
+      ok: false,
+      reason: `placeholder order mismatch: missing ${expected.length - i} placeholders at the end (expected total ${expected.length}, got ${i})`,
+    };
   }
   return { ok: true };
 }
 
-export function restoreCode(template: string, codeBlocks: string[], inlineCodes: string[]): string {
+export function restoreCode(
+  template: string,
+  codeBlocks: string[],
+  inlineCodes: string[],
+  expectedSequence?: readonly PlaceholderRef[],
+): string {
   // テンプレート側で各プレースホルダが exactly 1 回現れることを検証する。
   // - 0 回 = LLM が drop した
   // - 2 回以上 = LLM が重複させた（同じ code が複数箇所に挿入されてしまう）
@@ -164,10 +189,38 @@ export function restoreCode(template: string, codeBlocks: string[], inlineCodes:
     }
   }
 
-  // 順序検証: ⟨⟨BLOCK_0⟩⟩ → ⟨⟨BLOCK_1⟩⟩ → ... の昇順で並んでいるべき（LLM の swap 検出）
-  const order = validatePlaceholderOrder(template);
-  if (!order.ok) {
-    throw new Error(`Restore failed: ${order.reason ?? 'placeholder order invalid'}`);
+  // 順序検証: expectedSequence が渡されればドキュメント順との完全一致を検証（クロス型入れ替えも検出）。
+  // 渡されない場合は BLOCK 同士・INLINE 同士の番号昇順のみ検証（後方互換）
+  if (expectedSequence !== undefined) {
+    const order = validatePlaceholderOrder(template, expectedSequence);
+    if (!order.ok) {
+      throw new Error(`Restore failed: ${order.reason ?? 'placeholder order invalid'}`);
+    }
+  } else {
+    // legacy: BLOCK と INLINE をそれぞれ独立に番号昇順チェック
+    const re = new RegExp(PLACEHOLDER_PATTERN_SOURCE, 'g');
+    let blockExpected = 0;
+    let inlineExpected = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(template)) !== null) {
+      const kind = m[1];
+      const idx = parseInt(m[2], 10);
+      if (kind === 'BLOCK') {
+        if (idx !== blockExpected) {
+          throw new Error(
+            `Restore failed: placeholder order mismatch: expected ⟨⟨BLOCK_${blockExpected}⟩⟩ but found ⟨⟨BLOCK_${idx}⟩⟩`,
+          );
+        }
+        blockExpected++;
+      } else {
+        if (idx !== inlineExpected) {
+          throw new Error(
+            `Restore failed: placeholder order mismatch: expected ⟨⟨INLINE_${inlineExpected}⟩⟩ but found ⟨⟨INLINE_${idx}⟩⟩`,
+          );
+        }
+        inlineExpected++;
+      }
+    }
   }
 
   // テンプレート内のプレースホルダを順序通りに置換。

--- a/tools/auto-translate/code-extractor.ts
+++ b/tools/auto-translate/code-extractor.ts
@@ -105,6 +105,38 @@ function countOccurrences(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1;
 }
 
+// テンプレート内のプレースホルダが extractCode で付与した番号順（0, 1, 2, ...）通りに
+// 左→右で並んでいることを検証する。LLM がブロック順序を入れ替えた場合に検出する
+// （順序入れ替えは記事の意味的構造を壊すため拒否する）
+function validatePlaceholderOrder(template: string): { ok: boolean; reason?: string } {
+  const re = new RegExp(PLACEHOLDER_PATTERN_SOURCE, 'g');
+  let blockExpected = 0;
+  let inlineExpected = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(template)) !== null) {
+    const kind = m[1];
+    const idx = parseInt(m[2], 10);
+    if (kind === 'BLOCK') {
+      if (idx !== blockExpected) {
+        return {
+          ok: false,
+          reason: `placeholder order mismatch: expected ⟨⟨BLOCK_${blockExpected}⟩⟩ but found ⟨⟨BLOCK_${idx}⟩⟩ (LLM may have swapped block order)`,
+        };
+      }
+      blockExpected++;
+    } else {
+      if (idx !== inlineExpected) {
+        return {
+          ok: false,
+          reason: `placeholder order mismatch: expected ⟨⟨INLINE_${inlineExpected}⟩⟩ but found ⟨⟨INLINE_${idx}⟩⟩ (LLM may have swapped inline order)`,
+        };
+      }
+      inlineExpected++;
+    }
+  }
+  return { ok: true };
+}
+
 export function restoreCode(template: string, codeBlocks: string[], inlineCodes: string[]): string {
   // テンプレート側で各プレースホルダが exactly 1 回現れることを検証する。
   // - 0 回 = LLM が drop した
@@ -130,6 +162,12 @@ export function restoreCode(template: string, codeBlocks: string[], inlineCodes:
     if (n > 1) {
       throw new Error(`Restore failed: placeholder ${ph} appears ${n} times in template (LLM duplicated it?)`);
     }
+  }
+
+  // 順序検証: ⟨⟨BLOCK_0⟩⟩ → ⟨⟨BLOCK_1⟩⟩ → ... の昇順で並んでいるべき（LLM の swap 検出）
+  const order = validatePlaceholderOrder(template);
+  if (!order.ok) {
+    throw new Error(`Restore failed: ${order.reason ?? 'placeholder order invalid'}`);
   }
 
   // テンプレート内のプレースホルダを順序通りに置換。

--- a/tools/auto-translate/code-extractor.ts
+++ b/tools/auto-translate/code-extractor.ts
@@ -11,7 +11,9 @@ const remarkProcessor = remark().use(remarkGfm);
 
 const BLOCK_PLACEHOLDER = (i: number) => `⟨⟨BLOCK_${i}⟩⟩`;
 const INLINE_PLACEHOLDER = (i: number) => `⟨⟨INLINE_${i}⟩⟩`;
-const PLACEHOLDER_PATTERN = /⟨⟨(BLOCK|INLINE)_(\d+)⟩⟩/g;
+// g フラグ付きモジュール定数は exec() ループで lastIndex が残留する落とし穴があるため、
+// パターンは source 文字列で保持して使用箇所で new RegExp する
+const PLACEHOLDER_PATTERN_SOURCE = '⟨⟨(BLOCK|INLINE)_(\\d+)⟩⟩';
 
 // prose 中に文字列として ⟨⟨ や ⟩⟩ が現れる場合（このシステム自体を解説する記事等）に、
 // extractCode が生成するプレースホルダと衝突しないよう一旦別文字に escape する。
@@ -124,20 +126,27 @@ export function restoreCode(template: string, codeBlocks: string[], inlineCodes:
 
   // テンプレート内のプレースホルダを順序通りに置換。
   // String#replace のコールバック形式を使い、$ を含む code が special replacement として誤解釈されないようにする
-  const restored = template.replace(PLACEHOLDER_PATTERN, (_match, kind: string, idxStr: string) => {
-    const idx = Number(idxStr);
-    if (kind === 'BLOCK') {
-      if (idx >= codeBlocks.length) {
-        throw new Error(`Restore failed: placeholder ⟨⟨BLOCK_${idx}⟩⟩ has no corresponding code block (hallucinated?)`);
+  const restored = template.replace(
+    new RegExp(PLACEHOLDER_PATTERN_SOURCE, 'g'),
+    (_match, kind: string, idxStr: string) => {
+      const idx = Number(idxStr);
+      if (kind === 'BLOCK') {
+        if (idx >= codeBlocks.length) {
+          throw new Error(
+            `Restore failed: placeholder ⟨⟨BLOCK_${idx}⟩⟩ has no corresponding code block (hallucinated?)`,
+          );
+        }
+        return codeBlocks[idx];
       }
-      return codeBlocks[idx];
-    }
-    // INLINE
-    if (idx >= inlineCodes.length) {
-      throw new Error(`Restore failed: placeholder ⟨⟨INLINE_${idx}⟩⟩ has no corresponding inline code (hallucinated?)`);
-    }
-    return inlineCodes[idx];
-  });
+      // INLINE
+      if (idx >= inlineCodes.length) {
+        throw new Error(
+          `Restore failed: placeholder ⟨⟨INLINE_${idx}⟩⟩ has no corresponding inline code (hallucinated?)`,
+        );
+      }
+      return inlineCodes[idx];
+    },
+  );
 
   // extractCode で escape した ⟪⟪ ⟫⟫ を元の ⟨⟨ ⟩⟩ に戻す（prose 中・code 内容両方に適用）
   return unescapeBareMarkers(restored);

--- a/tools/auto-translate/code-extractor.ts
+++ b/tools/auto-translate/code-extractor.ts
@@ -39,11 +39,22 @@ function unescapeBareMarkers(s: string): string {
 }
 
 export interface ExtractedCode {
-  /** プレースホルダで code を置換した markdown。LLM にはこれを渡す */
+  /**
+   * プレースホルダで code を置換した markdown。LLM にはこれを渡す。
+   * markdown 全体は ⟨⟨/⟩⟩ → ⟪⟪/⟫⟫ に escape 済みなので、生 prose にも escape が含まれる
+   */
   template: string;
-  /** コードブロックの元テキスト（fence 含む完全な形）を順序通りに保持 */
+  /**
+   * コードブロックのテキスト（fence 含む完全な形）を順序通りに保持。
+   * extractCode 時点で markdown 全体を escape 済みのため、code 内に元 ⟨⟨/⟩⟩ があると ⟪⟪/⟫⟫ として保持される。
+   * 復元（元 ⟨⟨/⟩⟩ への変換）は restoreCode の末尾で行われるため、外部利用時はこの値を「元テキスト」として
+   * 直接使わないこと
+   */
   codeBlocks: string[];
-  /** インラインコードの元テキスト（バッククォート含む）を順序通りに保持 */
+  /**
+   * インラインコードのテキスト（バッククォート含む）を順序通りに保持。
+   * codeBlocks と同様に escape 処理済みのテキストである点に注意
+   */
   inlineCodes: string[];
 }
 

--- a/tools/auto-translate/code-extractor.ts
+++ b/tools/auto-translate/code-extractor.ts
@@ -4,7 +4,8 @@
 
 import { remark } from 'remark';
 import remarkGfm from 'remark-gfm';
-import { visit } from 'unist-util-visit';
+import type { Node, Parent } from 'unist';
+import { visitParents } from 'unist-util-visit-parents';
 
 const remarkProcessor = remark().use(remarkGfm);
 
@@ -21,18 +22,26 @@ export interface ExtractedCode {
   inlineCodes: string[];
 }
 
+// blockquote 内の code/inlineCode は markdown.slice() が `> ` プレフィックス混在の文字列を返すため、
+// プレースホルダ化すると translateCodeBlock 側の fence 検証が壊れる（silent failure を起こす）。
+// 抽出対象外として template に残し、LLM の prose 翻訳に委ねる
+function hasBlockquoteAncestor(ancestors: readonly Parent[]): boolean {
+  return ancestors.some((a) => a.type === 'blockquote');
+}
+
 export function extractCode(markdown: string): ExtractedCode {
   const tree = remarkProcessor.parse(markdown);
   const replacements: { start: number; end: number; replacement: string }[] = [];
   const codeBlocks: string[] = [];
   const inlineCodes: string[] = [];
 
-  visit(tree, (node) => {
+  visitParents(tree, (node: Node, ancestors: Parent[]) => {
     const pos = node.position;
     if (pos == null) return;
     const start = pos.start.offset;
     const end = pos.end.offset;
     if (start == null || end == null) return;
+    if (hasBlockquoteAncestor(ancestors)) return;
 
     if (node.type === 'code') {
       const idx = codeBlocks.length;

--- a/tools/auto-translate/code-extractor.ts
+++ b/tools/auto-translate/code-extractor.ts
@@ -6,6 +6,7 @@ import { remark } from 'remark';
 import remarkGfm from 'remark-gfm';
 import type { Node, Parent } from 'unist';
 import { visitParents } from 'unist-util-visit-parents';
+import { hasBlockquoteAncestor } from './ast-utils.ts';
 
 const remarkProcessor = remark().use(remarkGfm);
 
@@ -46,13 +47,9 @@ export interface ExtractedCode {
   inlineCodes: string[];
 }
 
-// blockquote 内の code/inlineCode は markdown.slice() が `> ` プレフィックス混在の文字列を返すため、
+// 注意: blockquote 内の code/inlineCode は markdown.slice() が "> " プレフィックス混在の文字列を返すため、
 // プレースホルダ化すると translateCodeBlock 側の fence 検証が壊れる（silent failure を起こす）。
-// 抽出対象外として template に残し、LLM の prose 翻訳に委ねる
-function hasBlockquoteAncestor(ancestors: readonly Parent[]): boolean {
-  return ancestors.some((a) => a.type === 'blockquote');
-}
-
+// 抽出対象外として template に残し、LLM の prose 翻訳に委ねる（hasBlockquoteAncestor は ast-utils.ts 経由で共有）
 export function extractCode(markdown: string): ExtractedCode {
   // markdown 全体の ⟨⟨ ⟩⟩ を別文字に escape してからパース。
   // これによりプレースホルダ ⟨⟨BLOCK_N⟩⟩ と prose 中の同名文字列の衝突を回避する。

--- a/tools/auto-translate/code-extractor.ts
+++ b/tools/auto-translate/code-extractor.ts
@@ -1,0 +1,96 @@
+// LLM に code を見せず prose だけ翻訳させるための extractor / restorer。
+// LLM に code byte-fidelity を要求するのは無理筋なので、コードを抽出してプレースホルダ ⟨⟨BLOCK_N⟩⟩ /
+// ⟨⟨INLINE_N⟩⟩ に置換し、翻訳後にプログラムで復元する。これにより code は LLM を経由しない。
+
+import { remark } from 'remark';
+import remarkGfm from 'remark-gfm';
+import { visit } from 'unist-util-visit';
+
+const remarkProcessor = remark().use(remarkGfm);
+
+const BLOCK_PLACEHOLDER = (i: number) => `⟨⟨BLOCK_${i}⟩⟩`;
+const INLINE_PLACEHOLDER = (i: number) => `⟨⟨INLINE_${i}⟩⟩`;
+const PLACEHOLDER_PATTERN = /⟨⟨(BLOCK|INLINE)_(\d+)⟩⟩/g;
+
+export interface ExtractedCode {
+  /** プレースホルダで code を置換した markdown。LLM にはこれを渡す */
+  template: string;
+  /** コードブロックの元テキスト（fence 含む完全な形）を順序通りに保持 */
+  codeBlocks: string[];
+  /** インラインコードの元テキスト（バッククォート含む）を順序通りに保持 */
+  inlineCodes: string[];
+}
+
+export function extractCode(markdown: string): ExtractedCode {
+  const tree = remarkProcessor.parse(markdown);
+  const replacements: { start: number; end: number; replacement: string }[] = [];
+  const codeBlocks: string[] = [];
+  const inlineCodes: string[] = [];
+
+  visit(tree, (node) => {
+    const pos = node.position;
+    if (pos == null) return;
+    const start = pos.start.offset;
+    const end = pos.end.offset;
+    if (start == null || end == null) return;
+
+    if (node.type === 'code') {
+      const idx = codeBlocks.length;
+      codeBlocks.push(markdown.slice(start, end));
+      replacements.push({ start, end, replacement: BLOCK_PLACEHOLDER(idx) });
+    } else if (node.type === 'inlineCode') {
+      const idx = inlineCodes.length;
+      inlineCodes.push(markdown.slice(start, end));
+      replacements.push({ start, end, replacement: INLINE_PLACEHOLDER(idx) });
+    }
+  });
+
+  // 右から左へ置換することでオフセットがズレないようにする
+  replacements.sort((a, b) => b.start - a.start);
+  let template = markdown;
+  for (const r of replacements) {
+    template = template.slice(0, r.start) + r.replacement + template.slice(r.end);
+  }
+  return { template, codeBlocks, inlineCodes };
+}
+
+export function restoreCode(template: string, codeBlocks: string[], inlineCodes: string[]): string {
+  // テンプレート内のプレースホルダを順序通りに置換。
+  // String#replace のコールバック形式を使い、$ を含む code が special replacement として誤解釈されないようにする
+  const result = template.replace(PLACEHOLDER_PATTERN, (_match, kind: string, idxStr: string) => {
+    const idx = Number(idxStr);
+    if (kind === 'BLOCK') {
+      if (idx >= codeBlocks.length) {
+        throw new Error(`Restore failed: placeholder ⟨⟨BLOCK_${idx}⟩⟩ has no corresponding code block`);
+      }
+      return codeBlocks[idx];
+    }
+    // INLINE
+    if (idx >= inlineCodes.length) {
+      throw new Error(`Restore failed: placeholder ⟨⟨INLINE_${idx}⟩⟩ has no corresponding inline code`);
+    }
+    return inlineCodes[idx];
+  });
+
+  // restored 後にまだプレースホルダが残っていたら何かおかしい（unexpected pattern）
+  if (PLACEHOLDER_PATTERN.test(result)) {
+    PLACEHOLDER_PATTERN.lastIndex = 0;
+    throw new Error(`Restore failed: placeholder pattern remains after restoration`);
+  }
+  PLACEHOLDER_PATTERN.lastIndex = 0;
+
+  // テンプレートに含まれていなかったプレースホルダ index があれば、LLM が drop した可能性
+  // （上の置換でカウント済みなので余り index がないか検証）
+  for (let i = 0; i < codeBlocks.length; i++) {
+    if (template.indexOf(BLOCK_PLACEHOLDER(i)) === -1) {
+      throw new Error(`Restore failed: placeholder ⟨⟨BLOCK_${i}⟩⟩ missing from template (LLM dropped it?)`);
+    }
+  }
+  for (let i = 0; i < inlineCodes.length; i++) {
+    if (template.indexOf(INLINE_PLACEHOLDER(i)) === -1) {
+      throw new Error(`Restore failed: placeholder ⟨⟨INLINE_${i}⟩⟩ missing from template (LLM dropped it?)`);
+    }
+  }
+
+  return result;
+}

--- a/tools/auto-translate/code-extractor.ts
+++ b/tools/auto-translate/code-extractor.ts
@@ -54,43 +54,52 @@ export function extractCode(markdown: string): ExtractedCode {
   return { template, codeBlocks, inlineCodes };
 }
 
+function countOccurrences(haystack: string, needle: string): number {
+  if (needle.length === 0) return 0;
+  return haystack.split(needle).length - 1;
+}
+
 export function restoreCode(template: string, codeBlocks: string[], inlineCodes: string[]): string {
+  // テンプレート側で各プレースホルダが exactly 1 回現れることを検証する。
+  // - 0 回 = LLM が drop した
+  // - 2 回以上 = LLM が重複させた（同じ code が複数箇所に挿入されてしまう）
+  // 復元後の result でプレースホルダパターンを検査するのは誤り: codeBlocks[i] の内容自体が
+  // ⟨⟨BLOCK_N⟩⟩ のような文字列を含む可能性がある（このシステムを解説する記事等）
+  for (let i = 0; i < codeBlocks.length; i++) {
+    const ph = BLOCK_PLACEHOLDER(i);
+    const n = countOccurrences(template, ph);
+    if (n === 0) {
+      throw new Error(`Restore failed: placeholder ${ph} missing from template (LLM dropped it?)`);
+    }
+    if (n > 1) {
+      throw new Error(`Restore failed: placeholder ${ph} appears ${n} times in template (LLM duplicated it?)`);
+    }
+  }
+  for (let i = 0; i < inlineCodes.length; i++) {
+    const ph = INLINE_PLACEHOLDER(i);
+    const n = countOccurrences(template, ph);
+    if (n === 0) {
+      throw new Error(`Restore failed: placeholder ${ph} missing from template (LLM dropped it?)`);
+    }
+    if (n > 1) {
+      throw new Error(`Restore failed: placeholder ${ph} appears ${n} times in template (LLM duplicated it?)`);
+    }
+  }
+
   // テンプレート内のプレースホルダを順序通りに置換。
   // String#replace のコールバック形式を使い、$ を含む code が special replacement として誤解釈されないようにする
-  const result = template.replace(PLACEHOLDER_PATTERN, (_match, kind: string, idxStr: string) => {
+  return template.replace(PLACEHOLDER_PATTERN, (_match, kind: string, idxStr: string) => {
     const idx = Number(idxStr);
     if (kind === 'BLOCK') {
       if (idx >= codeBlocks.length) {
-        throw new Error(`Restore failed: placeholder ⟨⟨BLOCK_${idx}⟩⟩ has no corresponding code block`);
+        throw new Error(`Restore failed: placeholder ⟨⟨BLOCK_${idx}⟩⟩ has no corresponding code block (hallucinated?)`);
       }
       return codeBlocks[idx];
     }
     // INLINE
     if (idx >= inlineCodes.length) {
-      throw new Error(`Restore failed: placeholder ⟨⟨INLINE_${idx}⟩⟩ has no corresponding inline code`);
+      throw new Error(`Restore failed: placeholder ⟨⟨INLINE_${idx}⟩⟩ has no corresponding inline code (hallucinated?)`);
     }
     return inlineCodes[idx];
   });
-
-  // restored 後にまだプレースホルダが残っていたら何かおかしい（unexpected pattern）
-  if (PLACEHOLDER_PATTERN.test(result)) {
-    PLACEHOLDER_PATTERN.lastIndex = 0;
-    throw new Error(`Restore failed: placeholder pattern remains after restoration`);
-  }
-  PLACEHOLDER_PATTERN.lastIndex = 0;
-
-  // テンプレートに含まれていなかったプレースホルダ index があれば、LLM が drop した可能性
-  // （上の置換でカウント済みなので余り index がないか検証）
-  for (let i = 0; i < codeBlocks.length; i++) {
-    if (template.indexOf(BLOCK_PLACEHOLDER(i)) === -1) {
-      throw new Error(`Restore failed: placeholder ⟨⟨BLOCK_${i}⟩⟩ missing from template (LLM dropped it?)`);
-    }
-  }
-  for (let i = 0; i < inlineCodes.length; i++) {
-    if (template.indexOf(INLINE_PLACEHOLDER(i)) === -1) {
-      throw new Error(`Restore failed: placeholder ⟨⟨INLINE_${i}⟩⟩ missing from template (LLM dropped it?)`);
-    }
-  }
-
-  return result;
 }

--- a/tools/auto-translate/code-extractor.ts
+++ b/tools/auto-translate/code-extractor.ts
@@ -129,7 +129,10 @@ export function restoreCode(template: string, codeBlocks: string[], inlineCodes:
   const restored = template.replace(
     new RegExp(PLACEHOLDER_PATTERN_SOURCE, 'g'),
     (_match, kind: string, idxStr: string) => {
-      const idx = Number(idxStr);
+      const idx = parseInt(idxStr, 10);
+      if (!Number.isInteger(idx) || idx < 0) {
+        throw new Error(`Restore failed: invalid placeholder index "${idxStr}"`);
+      }
       if (kind === 'BLOCK') {
         if (idx >= codeBlocks.length) {
           throw new Error(

--- a/tools/auto-translate/code-translator.spec.ts
+++ b/tools/auto-translate/code-translator.spec.ts
@@ -130,6 +130,23 @@ describe('translateCodeBlock', () => {
     assert.equal(result, original);
   });
 
+  test('LLM がコメント以外（識別子）を改変した場合は原文に fallback', async () => {
+    // 行数・fence・言語タグは保たれるが、識別子 foo → bar に変更
+    const original = '```ts\n// 元コメント\nconst foo = 1;\n```';
+    const tampered = '```ts\n// translated\nconst bar = 1;\n```';
+    const client: CodeTranslatorClient = mock.fn(() => Promise.resolve(tampered));
+    const result = await translateCodeBlock({ code: original, client, model: MODEL });
+    assert.equal(result, original);
+  });
+
+  test('LLM が文字列リテラルを改変した場合は原文に fallback', async () => {
+    const original = '```ts\n// 元コメント\nconst x = "hello";\n```';
+    const tampered = '```ts\n// translated\nconst x = "world";\n```';
+    const client: CodeTranslatorClient = mock.fn(() => Promise.resolve(tampered));
+    const result = await translateCodeBlock({ code: original, client, model: MODEL });
+    assert.equal(result, original);
+  });
+
   test('リスト項目内のインデント付きコードブロックでも fence intact 判定が動作する', async () => {
     // remark は list item 内コードの position offset でインデント先頭から始まる範囲を返すため、
     // markdown.slice() の結果は各行の先頭が "  ```ts" のようなインデント付きになる。

--- a/tools/auto-translate/code-translator.spec.ts
+++ b/tools/auto-translate/code-translator.spec.ts
@@ -1,0 +1,83 @@
+import { strict as assert } from 'node:assert';
+import { test, describe, mock } from 'node:test';
+import { translateCodeBlock, hasTranslatableComment, type CodeTranslatorClient } from './code-translator.ts';
+
+const MODEL = 'test-model';
+
+describe('hasTranslatableComment', () => {
+  test('// 行コメント検出', () => {
+    assert.equal(hasTranslatableComment('```ts\n// 注釈\nconst x = 1;\n```'), true);
+  });
+
+  test('# 行コメント検出', () => {
+    assert.equal(hasTranslatableComment('```python\n# 説明\nx = 1\n```'), true);
+  });
+
+  test('/* ... */ ブロックコメント検出', () => {
+    assert.equal(hasTranslatableComment('```ts\n/* 説明 */\nconst x = 1;\n```'), true);
+  });
+
+  test('<!-- ... --> HTML コメント検出', () => {
+    assert.equal(hasTranslatableComment('```html\n<!-- 説明 -->\n<div></div>\n```'), true);
+  });
+
+  test('コメントなし → false', () => {
+    assert.equal(hasTranslatableComment('```ts\nconst x = 1;\n```'), false);
+  });
+
+  test('// だけで本文なし → false', () => {
+    assert.equal(hasTranslatableComment('```ts\n//\nconst x = 1;\n```'), false);
+  });
+
+  test('英数字のみのコメント → false（翻訳不要）', () => {
+    assert.equal(hasTranslatableComment('```ts\n// TODO\nconst x = 1;\n```'), false);
+  });
+
+  test('日本語コメント → true', () => {
+    assert.equal(hasTranslatableComment('```ts\n// これは日本語コメントです\n```'), true);
+  });
+});
+
+describe('translateCodeBlock', () => {
+  test('コメントなしブロック → API 呼ばずそのまま返す', async () => {
+    const code = '```ts\nconst x = 1;\n```';
+    const client: CodeTranslatorClient = mock.fn(() => Promise.resolve(code));
+    const result = await translateCodeBlock({ code, client, model: MODEL });
+    assert.equal(result, code);
+    assert.equal((client as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 0);
+  });
+
+  test('コメントあり + LLM が translated を返す → translated を採用', async () => {
+    const original = '```ts\n// 元のコメント\nconst x = 1;\n```';
+    const translated = '```ts\n// translated comment\nconst x = 1;\n```';
+    const client: CodeTranslatorClient = mock.fn(() => Promise.resolve(translated));
+    const result = await translateCodeBlock({ code: original, client, model: MODEL });
+    assert.equal(result, translated);
+    assert.equal((client as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 1);
+  });
+
+  test('LLM の出力が行数不一致 → 原文に fallback', async () => {
+    const original = '```ts\n// 元のコメント\nconst x = 1;\n```';
+    // LLM が行数を変えた（壊れた出力）
+    const broken = '```ts\nconst x = 1;\n```';
+    const client: CodeTranslatorClient = mock.fn(() => Promise.resolve(broken));
+    const result = await translateCodeBlock({ code: original, client, model: MODEL });
+    assert.equal(result, original);
+  });
+
+  test('LLM throw → 原文に fallback（fail-safe）', async () => {
+    const original = '```ts\n// 元のコメント\nconst x = 1;\n```';
+    const client: CodeTranslatorClient = mock.fn(() => Promise.reject(new Error('API error')));
+    const result = await translateCodeBlock({ code: original, client, model: MODEL });
+    assert.equal(result, original);
+  });
+
+  test('fence 構造（```ts ... ```）が壊れたら原文に fallback', async () => {
+    const original = '```ts\n// コメント\nconst x = 1;\n```';
+    // LLM が fence を壊した
+    const broken = '// コメント\nconst x = 1;\n';
+    const client: CodeTranslatorClient = mock.fn(() => Promise.resolve(broken));
+    const result = await translateCodeBlock({ code: original, client, model: MODEL });
+    assert.equal(result, original);
+  });
+});

--- a/tools/auto-translate/code-translator.spec.ts
+++ b/tools/auto-translate/code-translator.spec.ts
@@ -13,6 +13,14 @@ describe('hasTranslatableComment', () => {
     assert.equal(hasTranslatableComment('```python\n# 説明\nx = 1\n```'), true);
   });
 
+  test('# とコメント本文の間にスペースがなくても検出（#コメント スタイル）', () => {
+    assert.equal(hasTranslatableComment('```python\n#日本語コメント\nx = 1\n```'), true);
+  });
+
+  test('shebang 行 (#!) は翻訳対象として検出しない', () => {
+    assert.equal(hasTranslatableComment('```bash\n#!/usr/bin/env bash\necho hello\n```'), false);
+  });
+
   test('/* ... */ ブロックコメント検出', () => {
     assert.equal(hasTranslatableComment('```ts\n/* 説明 */\nconst x = 1;\n```'), true);
   });

--- a/tools/auto-translate/code-translator.spec.ts
+++ b/tools/auto-translate/code-translator.spec.ts
@@ -63,6 +63,19 @@ describe('hasTranslatableComment', () => {
     const code = '```ts\n/* multiline\n   日本語含む\n   comment */\nconst x = 1;\n```';
     assert.equal(hasTranslatableComment(code), true);
   });
+
+  test('URL 文字列リテラル内の // は誤検出しない', () => {
+    // `://` の // をコメントマーカーとして検出すると、URL パス内の非 ASCII 文字を
+    // 翻訳対象として API を呼んでしまう偽陽性が発生する
+    const code = '```ts\nconst url = "https://example.com/日本語";\n```';
+    assert.equal(hasTranslatableComment(code), false);
+  });
+
+  test('URL の後にコメントが続く場合は検出する', () => {
+    // 行末に // コメントが付く場合、URL の // と区別する必要がある
+    const code = '```ts\nconst url = "https://example.com"; // 日本語コメント\n```';
+    assert.equal(hasTranslatableComment(code), true);
+  });
 });
 
 describe('translateCodeBlock', () => {

--- a/tools/auto-translate/code-translator.spec.ts
+++ b/tools/auto-translate/code-translator.spec.ts
@@ -40,6 +40,21 @@ describe('hasTranslatableComment', () => {
   test('日本語コメント → true', () => {
     assert.equal(hasTranslatableComment('```ts\n// これは日本語コメントです\n```'), true);
   });
+
+  test('英文の複数行ブロックコメント /* ... */ → false（改行で誤検出しない）', () => {
+    const code = '```ts\n/* multiline\n   english only comment */\nconst x = 1;\n```';
+    assert.equal(hasTranslatableComment(code), false);
+  });
+
+  test('英文の複数行 HTML コメント <!-- ... --> → false', () => {
+    const code = '```html\n<!-- multi\n  line comment -->\n<div></div>\n```';
+    assert.equal(hasTranslatableComment(code), false);
+  });
+
+  test('日本語を含む複数行ブロックコメント → true', () => {
+    const code = '```ts\n/* multiline\n   日本語含む\n   comment */\nconst x = 1;\n```';
+    assert.equal(hasTranslatableComment(code), true);
+  });
 });
 
 describe('translateCodeBlock', () => {

--- a/tools/auto-translate/code-translator.spec.ts
+++ b/tools/auto-translate/code-translator.spec.ts
@@ -99,4 +99,13 @@ describe('translateCodeBlock', () => {
     const result = await translateCodeBlock({ code: original, client, model: MODEL });
     assert.equal(result, original);
   });
+
+  test('LLM が fence の言語タグを書き換えた場合は原文に fallback', async () => {
+    const original = '```ts\n// 日本語コメント\nconst x = 1;\n```';
+    // 言語タグが ts → javascript に変わった
+    const tampered = '```javascript\n// translated comment\nconst x = 1;\n```';
+    const client: CodeTranslatorClient = mock.fn(() => Promise.resolve(tampered));
+    const result = await translateCodeBlock({ code: original, client, model: MODEL });
+    assert.equal(result, original);
+  });
 });

--- a/tools/auto-translate/code-translator.spec.ts
+++ b/tools/auto-translate/code-translator.spec.ts
@@ -108,4 +108,13 @@ describe('translateCodeBlock', () => {
     const result = await translateCodeBlock({ code: original, client, model: MODEL });
     assert.equal(result, original);
   });
+
+  test('チルダフェンス (~~~) の翻訳でも fence intact 判定が正しく動作する', async () => {
+    const original = '~~~ts\n// 日本語コメント\nconst x = 1;\n~~~';
+    const translated = '~~~ts\n// translated comment\nconst x = 1;\n~~~';
+    const client: CodeTranslatorClient = mock.fn(() => Promise.resolve(translated));
+    const result = await translateCodeBlock({ code: original, client, model: MODEL });
+    // チルダフェンスもバッククォートフェンスと同等に扱われ、誤って原文 fallback しないこと
+    assert.equal(result, translated);
+  });
 });

--- a/tools/auto-translate/code-translator.spec.ts
+++ b/tools/auto-translate/code-translator.spec.ts
@@ -33,6 +33,10 @@ describe('hasTranslatableComment', () => {
     assert.equal(hasTranslatableComment('```ts\n// TODO\nconst x = 1;\n```'), false);
   });
 
+  test('英文コメントも → false（既に英語なので翻訳不要、API コスト削減）', () => {
+    assert.equal(hasTranslatableComment('```ts\n// returns the user object\nconst x = 1;\n```'), false);
+  });
+
   test('日本語コメント → true', () => {
     assert.equal(hasTranslatableComment('```ts\n// これは日本語コメントです\n```'), true);
   });

--- a/tools/auto-translate/code-translator.spec.ts
+++ b/tools/auto-translate/code-translator.spec.ts
@@ -130,6 +130,18 @@ describe('translateCodeBlock', () => {
     assert.equal(result, original);
   });
 
+  test('リスト項目内のインデント付きコードブロックでも fence intact 判定が動作する', async () => {
+    // remark は list item 内コードの position offset でインデント先頭から始まる範囲を返すため、
+    // markdown.slice() の結果は各行の先頭が "  ```ts" のようなインデント付きになる。
+    // fenceLines が空白を許容しないと isCodeFenceIntact が false → コメント翻訳がスキップされる
+    const original = '  ```ts\n  // 日本語コメント\n  const x = 1;\n  ```';
+    const translated = '  ```ts\n  // translated comment\n  const x = 1;\n  ```';
+    const client: CodeTranslatorClient = mock.fn(() => Promise.resolve(translated));
+    const result = await translateCodeBlock({ code: original, client, model: MODEL });
+    // 原文 fallback ではなく translated が採用されることを確認
+    assert.equal(result, translated);
+  });
+
   test('チルダフェンス (~~~) の翻訳でも fence intact 判定が正しく動作する', async () => {
     const original = '~~~ts\n// 日本語コメント\nconst x = 1;\n~~~';
     const translated = '~~~ts\n// translated comment\nconst x = 1;\n~~~';

--- a/tools/auto-translate/code-translator.ts
+++ b/tools/auto-translate/code-translator.ts
@@ -25,14 +25,16 @@ const COMMENT_PATTERNS: RegExp[] = [
 
 export function hasTranslatableComment(code: string): boolean {
   // 翻訳ターゲットは英語なので、既に英語のコメントは API を呼ばない（ノイズ・コスト削減）。
-  // 非 ASCII 文字（日本語等）を含むコメントだけを翻訳対象とする
+  // 非 ASCII 文字（日本語等）を含むコメントだけを翻訳対象とする。
+  // \s（\n, \r, \t 等）はホワイトスペースなので除外する: /* */ や <!-- --> の複数行コメントで
+  // m[1] に \n が混じるため、これを非 ASCII 扱いすると英語のみの複数行コメントを誤って翻訳対象にしてしまう
   for (const re of COMMENT_PATTERNS) {
     re.lastIndex = 0;
     let m: RegExpExecArray | null;
     while ((m = re.exec(code)) !== null) {
       const content = m[1].trim();
       if (content.length === 0) continue;
-      if (/[^\x20-\x7e]/.test(content)) return true;
+      if (/[^\x20-\x7e\s]/.test(content)) return true;
     }
   }
   return false;

--- a/tools/auto-translate/code-translator.ts
+++ b/tools/auto-translate/code-translator.ts
@@ -14,13 +14,15 @@ export interface TranslateCodeBlockArgs {
 
 // 翻訳対象になりうるコメントを含むかの簡易ヒューリスティック。
 // 言語非依存に「//」「#」「/* */」「<!-- -->」を検出。
-// 改行を跨いで誤検出しないよう、行コメントは [^\n]* で同一行内に限定する
-const COMMENT_PATTERNS: RegExp[] = [
-  /\/\/[ \t]*([^\n]*)/g, // C/JS/TS line comment
-  /\/\*([\s\S]*?)\*\//g, // C/JS block comment
-  /<!--([\s\S]*?)-->/g, // HTML comment
+// 改行を跨いで誤検出しないよう、行コメントは [^\n]* で同一行内に限定する。
+// パターンは関数内で都度 new RegExp で生成する（モジュールスコープの g フラグ付き定数は
+// lastIndex がイテレーション間で残るため、ステートを持たせないことで堅牢にする）
+const COMMENT_PATTERN_SOURCES: string[] = [
+  '\\/\\/[ \\t]*([^\\n]*)', // C/JS/TS line comment
+  '\\/\\*([\\s\\S]*?)\\*\\/', // C/JS block comment
+  '<!--([\\s\\S]*?)-->', // HTML comment
   // # コメントは shell/python 等で頻出。`#include` 等の preprocessor を避けるため行頭近接のみ
-  /(?:^|\n)[ \t]*#[ \t]+([^\n]*)/g,
+  '(?:^|\\n)[ \\t]*#[ \\t]+([^\\n]*)',
 ];
 
 export function hasTranslatableComment(code: string): boolean {
@@ -28,8 +30,8 @@ export function hasTranslatableComment(code: string): boolean {
   // 非 ASCII 文字（日本語等）を含むコメントだけを翻訳対象とする。
   // \s（\n, \r, \t 等）はホワイトスペースなので除外する: /* */ や <!-- --> の複数行コメントで
   // m[1] に \n が混じるため、これを非 ASCII 扱いすると英語のみの複数行コメントを誤って翻訳対象にしてしまう
-  for (const re of COMMENT_PATTERNS) {
-    re.lastIndex = 0;
+  for (const source of COMMENT_PATTERN_SOURCES) {
+    const re = new RegExp(source, 'g');
     let m: RegExpExecArray | null;
     while ((m = re.exec(code)) !== null) {
       const content = m[1].trim();

--- a/tools/auto-translate/code-translator.ts
+++ b/tools/auto-translate/code-translator.ts
@@ -4,6 +4,8 @@
 // - 行数一致と fence 保持を最低限のサニティチェック（厳密な構文検証は LLM では困難）
 // - 検証失敗・API 失敗 → 原文を返す（fail-safe）。「翻訳されない」より「壊れる」方が悪い
 
+import { errorMessage } from './ast-utils.ts';
+
 export type CodeTranslatorClient = (code: string, model: string) => Promise<string>;
 
 export interface TranslateCodeBlockArgs {
@@ -99,8 +101,13 @@ function stripComments(code: string): string {
   result = result.replace(/<!--[\s\S]*?-->/g, ''); // <!-- ... -->
   // (?<!:) 負先読みで URL の :// は除外（hasTranslatableComment と同じヒューリスティック）
   result = result.replace(/(?<!:)\/\/[^\n]*/g, ''); // // line comment
-  // # 行コメント（shebang は除外、行頭近接のみ）
-  result = result.replace(/(^|\n)([ \t]*)#(?!!)[^\n]*/g, '$1$2'); // インデント保持
+  // # コメント（shebang は除外）。hasTranslatableComment と同じく行頭・行中の両方をカバー。
+  // 行頭 #: (^|\n)[ \t]*#(?!!) のあとの行内容を除去（インデント保持）
+  result = result.replace(/(^|\n)([ \t]*)#(?!!)[^\n]*/g, '$1$2');
+  // 行中 #: 文字列リテラル考慮なしの簡易ヒューリスティック。code 内の前後に空白がある # の後を除去。
+  // 偽陽性（"a#b" のような hash 文字使用）は稀であり、stripComments は片方向比較に使うため
+  // ja/en で同じ偽陽性除去が起きれば問題にならない
+  result = result.replace(/[ \t]+#(?!!)[^\n]*/g, '');
   return result;
 }
 
@@ -114,7 +121,7 @@ export async function translateCodeBlock(args: TranslateCodeBlockArgs): Promise<
   try {
     translated = await client(code, model);
   } catch (e) {
-    console.warn(`[auto-translate] code block comment translation failed: ${(e as Error).message} — keeping original`);
+    console.warn(`[auto-translate] code block comment translation failed: ${errorMessage(e)} — keeping original`);
     return code;
   }
 

--- a/tools/auto-translate/code-translator.ts
+++ b/tools/auto-translate/code-translator.ts
@@ -33,8 +33,10 @@ const COMMENT_PATTERN_SOURCES: string[] = [
 
 // extractCode が prose の ⟨⟨/⟩⟩ を ⟪⟪/⟫⟫ に escape した状態で codeBlocks に格納するため、
 // コードブロック内コメントに ⟨⟨...⟩⟩ が含まれる場合（このシステムを解説する記事等）に
-// hasTranslatableComment が ⟪ を非 ASCII と誤検出しないよう、判定前に escape マーカーを除去する
-const ESCAPE_MARKER_RE = /⟪⟪|⟫⟫/g;
+// hasTranslatableComment が ⟪ を非 ASCII と誤検出しないよう、判定前に escape マーカーを除去する。
+// COMMENT_PATTERN_SOURCES と同じく source 文字列で保持し、使用箇所で new RegExp する
+// （g フラグ付きモジュール定数の lastIndex 残留問題を避けるため）
+const ESCAPE_MARKER_RE_SOURCE = '⟪⟪|⟫⟫';
 
 export function hasTranslatableComment(code: string): boolean {
   // 翻訳ターゲットは英語なので、既に英語のコメントは API を呼ばない（ノイズ・コスト削減）。
@@ -47,7 +49,7 @@ export function hasTranslatableComment(code: string): boolean {
     while ((m = re.exec(code)) !== null) {
       // escape マーカーは upstream のパイプライン都合で挿入された人工的な文字なので、
       // コメント実体の判定からは取り除いて評価する
-      const content = m[1].replace(ESCAPE_MARKER_RE, '').trim();
+      const content = m[1].replace(new RegExp(ESCAPE_MARKER_RE_SOURCE, 'g'), '').trim();
       if (content.length === 0) continue;
       if (/[^\x20-\x7e\s]/.test(content)) return true;
     }

--- a/tools/auto-translate/code-translator.ts
+++ b/tools/auto-translate/code-translator.ts
@@ -21,8 +21,10 @@ const COMMENT_PATTERN_SOURCES: string[] = [
   '\\/\\/[ \\t]*([^\\n]*)', // C/JS/TS line comment
   '\\/\\*([\\s\\S]*?)\\*\\/', // C/JS block comment
   '<!--([\\s\\S]*?)-->', // HTML comment
-  // # コメントは shell/python 等で頻出。`#include` 等の preprocessor を避けるため行頭近接のみ
-  '(?:^|\\n)[ \\t]*#[ \\t]+([^\\n]*)',
+  // # コメントは shell/python 等で頻出。
+  // 行頭近接のみ判定（`#include` のような preprocessor 行は内容に来るが、ここでは shebang `#!` を除外）。
+  // `#コメント` のようにスペースなしで書かれるスタイルも捉えるため、# 直後のスペースは [ \t]* にする
+  '(?:^|\\n)[ \\t]*#(?!!)[ \\t]*([^\\n]*)',
 ];
 
 export function hasTranslatableComment(code: string): boolean {

--- a/tools/auto-translate/code-translator.ts
+++ b/tools/auto-translate/code-translator.ts
@@ -53,9 +53,10 @@ function lineCount(s: string): number {
 }
 
 function fenceLines(code: string): string[] {
-  // 行頭判定なので trim しない（インデント済みの fence はネスト/コンテンツの一部であり fence ではない）。
-  // バッククォート（```）とチルダ（~~~）の両形式を扱う。remark もどちらも code ノードとしてパースする
-  return code.split('\n').filter((l) => /^(?:`{3,}|~{3,})/.test(l));
+  // バッククォート（```）とチルダ（~~~）の両形式を扱う。remark もどちらも code ノードとしてパースする。
+  // リスト項目内のコードブロックは markdown.slice() がインデント付きの fence 行を含むため、
+  // 先頭空白を許容する（"  ```ts" のような行も fence として認識）
+  return code.split('\n').filter((l) => /^\s*(?:`{3,}|~{3,})/.test(l));
 }
 
 function isCodeFenceIntact(code: string): boolean {

--- a/tools/auto-translate/code-translator.ts
+++ b/tools/auto-translate/code-translator.ts
@@ -45,8 +45,9 @@ function lineCount(s: string): number {
 }
 
 function fenceLines(code: string): string[] {
-  // 行頭判定なので trim しない（インデント済みの ``` はネスト/コンテンツの一部であり fence ではない）
-  return code.split('\n').filter((l) => /^```/.test(l));
+  // 行頭判定なので trim しない（インデント済みの fence はネスト/コンテンツの一部であり fence ではない）。
+  // バッククォート（```）とチルダ（~~~）の両形式を扱う。remark もどちらも code ノードとしてパースする
+  return code.split('\n').filter((l) => /^(?:`{3,}|~{3,})/.test(l));
 }
 
 function isCodeFenceIntact(code: string): boolean {

--- a/tools/auto-translate/code-translator.ts
+++ b/tools/auto-translate/code-translator.ts
@@ -17,8 +17,12 @@ export interface TranslateCodeBlockArgs {
 // 改行を跨いで誤検出しないよう、行コメントは [^\n]* で同一行内に限定する。
 // パターンは関数内で都度 new RegExp で生成する（モジュールスコープの g フラグ付き定数は
 // lastIndex がイテレーション間で残るため、ステートを持たせないことで堅牢にする）
+//
+// 既知の限界: 文字列リテラル内のコメントマーカーを誤検出する可能性がある。完全な解析には
+// 言語別 lexer が必要なため、よくある偽陽性のみ heuristic で除外する:
+// - `://` URL: `(?<!:)\/\/` で URL 内の // を除外
 const COMMENT_PATTERN_SOURCES: string[] = [
-  '\\/\\/[ \\t]*([^\\n]*)', // C/JS/TS line comment
+  '(?<!:)\\/\\/[ \\t]*([^\\n]*)', // C/JS/TS line comment（URL の :// を除外）
   '\\/\\*([\\s\\S]*?)\\*\\/', // C/JS block comment
   '<!--([\\s\\S]*?)-->', // HTML comment
   // # コメントは shell/python 等で頻出。

--- a/tools/auto-translate/code-translator.ts
+++ b/tools/auto-translate/code-translator.ts
@@ -31,6 +31,11 @@ const COMMENT_PATTERN_SOURCES: string[] = [
   '(?:^|\\n)[ \\t]*#(?!!)[ \\t]*([^\\n]*)',
 ];
 
+// extractCode が prose の ⟨⟨/⟩⟩ を ⟪⟪/⟫⟫ に escape した状態で codeBlocks に格納するため、
+// コードブロック内コメントに ⟨⟨...⟩⟩ が含まれる場合（このシステムを解説する記事等）に
+// hasTranslatableComment が ⟪ を非 ASCII と誤検出しないよう、判定前に escape マーカーを除去する
+const ESCAPE_MARKER_RE = /⟪⟪|⟫⟫/g;
+
 export function hasTranslatableComment(code: string): boolean {
   // 翻訳ターゲットは英語なので、既に英語のコメントは API を呼ばない（ノイズ・コスト削減）。
   // 非 ASCII 文字（日本語等）を含むコメントだけを翻訳対象とする。
@@ -40,7 +45,9 @@ export function hasTranslatableComment(code: string): boolean {
     const re = new RegExp(source, 'g');
     let m: RegExpExecArray | null;
     while ((m = re.exec(code)) !== null) {
-      const content = m[1].trim();
+      // escape マーカーは upstream のパイプライン都合で挿入された人工的な文字なので、
+      // コメント実体の判定からは取り除いて評価する
+      const content = m[1].replace(ESCAPE_MARKER_RE, '').trim();
       if (content.length === 0) continue;
       if (/[^\x20-\x7e\s]/.test(content)) return true;
     }
@@ -76,6 +83,20 @@ function fenceLanguageTagsMatch(original: string, translated: string): boolean {
   return true;
 }
 
+// 行コメントとブロックコメントを除去した「非コメント部分」を返す。
+// コメント以外（識別子・文字列リテラル等）の改変を検出するために使う。
+// 簡易ヒューリスティックなので完全な lexer ではないが、既知の主要コメント形式をカバーする
+function stripComments(code: string): string {
+  let result = code;
+  result = result.replace(/\/\*[\s\S]*?\*\//g, ''); // /* ... */
+  result = result.replace(/<!--[\s\S]*?-->/g, ''); // <!-- ... -->
+  // (?<!:) 負先読みで URL の :// は除外（hasTranslatableComment と同じヒューリスティック）
+  result = result.replace(/(?<!:)\/\/[^\n]*/g, ''); // // line comment
+  // # 行コメント（shebang は除外、行頭近接のみ）
+  result = result.replace(/(^|\n)([ \t]*)#(?!!)[^\n]*/g, '$1$2'); // インデント保持
+  return result;
+}
+
 export async function translateCodeBlock(args: TranslateCodeBlockArgs): Promise<string> {
   const { code, client, model } = args;
 
@@ -104,6 +125,14 @@ export async function translateCodeBlock(args: TranslateCodeBlockArgs): Promise<
   if (!fenceLanguageTagsMatch(code, translated)) {
     console.warn(
       `[auto-translate] code block comment translation modified fence (language tag changed?) — keeping original`,
+    );
+    return code;
+  }
+  // 非コメント部分（識別子・文字列リテラル等）が改変されていないか確認。
+  // LLM が「コメント翻訳のついでに」識別子や文字列を変更するケースを検出する
+  if (stripComments(code) !== stripComments(translated)) {
+    console.warn(
+      `[auto-translate] code block comment translation modified non-comment content (identifiers / string literals?) — keeping original`,
     );
     return code;
   }

--- a/tools/auto-translate/code-translator.ts
+++ b/tools/auto-translate/code-translator.ts
@@ -44,10 +44,26 @@ function lineCount(s: string): number {
   return s.split('\n').length;
 }
 
+function fenceLines(code: string): string[] {
+  // 行頭判定なので trim しない（インデント済みの ``` はネスト/コンテンツの一部であり fence ではない）
+  return code.split('\n').filter((l) => /^```/.test(l));
+}
+
 function isCodeFenceIntact(code: string): boolean {
-  // コードフェンスは ``` で開始・終了する想定。fence 行の数が偶数（>=2）であること
-  const fenceLines = code.split('\n').filter((l) => /^```/.test(l.trim()));
-  return fenceLines.length >= 2 && fenceLines.length % 2 === 0;
+  // コードフェンス行の数が偶数（>=2）であること
+  const lines = fenceLines(code);
+  return lines.length >= 2 && lines.length % 2 === 0;
+}
+
+function fenceLanguageTagsMatch(original: string, translated: string): boolean {
+  // 各 fence 行を順に比較し、すべて文字列一致であること（言語タグ・属性も含む）
+  const a = fenceLines(original);
+  const b = fenceLines(translated);
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
 }
 
 export async function translateCodeBlock(args: TranslateCodeBlockArgs): Promise<string> {
@@ -64,10 +80,20 @@ export async function translateCodeBlock(args: TranslateCodeBlockArgs): Promise<
     return code;
   }
 
-  // サニティチェック: 行数一致 & fence 健全
-  if (lineCount(translated) !== lineCount(code) || !isCodeFenceIntact(translated)) {
+  // サニティチェック: 行数一致 & fence 健全 & 言語タグ保全
+  if (lineCount(translated) !== lineCount(code)) {
     console.warn(
-      `[auto-translate] code block comment translation produced malformed output (lines ${lineCount(code)}→${lineCount(translated)}, fence intact=${isCodeFenceIntact(translated)}) — keeping original`,
+      `[auto-translate] code block comment translation produced malformed output (lines ${lineCount(code)}→${lineCount(translated)}) — keeping original`,
+    );
+    return code;
+  }
+  if (!isCodeFenceIntact(translated)) {
+    console.warn(`[auto-translate] code block comment translation broke fence structure — keeping original`);
+    return code;
+  }
+  if (!fenceLanguageTagsMatch(code, translated)) {
+    console.warn(
+      `[auto-translate] code block comment translation modified fence (language tag changed?) — keeping original`,
     );
     return code;
   }

--- a/tools/auto-translate/code-translator.ts
+++ b/tools/auto-translate/code-translator.ts
@@ -24,17 +24,15 @@ const COMMENT_PATTERNS: RegExp[] = [
 ];
 
 export function hasTranslatableComment(code: string): boolean {
+  // 翻訳ターゲットは英語なので、既に英語のコメントは API を呼ばない（ノイズ・コスト削減）。
+  // 非 ASCII 文字（日本語等）を含むコメントだけを翻訳対象とする
   for (const re of COMMENT_PATTERNS) {
     re.lastIndex = 0;
     let m: RegExpExecArray | null;
     while ((m = re.exec(code)) !== null) {
       const content = m[1].trim();
       if (content.length === 0) continue;
-      // ASCII 英数字・記号のみは翻訳不要（識別子的なコメント）
-      // 非 ASCII（日本語等）または英文相当の文章があれば翻訳対象
       if (/[^\x20-\x7e]/.test(content)) return true;
-      // ASCII 英文判定: 単語数 2 以上で空白を含む（"TODO" などの単独語は除外）
-      if (/[a-zA-Z]/.test(content) && /\s/.test(content) && content.length > 5) return true;
     }
   }
   return false;

--- a/tools/auto-translate/code-translator.ts
+++ b/tools/auto-translate/code-translator.ts
@@ -64,7 +64,12 @@ function lineCount(s: string): number {
 function fenceLines(code: string): string[] {
   // バッククォート（```）とチルダ（~~~）の両形式を扱う。remark もどちらも code ノードとしてパースする。
   // リスト項目内のコードブロックは markdown.slice() がインデント付きの fence 行を含むため、
-  // 先頭空白を許容する（"  ```ts" のような行も fence として認識）
+  // 先頭空白を許容する（"  ```ts" のような行も fence として認識）。
+  //
+  // 既知の制約: 4-backtick フェンス（meta-documentation で「コードブロックの書き方を解説する
+  // コードブロック」として使われる）の内側に含まれる 3-backtick 行も fence 行としてカウントされ、
+  // isCodeFenceIntact が false → translateCodeBlock が原文 fallback する。壊れない（機能的欠落のみ）、
+  // 個人ブログでの実用頻度が低いため対応保留
   return code.split('\n').filter((l) => /^\s*(?:`{3,}|~{3,})/.test(l));
 }
 

--- a/tools/auto-translate/code-translator.ts
+++ b/tools/auto-translate/code-translator.ts
@@ -1,0 +1,76 @@
+// コードブロック内のコメントだけを翻訳するモジュール。
+// 実装方針:
+// - LLM に「コメントのみ翻訳、syntax は byte 同一に保て」と指示
+// - 行数一致と fence 保持を最低限のサニティチェック（厳密な構文検証は LLM では困難）
+// - 検証失敗・API 失敗 → 原文を返す（fail-safe）。「翻訳されない」より「壊れる」方が悪い
+
+export type CodeTranslatorClient = (code: string, model: string) => Promise<string>;
+
+export interface TranslateCodeBlockArgs {
+  code: string;
+  client: CodeTranslatorClient;
+  model: string;
+}
+
+// 翻訳対象になりうるコメントを含むかの簡易ヒューリスティック。
+// 言語非依存に「//」「#」「/* */」「<!-- -->」を検出。
+// 改行を跨いで誤検出しないよう、行コメントは [^\n]* で同一行内に限定する
+const COMMENT_PATTERNS: RegExp[] = [
+  /\/\/[ \t]*([^\n]*)/g, // C/JS/TS line comment
+  /\/\*([\s\S]*?)\*\//g, // C/JS block comment
+  /<!--([\s\S]*?)-->/g, // HTML comment
+  // # コメントは shell/python 等で頻出。`#include` 等の preprocessor を避けるため行頭近接のみ
+  /(?:^|\n)[ \t]*#[ \t]+([^\n]*)/g,
+];
+
+export function hasTranslatableComment(code: string): boolean {
+  for (const re of COMMENT_PATTERNS) {
+    re.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(code)) !== null) {
+      const content = m[1].trim();
+      if (content.length === 0) continue;
+      // ASCII 英数字・記号のみは翻訳不要（識別子的なコメント）
+      // 非 ASCII（日本語等）または英文相当の文章があれば翻訳対象
+      if (/[^\x20-\x7e]/.test(content)) return true;
+      // ASCII 英文判定: 単語数 2 以上で空白を含む（"TODO" などの単独語は除外）
+      if (/[a-zA-Z]/.test(content) && /\s/.test(content) && content.length > 5) return true;
+    }
+  }
+  return false;
+}
+
+function lineCount(s: string): number {
+  return s.split('\n').length;
+}
+
+function isCodeFenceIntact(code: string): boolean {
+  // コードフェンスは ``` で開始・終了する想定。fence 行の数が偶数（>=2）であること
+  const fenceLines = code.split('\n').filter((l) => /^```/.test(l.trim()));
+  return fenceLines.length >= 2 && fenceLines.length % 2 === 0;
+}
+
+export async function translateCodeBlock(args: TranslateCodeBlockArgs): Promise<string> {
+  const { code, client, model } = args;
+
+  // 翻訳対象がないなら API を呼ばずそのまま返す（コスト削減）
+  if (!hasTranslatableComment(code)) return code;
+
+  let translated: string;
+  try {
+    translated = await client(code, model);
+  } catch (e) {
+    console.warn(`[auto-translate] code block comment translation failed: ${(e as Error).message} — keeping original`);
+    return code;
+  }
+
+  // サニティチェック: 行数一致 & fence 健全
+  if (lineCount(translated) !== lineCount(code) || !isCodeFenceIntact(translated)) {
+    console.warn(
+      `[auto-translate] code block comment translation produced malformed output (lines ${lineCount(code)}→${lineCount(translated)}, fence intact=${isCodeFenceIntact(translated)}) — keeping original`,
+    );
+    return code;
+  }
+
+  return translated;
+}

--- a/tools/auto-translate/main.ts
+++ b/tools/auto-translate/main.ts
@@ -65,6 +65,7 @@ Do NOT flag:
 - Hedging differences ("I think" vs "perhaps") — both are acceptable.
 - Minor word choices that preserve meaning.
 - Code blocks themselves (validated separately).
+- Differences in code-block COMMENTS between the source and translation. Comments inside code blocks are translated by a separate pipeline stage; the translation intentionally renders Japanese comments in English (or leaves English-only comments unchanged). Do NOT flag comment-level differences inside fenced code blocks.
 - ANY inconsistency that exists identically in the Japanese source. If the source uses an identifier informally (e.g., source prose says \`active\` referring to a variable named \`activePromise\` in code), the translation may faithfully preserve this. This is the author's choice, not a defect.
 
 If the translation has no translation-induced defects, return ok=true and empty issues. Otherwise return ok=false with a precise list of issues.

--- a/tools/auto-translate/main.ts
+++ b/tools/auto-translate/main.ts
@@ -44,7 +44,7 @@ Other structural rules:
 - URLs and image paths: leave unchanged.
 - Bare URL paragraphs (a paragraph consisting only of a single URL) MUST remain as standalone paragraphs containing only that URL. Do NOT wrap them in prose, do NOT add surrounding sentences.
 - Markdown structure (heading levels, lists, blockquotes, tables) must be preserved.
-- Code blocks INSIDE blockquotes (lines starting with \`> \`) are NOT replaced by placeholders and appear in the source you receive. Keep these blockquote-nested code blocks BYTE-FOR-BYTE identical to the source. Do NOT translate their comments. Do NOT change any character including quotation marks, dashes, or whitespace.
+- Code blocks INSIDE blockquotes (lines starting with "> ") are NOT replaced by placeholders and appear in the source you receive. Keep these blockquote-nested code blocks BYTE-FOR-BYTE identical to the source. Do NOT translate their comments. Do NOT change any character including quotation marks, dashes, or whitespace.
 - LaTeX math ($...$ and $$...$$) and Mermaid: keep as-is.
 
 Output only the translated title and body (with placeholders preserved) in the requested JSON schema. Do not include the YAML frontmatter.`;
@@ -65,7 +65,8 @@ Do NOT flag:
 - Hedging differences ("I think" vs "perhaps") — both are acceptable.
 - Minor word choices that preserve meaning.
 - Code blocks themselves (validated separately).
-- Differences in code-block COMMENTS between the source and translation. Comments inside code blocks are translated by a separate pipeline stage; the translation intentionally renders Japanese comments in English (or leaves English-only comments unchanged). Do NOT flag comment-level differences inside fenced code blocks.
+- Differences in code-block COMMENTS between the source and translation. Comments inside fenced code blocks are translated by a separate pipeline stage; the translation intentionally renders Japanese comments in English (or leaves English-only comments unchanged). Do NOT flag comment-level differences inside fenced code blocks.
+- Note that this comment-translation only applies to top-level fenced code blocks. Code blocks INSIDE blockquotes (lines starting with "> ") are NOT translated by the comment-translation stage and are kept byte-for-byte identical to the source. Do NOT flag a blockquote-nested code block as a defect just because its comments remain in Japanese.
 - ANY inconsistency that exists identically in the Japanese source. If the source uses an identifier informally (e.g., source prose says \`active\` referring to a variable named \`activePromise\` in code), the translation may faithfully preserve this. This is the author's choice, not a defect.
 
 If the translation has no translation-induced defects, return ok=true and empty issues. Otherwise return ok=false with a precise list of issues.

--- a/tools/auto-translate/main.ts
+++ b/tools/auto-translate/main.ts
@@ -44,7 +44,7 @@ Other structural rules:
 - URLs and image paths: leave unchanged.
 - Bare URL paragraphs (a paragraph consisting only of a single URL) MUST remain as standalone paragraphs containing only that URL. Do NOT wrap them in prose, do NOT add surrounding sentences.
 - Markdown structure (heading levels, lists, blockquotes, tables) must be preserved.
-- Code blocks INSIDE blockquotes (lines starting with "> ") are NOT replaced by placeholders and appear in the source you receive. Keep these blockquote-nested code blocks BYTE-FOR-BYTE identical to the source. Do NOT translate their comments. Do NOT change any character including quotation marks, dashes, or whitespace.
+- Code blocks AND inline code INSIDE blockquotes (lines starting with "> ") are NOT replaced by placeholders and appear in the source you receive. Keep these blockquote-nested code blocks AND inline code (text wrapped in backticks within blockquotes) BYTE-FOR-BYTE identical to the source. Do NOT translate their comments. Do NOT change any character including quotation marks, dashes, or whitespace.
 - LaTeX math ($...$ and $$...$$) and Mermaid: keep as-is.
 
 Output only the translated title and body (with placeholders preserved) in the requested JSON schema. Do not include the YAML frontmatter.`;

--- a/tools/auto-translate/main.ts
+++ b/tools/auto-translate/main.ts
@@ -106,16 +106,16 @@ function createCodeTranslatorClient(apiKey: string): CodeTranslatorClient {
 function createProofreaderClient(apiKey: string): ProofreaderClient {
   const ai = new GoogleGenAI({ apiKey });
   return async (input, model) => {
+    // ソースと訳文はマークダウン（コードブロック含む）が含まれるので、フェンスで囲むと
+    // 内部の ```ts 等がアウターフェンスを誤閉じして LLM が構造を見失う。XML 風タグで囲って区切る
     const userMessage = [
-      'Japanese source:',
-      '```',
+      '<japanese-source>',
       input.jaSource,
-      '```',
+      '</japanese-source>',
       '',
-      'English translation:',
-      '```',
+      '<english-translation>',
       input.enTranslation,
-      '```',
+      '</english-translation>',
     ].join('\n');
 
     const response = await ai.models.generateContent({

--- a/tools/auto-translate/main.ts
+++ b/tools/auto-translate/main.ts
@@ -39,6 +39,7 @@ Other structural rules:
 - URLs and image paths: leave unchanged.
 - Bare URL paragraphs (a paragraph consisting only of a single URL) MUST remain as standalone paragraphs containing only that URL. Do NOT wrap them in prose, do NOT add surrounding sentences.
 - Markdown structure (heading levels, lists, blockquotes, tables) must be preserved.
+- Code blocks INSIDE blockquotes (lines starting with \`> \`) are NOT replaced by placeholders and appear in the source you receive. Keep these blockquote-nested code blocks BYTE-FOR-BYTE identical to the source. Do NOT translate their comments. Do NOT change any character including quotation marks, dashes, or whitespace.
 - LaTeX math ($...$ and $$...$$) and Mermaid: keep as-is.
 
 Output only the translated title and body (with placeholders preserved) in the requested JSON schema. Do not include the YAML frontmatter.`;

--- a/tools/auto-translate/main.ts
+++ b/tools/auto-translate/main.ts
@@ -1,6 +1,7 @@
 import { GoogleGenAI, Type } from '@google/genai';
 import { readFile, writeFile, unlink, readdir } from 'node:fs/promises';
 import * as path from 'node:path';
+import { errorMessage } from './ast-utils.ts';
 import { classifyFile, jaToEnPath } from './discover.ts';
 import type { CodeTranslatorClient } from './code-translator.ts';
 import type { ProofreaderClient } from './proofreader.ts';
@@ -240,7 +241,7 @@ async function listJaFiles(contentDir: string): Promise<string[]> {
 type ReadEnResult =
   | { kind: 'present'; content: string; frontmatter: Frontmatter }
   | { kind: 'absent' }
-  | { kind: 'parse-error'; error: Error };
+  | { kind: 'parse-error'; error: unknown };
 
 async function readEn(enPath: string): Promise<ReadEnResult> {
   let content: string;
@@ -257,7 +258,7 @@ async function readEn(enPath: string): Promise<ReadEnResult> {
   } catch (e) {
     // パース不能な en は手動翻訳の破損か自動翻訳の破損か区別できない。
     // 手動 en を上書きするリスクを避けるため、当該記事は failed として skip する
-    return { kind: 'parse-error', error: e as Error };
+    return { kind: 'parse-error', error: e };
   }
 }
 
@@ -301,7 +302,7 @@ async function main(): Promise<void> {
       jaContent = await readFile(jaPath, 'utf8');
       ja = splitFrontmatter(jaContent).frontmatter;
     } catch (e) {
-      console.error(`[auto-translate] ja parse error for ${baseName}: ${(e as Error).message}`);
+      console.error(`[auto-translate] ja parse error for ${baseName}: ${errorMessage(e)}`);
       stats.failed++;
       continue;
     }
@@ -311,14 +312,14 @@ async function main(): Promise<void> {
       enFile = await readEn(enPath);
     } catch (e) {
       // 権限エラー等の I/O 異常は当該記事を失敗扱いにして継続
-      console.error(`[auto-translate] failed to read en for ${baseName}: ${(e as Error).message}`);
+      console.error(`[auto-translate] failed to read en for ${baseName}: ${errorMessage(e)}`);
       stats.failed++;
       continue;
     }
     if (enFile.kind === 'parse-error') {
       // YAML 破損した en が手動 en か自動 en か区別できない。手動 en の保護を優先して skip
       console.error(
-        `[auto-translate] en frontmatter parse error for ${path.basename(enPath)}: ${enFile.error.message} — skipping to protect potentially manual en`,
+        `[auto-translate] en frontmatter parse error for ${path.basename(enPath)}: ${errorMessage(enFile.error)} — skipping to protect potentially manual en`,
       );
       stats.failed++;
       continue;
@@ -344,7 +345,7 @@ async function main(): Promise<void> {
           console.log(`[auto-translate] removed orphaned auto-translation: ${path.basename(enPath)}`);
           stats.deleted++;
         } catch (e) {
-          console.error(`[auto-translate] failed to delete ${path.basename(enPath)}: ${(e as Error).message}`);
+          console.error(`[auto-translate] failed to delete ${path.basename(enPath)}: ${errorMessage(e)}`);
           stats.failed++;
         }
         break;
@@ -367,7 +368,7 @@ async function main(): Promise<void> {
               console.log(`[auto-translate] translated: ${path.basename(enPath)}`);
               stats.translated++;
             } catch (e) {
-              console.error(`[auto-translate] failed to write ${path.basename(enPath)}: ${(e as Error).message}`);
+              console.error(`[auto-translate] failed to write ${path.basename(enPath)}: ${errorMessage(e)}`);
               stats.failed++;
             }
             break;
@@ -377,7 +378,7 @@ async function main(): Promise<void> {
               console.log(`[auto-translate] frontmatter-only: ${path.basename(enPath)}`);
               stats.frontmatterOnly++;
             } catch (e) {
-              console.error(`[auto-translate] failed to write ${path.basename(enPath)}: ${(e as Error).message}`);
+              console.error(`[auto-translate] failed to write ${path.basename(enPath)}: ${errorMessage(e)}`);
               stats.failed++;
             }
             break;

--- a/tools/auto-translate/main.ts
+++ b/tools/auto-translate/main.ts
@@ -155,6 +155,14 @@ function createProofreaderClient(ai: GoogleGenAI): ProofreaderClient {
     if (typeof parsed.ok !== 'boolean' || !Array.isArray(parsed.issues)) {
       throw new Error('Proofreader response did not match schema');
     }
+    // 各 issue の必須フィールドが string であることを検証（responseSchema が強制するが、
+    // SDK 側のバグや malformed JSON を想定して防御的に確認）
+    const issuesValid = parsed.issues.every(
+      (i) => typeof i.location === 'string' && typeof i.problem === 'string' && typeof i.suggestion === 'string',
+    );
+    if (!issuesValid) {
+      throw new Error('Proofreader issue items did not match schema');
+    }
     return { ok: parsed.ok, issues: parsed.issues };
   };
 }

--- a/tools/auto-translate/main.ts
+++ b/tools/auto-translate/main.ts
@@ -2,6 +2,7 @@ import { GoogleGenAI, Type } from '@google/genai';
 import { readFile, writeFile, unlink, readdir } from 'node:fs/promises';
 import * as path from 'node:path';
 import { classifyFile, jaToEnPath } from './discover.ts';
+import type { ProofreaderClient } from './proofreader.ts';
 import { splitFrontmatter, translateOne, DEFAULT_MODEL, type GeminiClient } from './translator.ts';
 import type { Frontmatter } from './frontmatter.ts';
 
@@ -30,6 +31,83 @@ Strict structural preservation rules:
 - LaTeX math ($...$ and $$...$$) and Mermaid blocks: keep as-is.
 
 Output only the translated title and body in the requested JSON schema. Do not include the YAML frontmatter.`;
+
+const PROOFREADER_INSTRUCTION = `You are a meticulous bilingual (Japanese-English) technical proofreader for software engineering blog articles. You receive a Japanese source and its English translation. Your role is fact-checking and consistency review, NOT style polishing.
+
+Detect translation defects that mislead the reader. Specifically:
+1. Identifier mismatches: prose references a name (in backticks like \`foo\`) that does not appear in the surrounding code blocks. Example: prose says "the \`active\` variable" but code uses \`waiting\`.
+2. Inverted meaning: negation flipped, comparison reversed, "before" vs "after" swapped, etc.
+3. Hallucinations: facts, terms, or claims that exist in the translation but not in the source.
+4. Omissions: significant content from the source missing in the translation.
+5. Wrong technical terminology: e.g., "object" vs "instance", "type" vs "interface", "function" vs "method" used inconsistently with the source.
+
+Do NOT flag:
+- Style or tone preferences (the translator handles voice).
+- Hedging differences ("I think" vs "perhaps") — both are acceptable.
+- Minor word choices that preserve meaning.
+- Code blocks themselves (those are validated separately for byte-equality).
+
+If the translation has no defects, return ok=true and empty issues. Otherwise return ok=false with a precise list of issues.
+
+For each issue, "location" must be a concrete reference (e.g., "paragraph 3", "the sentence containing 'setTimeout'"), "problem" describes what is wrong, "suggestion" gives the correct phrasing.`;
+
+function createProofreaderClient(apiKey: string): ProofreaderClient {
+  const ai = new GoogleGenAI({ apiKey });
+  return async (input, model) => {
+    const userMessage = [
+      'Japanese source:',
+      '```',
+      input.jaSource,
+      '```',
+      '',
+      'English translation:',
+      '```',
+      input.enTranslation,
+      '```',
+    ].join('\n');
+
+    const response = await ai.models.generateContent({
+      model,
+      contents: userMessage,
+      config: {
+        systemInstruction: PROOFREADER_INSTRUCTION,
+        responseMimeType: 'application/json',
+        responseSchema: {
+          type: Type.OBJECT,
+          properties: {
+            ok: { type: Type.BOOLEAN },
+            issues: {
+              type: Type.ARRAY,
+              items: {
+                type: Type.OBJECT,
+                properties: {
+                  location: { type: Type.STRING },
+                  problem: { type: Type.STRING },
+                  suggestion: { type: Type.STRING },
+                },
+                required: ['location', 'problem', 'suggestion'],
+                propertyOrdering: ['location', 'problem', 'suggestion'],
+              },
+            },
+          },
+          required: ['ok', 'issues'],
+          propertyOrdering: ['ok', 'issues'],
+        },
+      },
+    });
+
+    const text = response.text;
+    if (!text) throw new Error('Empty response from proofreader');
+    const parsed = JSON.parse(text) as {
+      ok: boolean;
+      issues: { location: string; problem: string; suggestion: string }[];
+    };
+    if (typeof parsed.ok !== 'boolean' || !Array.isArray(parsed.issues)) {
+      throw new Error('Proofreader response did not match schema');
+    }
+    return { ok: parsed.ok, issues: parsed.issues };
+  };
+}
 
 function createGeminiClient(apiKey: string): GeminiClient {
   const ai = new GoogleGenAI({ apiKey });
@@ -134,6 +212,7 @@ async function main(): Promise<void> {
   console.log(`[auto-translate] model: ${model}`);
 
   const client = createGeminiClient(apiKey);
+  const proofreader = createProofreaderClient(apiKey);
   const stats: Stats = {
     translated: 0,
     frontmatterOnly: 0,
@@ -208,6 +287,7 @@ async function main(): Promise<void> {
           jaContent,
           enContent,
           geminiClient: client,
+          proofreaderClient: proofreader,
           model,
         });
         switch (result.kind) {

--- a/tools/auto-translate/main.ts
+++ b/tools/auto-translate/main.ts
@@ -81,7 +81,7 @@ Rules:
 - Do NOT change identifiers, string literals, numeric literals, operators, or any non-comment content.
 - Do NOT add or remove lines. The line count of input and output MUST match exactly.
 - Do NOT change the language tag of the fence (\`\`\`ts must stay \`\`\`ts, etc.).
-- The code may contain the literal sequences ⟪⟪ or ⟫⟫ (escape markers used by the upstream pipeline). Keep them BYTE-FOR-BYTE in their original positions.
+- The code may contain the literal sequences ⟪⟪ or ⟫⟫ (escape markers used by the upstream pipeline). They can appear ANYWHERE inside the code block, INCLUDING inside comments. Keep them BYTE-FOR-BYTE in their original positions. Do NOT translate, modify, normalize, or remove them, even if they appear inside a natural-language comment you are translating.
 - Place the translated code block (including the surrounding triple-backtick fences) into the \`translated_code\` JSON field as required by the response schema.`;
 
 function createCodeTranslatorClient(ai: GoogleGenAI): CodeTranslatorClient {

--- a/tools/auto-translate/main.ts
+++ b/tools/auto-translate/main.ts
@@ -2,6 +2,7 @@ import { GoogleGenAI, Type } from '@google/genai';
 import { readFile, writeFile, unlink, readdir } from 'node:fs/promises';
 import * as path from 'node:path';
 import { classifyFile, jaToEnPath } from './discover.ts';
+import type { CodeTranslatorClient } from './code-translator.ts';
 import type { ProofreaderClient } from './proofreader.ts';
 import { splitFrontmatter, translateOne, DEFAULT_MODEL, type GeminiClient } from './translator.ts';
 import type { Frontmatter } from './frontmatter.ts';
@@ -22,34 +23,85 @@ Title rules:
 - Do NOT expand short Japanese titles into long descriptive English titles. If the source is "Xを対象として見る", prefer "Viewing X as an Object" over "Viewing X as the Object of Your Work".
 - Avoid adding clarifying phrases that are not in the source.
 
-Strict structural preservation rules:
-- Code blocks: keep the entire code block content BYTE-FOR-BYTE identical to the source. Do NOT translate comments. Do NOT change any character including straight/curly quotation marks, dashes, whitespace, or backticks. The validator compares bytes exactly.
-- Inline code (text wrapped in backticks): keep BYTE-FOR-BYTE identical to the source. Do NOT change quotation marks or any character inside backticks.
+Code placeholders (CRITICAL — read carefully):
+The body you receive has had its code blocks and inline code replaced with opaque placeholders:
+- ⟨⟨BLOCK_0⟩⟩, ⟨⟨BLOCK_1⟩⟩, ... — represent fenced code blocks
+- ⟨⟨INLINE_0⟩⟩, ⟨⟨INLINE_1⟩⟩, ... — represent inline code (was wrapped in backticks in the source)
+
+Rules for placeholders:
+- Each placeholder MUST appear exactly once in your output, in a position that corresponds to where the original code appeared in the source.
+- Do NOT translate, modify, or remove placeholders. Copy them verbatim.
+- Do NOT invent new placeholders.
+- Do NOT wrap placeholders in additional backticks, brackets, or formatting.
+- When you reference a placeholder in prose (e.g., describing what the code does), refer to it by its placeholder token directly.
+
+Other structural rules:
 - URLs and image paths: leave unchanged.
 - Bare URL paragraphs (a paragraph consisting only of a single URL) MUST remain as standalone paragraphs containing only that URL. Do NOT wrap them in prose, do NOT add surrounding sentences.
-- Markdown structure (heading levels, lists, blockquotes, tables) must be preserved exactly.
-- LaTeX math ($...$ and $$...$$) and Mermaid blocks: keep as-is.
+- Markdown structure (heading levels, lists, blockquotes, tables) must be preserved.
+- LaTeX math ($...$ and $$...$$) and Mermaid: keep as-is.
 
-Output only the translated title and body in the requested JSON schema. Do not include the YAML frontmatter.`;
+Output only the translated title and body (with placeholders preserved) in the requested JSON schema. Do not include the YAML frontmatter.`;
 
-const PROOFREADER_INSTRUCTION = `You are a meticulous bilingual (Japanese-English) technical proofreader for software engineering blog articles. You receive a Japanese source and its English translation. Your role is fact-checking and consistency review, NOT style polishing.
+const PROOFREADER_INSTRUCTION = `You are a meticulous bilingual (Japanese-English) technical proofreader for software engineering blog articles. You receive a Japanese source and its English translation. Your role is to detect TRANSLATION-INDUCED defects that mislead the reader.
 
-Detect translation defects that mislead the reader. Specifically:
-1. Identifier mismatches: prose references a name (in backticks like \`foo\`) that does not appear in the surrounding code blocks. Example: prose says "the \`active\` variable" but code uses \`waiting\`.
-2. Inverted meaning: negation flipped, comparison reversed, "before" vs "after" swapped, etc.
-3. Hallucinations: facts, terms, or claims that exist in the translation but not in the source.
-4. Omissions: significant content from the source missing in the translation.
-5. Wrong technical terminology: e.g., "object" vs "instance", "type" vs "interface", "function" vs "method" used inconsistently with the source.
+CRITICAL: only flag issues that were introduced by the translation. If the same issue exists in the Japanese source, it is the author's editorial choice and you MUST NOT flag it. Always cross-check the source before flagging.
+
+Detect:
+1. Translation-induced identifier mismatches: prose in the English translation references a name (in backticks) that does not appear in surrounding code blocks, AND the Japanese source did not have that same mismatch. Example: source uses \`waiting\` but translation says \`active\`.
+2. Inverted meaning: negation flipped, comparison reversed, "before" vs "after" swapped between source and translation.
+3. Translation-induced hallucinations: facts/terms/claims in the translation that are not in the source.
+4. Translation-induced omissions: significant content from the source missing in the translation.
+5. Wrong technical terminology drift: e.g., source uses "debounce" but translation says "throttle"; source uses "object" but translation says "instance".
 
 Do NOT flag:
 - Style or tone preferences (the translator handles voice).
 - Hedging differences ("I think" vs "perhaps") — both are acceptable.
 - Minor word choices that preserve meaning.
-- Code blocks themselves (those are validated separately for byte-equality).
+- Code blocks themselves (validated separately).
+- ANY inconsistency that exists identically in the Japanese source. If the source uses an identifier informally (e.g., source prose says \`active\` referring to a variable named \`activePromise\` in code), the translation may faithfully preserve this. This is the author's choice, not a defect.
 
-If the translation has no defects, return ok=true and empty issues. Otherwise return ok=false with a precise list of issues.
+If the translation has no translation-induced defects, return ok=true and empty issues. Otherwise return ok=false with a precise list of issues.
 
-For each issue, "location" must be a concrete reference (e.g., "paragraph 3", "the sentence containing 'setTimeout'"), "problem" describes what is wrong, "suggestion" gives the correct phrasing.`;
+For each issue, "location" must be a concrete reference (e.g., "paragraph 3", "the sentence containing 'setTimeout'"), "problem" describes what is wrong AND confirms the source does NOT have this issue, "suggestion" gives the correct phrasing.`;
+
+const CODE_TRANSLATOR_INSTRUCTION = `You translate ONLY the natural-language comments inside a code block. Everything else (code identifiers, strings, syntax, indentation, fence markers, blank lines) must remain BYTE-FOR-BYTE identical to the input.
+
+Rules:
+- Translate Japanese (or non-English) comments to natural English. Do not translate code-only comments like "TODO" or single-word tags.
+- Preserve the comment delimiter exactly (// , #, /* */, <!-- -->, etc.) and the position of each comment line.
+- Do NOT change identifiers, string literals, numeric literals, operators, or any non-comment content.
+- Do NOT add or remove lines. The line count of input and output MUST match exactly.
+- Do NOT change the language tag of the fence (\`\`\`ts must stay \`\`\`ts, etc.).
+- Output the entire code block, including the surrounding triple-backtick fences, with comments translated.`;
+
+function createCodeTranslatorClient(apiKey: string): CodeTranslatorClient {
+  const ai = new GoogleGenAI({ apiKey });
+  return async (code, model) => {
+    const response = await ai.models.generateContent({
+      model,
+      contents: code,
+      config: {
+        systemInstruction: CODE_TRANSLATOR_INSTRUCTION,
+        responseMimeType: 'application/json',
+        responseSchema: {
+          type: Type.OBJECT,
+          properties: {
+            translated_code: { type: Type.STRING },
+          },
+          required: ['translated_code'],
+        },
+      },
+    });
+    const text = response.text;
+    if (!text) throw new Error('Empty response from code translator');
+    const parsed = JSON.parse(text) as { translated_code: string };
+    if (typeof parsed.translated_code !== 'string') {
+      throw new Error('Code translator response did not match schema');
+    }
+    return parsed.translated_code;
+  };
+}
 
 function createProofreaderClient(apiKey: string): ProofreaderClient {
   const ai = new GoogleGenAI({ apiKey });
@@ -213,6 +265,7 @@ async function main(): Promise<void> {
 
   const client = createGeminiClient(apiKey);
   const proofreader = createProofreaderClient(apiKey);
+  const codeTranslator = createCodeTranslatorClient(apiKey);
   const stats: Stats = {
     translated: 0,
     frontmatterOnly: 0,
@@ -288,6 +341,7 @@ async function main(): Promise<void> {
           enContent,
           geminiClient: client,
           proofreaderClient: proofreader,
+          codeTranslatorClient: codeTranslator,
           model,
         });
         switch (result.kind) {

--- a/tools/auto-translate/main.ts
+++ b/tools/auto-translate/main.ts
@@ -75,8 +75,7 @@ Rules:
 - Do NOT change the language tag of the fence (\`\`\`ts must stay \`\`\`ts, etc.).
 - Place the translated code block (including the surrounding triple-backtick fences) into the \`translated_code\` JSON field as required by the response schema.`;
 
-function createCodeTranslatorClient(apiKey: string): CodeTranslatorClient {
-  const ai = new GoogleGenAI({ apiKey });
+function createCodeTranslatorClient(ai: GoogleGenAI): CodeTranslatorClient {
   return async (code, model) => {
     const response = await ai.models.generateContent({
       model,
@@ -103,8 +102,7 @@ function createCodeTranslatorClient(apiKey: string): CodeTranslatorClient {
   };
 }
 
-function createProofreaderClient(apiKey: string): ProofreaderClient {
-  const ai = new GoogleGenAI({ apiKey });
+function createProofreaderClient(ai: GoogleGenAI): ProofreaderClient {
   return async (input, model) => {
     // ソースと訳文はマークダウン（コードブロック含む）が含まれるので、フェンスで囲むと
     // 内部の ```ts 等がアウターフェンスを誤閉じして LLM が構造を見失う。XML 風タグで囲って区切る
@@ -161,8 +159,7 @@ function createProofreaderClient(apiKey: string): ProofreaderClient {
   };
 }
 
-function createGeminiClient(apiKey: string): GeminiClient {
-  const ai = new GoogleGenAI({ apiKey });
+function createGeminiClient(ai: GoogleGenAI): GeminiClient {
   return async (input, model) => {
     const userMessageParts = [`Title: ${input.title}`, '', 'Body:', input.body];
     if (input.feedback) {
@@ -263,9 +260,11 @@ async function main(): Promise<void> {
   console.log(`[auto-translate] scanning ${jaFiles.length} ja files in ${contentDir}`);
   console.log(`[auto-translate] model: ${model}`);
 
-  const client = createGeminiClient(apiKey);
-  const proofreader = createProofreaderClient(apiKey);
-  const codeTranslator = createCodeTranslatorClient(apiKey);
+  // GoogleGenAI は内部で HTTP クライアントを保持するため、3 用途で 1 インスタンスを共有する
+  const ai = new GoogleGenAI({ apiKey });
+  const client = createGeminiClient(ai);
+  const proofreader = createProofreaderClient(ai);
+  const codeTranslator = createCodeTranslatorClient(ai);
   const stats: Stats = {
     translated: 0,
     frontmatterOnly: 0,

--- a/tools/auto-translate/main.ts
+++ b/tools/auto-translate/main.ts
@@ -73,7 +73,7 @@ Rules:
 - Do NOT change identifiers, string literals, numeric literals, operators, or any non-comment content.
 - Do NOT add or remove lines. The line count of input and output MUST match exactly.
 - Do NOT change the language tag of the fence (\`\`\`ts must stay \`\`\`ts, etc.).
-- Output the entire code block, including the surrounding triple-backtick fences, with comments translated.`;
+- Place the translated code block (including the surrounding triple-backtick fences) into the \`translated_code\` JSON field as required by the response schema.`;
 
 function createCodeTranslatorClient(apiKey: string): CodeTranslatorClient {
   const ai = new GoogleGenAI({ apiKey });

--- a/tools/auto-translate/main.ts
+++ b/tools/auto-translate/main.ts
@@ -35,6 +35,11 @@ Rules for placeholders:
 - Do NOT wrap placeholders in additional backticks, brackets, or formatting.
 - When you reference a placeholder in prose (e.g., describing what the code does), refer to it by its placeholder token directly.
 
+Escape markers (⟪⟪ and ⟫⟫):
+- The source you receive may contain the literal sequences ⟪⟪ and ⟫⟫ (mathematical double angle brackets, U+27EA / U+27EB).
+- These are escape markers used internally to avoid conflicts when the source prose itself mentions ⟨⟨ / ⟩⟩.
+- Treat ⟪⟪ and ⟫⟫ as opaque verbatim text: keep them exactly as they appear, in the same positions. Do NOT translate, modify, normalize, or remove them.
+
 Other structural rules:
 - URLs and image paths: leave unchanged.
 - Bare URL paragraphs (a paragraph consisting only of a single URL) MUST remain as standalone paragraphs containing only that URL. Do NOT wrap them in prose, do NOT add surrounding sentences.
@@ -74,6 +79,7 @@ Rules:
 - Do NOT change identifiers, string literals, numeric literals, operators, or any non-comment content.
 - Do NOT add or remove lines. The line count of input and output MUST match exactly.
 - Do NOT change the language tag of the fence (\`\`\`ts must stay \`\`\`ts, etc.).
+- The code may contain the literal sequences ⟪⟪ or ⟫⟫ (escape markers used by the upstream pipeline). Keep them BYTE-FOR-BYTE in their original positions.
 - Place the translated code block (including the surrounding triple-backtick fences) into the \`translated_code\` JSON field as required by the response schema.`;
 
 function createCodeTranslatorClient(ai: GoogleGenAI): CodeTranslatorClient {

--- a/tools/auto-translate/proofreader.spec.ts
+++ b/tools/auto-translate/proofreader.spec.ts
@@ -1,0 +1,62 @@
+import { strict as assert } from 'node:assert';
+import { test, describe, mock } from 'node:test';
+import { proofread, type ProofreaderClient } from './proofreader.ts';
+
+const MODEL = 'test-model';
+
+describe('proofread', () => {
+  test('client が ok=true を返す → ok', async () => {
+    const client: ProofreaderClient = mock.fn(() => Promise.resolve({ ok: true, issues: [] }));
+    const result = await proofread({ jaSource: 'ja text', enTranslation: 'en text', client, model: MODEL });
+    assert.equal(result.ok, true);
+    assert.equal(result.issues.length, 0);
+  });
+
+  test('client が issues を返す → ok=false + issues', async () => {
+    const client: ProofreaderClient = mock.fn(() =>
+      Promise.resolve({
+        ok: false,
+        issues: [
+          {
+            location: 'paragraph 2',
+            problem: 'variable name mismatch with code',
+            suggestion: 'use waiting instead of active',
+          },
+        ],
+      }),
+    );
+    const result = await proofread({ jaSource: 'ja text', enTranslation: 'en with bug', client, model: MODEL });
+    assert.equal(result.ok, false);
+    assert.equal(result.issues.length, 1);
+    assert.equal(result.issues[0].problem, 'variable name mismatch with code');
+  });
+
+  test('client throw → ok=true（fail open: proofread 失敗で翻訳全体を止めない）', async () => {
+    const client: ProofreaderClient = mock.fn(() => Promise.reject(new Error('proofread API error')));
+    const result = await proofread({ jaSource: 'ja', enTranslation: 'en', client, model: MODEL });
+    // proofread はベストエフォート。失敗時は構造検証 OK のものをそのまま採用
+    assert.equal(result.ok, true);
+    assert.equal(result.issues.length, 0);
+  });
+});
+
+describe('formatProofIssues', () => {
+  test('空 → 空文字列', async () => {
+    const { formatProofIssues } = await import('./proofreader.ts');
+    assert.equal(formatProofIssues([]), '');
+  });
+
+  test('1 件 → location/problem/suggestion を含む', async () => {
+    const { formatProofIssues } = await import('./proofreader.ts');
+    const text = formatProofIssues([
+      {
+        location: 'paragraph 2',
+        problem: 'variable name mismatch',
+        suggestion: 'use waiting instead of active',
+      },
+    ]);
+    assert.match(text, /paragraph 2/);
+    assert.match(text, /variable name mismatch/);
+    assert.match(text, /use waiting instead of active/);
+  });
+});

--- a/tools/auto-translate/proofreader.ts
+++ b/tools/auto-translate/proofreader.ts
@@ -1,0 +1,49 @@
+// 翻訳結果に対する別人格 LLM によるセルフレビュー（校正）モジュール。
+// translator は「訳す役」、proofreader は「整合性をチェックする役」と人格を分離する。
+// 検出対象: prose と code 識別子の不整合、反転した意味、捏造、欠落、誤った固有名詞。
+
+export interface ProofIssue {
+  location: string;
+  problem: string;
+  suggestion: string;
+}
+
+export interface ProofResult {
+  ok: boolean;
+  issues: ProofIssue[];
+}
+
+export type ProofreaderClient = (
+  input: { jaSource: string; enTranslation: string },
+  model: string,
+) => Promise<ProofResult>;
+
+export interface ProofreadArgs {
+  jaSource: string;
+  enTranslation: string;
+  client: ProofreaderClient;
+  model: string;
+}
+
+export async function proofread(args: ProofreadArgs): Promise<ProofResult> {
+  try {
+    return await args.client({ jaSource: args.jaSource, enTranslation: args.enTranslation }, args.model);
+  } catch (e) {
+    // proofread はベストエフォート。失敗で翻訳全体を止めると blast radius が大きいため fail open で採用する。
+    // ただしログには残す
+    console.warn(`[auto-translate] proofreader call failed (treating as ok): ${(e as Error).message}`);
+    return { ok: true, issues: [] };
+  }
+}
+
+export function formatProofIssues(issues: ProofIssue[]): string {
+  if (issues.length === 0) return '';
+  const lines = ['Proofreader detected the following issues in the translation:'];
+  for (const i of issues) {
+    lines.push(`- [${i.location}] ${i.problem}`);
+    lines.push(`  suggested fix: ${i.suggestion}`);
+  }
+  lines.push('');
+  lines.push('Please retranslate addressing these issues. Maintain structural fidelity (code blocks unchanged, etc.).');
+  return lines.join('\n');
+}

--- a/tools/auto-translate/proofreader.ts
+++ b/tools/auto-translate/proofreader.ts
@@ -44,6 +44,10 @@ export function formatProofIssues(issues: ProofIssue[]): string {
     lines.push(`  suggested fix: ${i.suggestion}`);
   }
   lines.push('');
-  lines.push('Please retranslate addressing these issues. Maintain structural fidelity (code blocks unchanged, etc.).');
+  // 翻訳者 LLM はコードブロックを直接見ず ⟨⟨BLOCK_N⟩⟩ プレースホルダのみを受け取るため、
+  // 「code blocks unchanged」ではなくプレースホルダを明示した指示にする
+  lines.push(
+    'Please retranslate addressing these issues. Keep all placeholders ⟨⟨BLOCK_N⟩⟩ and ⟨⟨INLINE_N⟩⟩ verbatim.',
+  );
   return lines.join('\n');
 }

--- a/tools/auto-translate/proofreader.ts
+++ b/tools/auto-translate/proofreader.ts
@@ -2,6 +2,8 @@
 // translator は「訳す役」、proofreader は「整合性をチェックする役」と人格を分離する。
 // 検出対象: prose と code 識別子の不整合、反転した意味、捏造、欠落、誤った固有名詞。
 
+import { errorMessage } from './ast-utils.ts';
+
 export interface ProofIssue {
   location: string;
   problem: string;
@@ -31,7 +33,7 @@ export async function proofread(args: ProofreadArgs): Promise<ProofResult> {
   } catch (e) {
     // proofread はベストエフォート。失敗で翻訳全体を止めると blast radius が大きいため fail open で採用する。
     // ただしログには残す
-    console.warn(`[auto-translate] proofreader call failed (treating as ok): ${(e as Error).message}`);
+    console.warn(`[auto-translate] proofreader call failed (treating as ok): ${errorMessage(e)}`);
     return { ok: true, issues: [] };
   }
 }

--- a/tools/auto-translate/structure-validator.spec.ts
+++ b/tools/auto-translate/structure-validator.spec.ts
@@ -221,6 +221,23 @@ describe('validateStructure', () => {
     assert.ok(result.mismatches.some((m) => m.kind === 'blockquoteInlineCodeContent'));
   });
 
+  test('blockquote 内インラインコードが削除された → ng (inlineCodes count)', () => {
+    // count 差異は inlineCodes 全体カウントで検出される（個別の blockquoteInlineCode count check は実装しない）
+    const source = '> 引用 `foo`\n';
+    const target = '> no code\n';
+    const result = validateStructure(source, target);
+    assert.equal(result.ok, false);
+    assert.ok(result.mismatches.some((m) => m.kind === 'inlineCodes'));
+  });
+
+  test('blockquote 内インラインコードが追加された → ng (inlineCodes count)', () => {
+    const source = '> 引用文\n';
+    const target = '> Added `code` here\n';
+    const result = validateStructure(source, target);
+    assert.equal(result.ok, false);
+    assert.ok(result.mismatches.some((m) => m.kind === 'inlineCodes'));
+  });
+
   test('blockquote 内コードが追加・削除された → ng (blockquoteCodeContent, count)', () => {
     const source = '> ```ts\n> const a = 1;\n> ```\n';
     const target = '> ```ts\n> const a = 1;\n> ```\n\n> ```ts\n> const b = 2;\n> ```\n';

--- a/tools/auto-translate/structure-validator.spec.ts
+++ b/tools/auto-translate/structure-validator.spec.ts
@@ -238,6 +238,29 @@ describe('validateStructure', () => {
     assert.ok(result.mismatches.some((m) => m.kind === 'inlineCodes'));
   });
 
+  test('blockquote 内コードの言語タグが変えられた → ng (blockquoteCodeContent, content)', () => {
+    // LLM が ```ts → ```javascript と書き換えた場合の検出
+    const source = '> ```ts\n> const x = 1;\n> ```\n';
+    const target = '> ```javascript\n> const x = 1;\n> ```\n';
+    const result = validateStructure(source, target);
+    assert.equal(result.ok, false);
+    const m = result.mismatches.find((x) => x.kind === 'blockquoteCodeContent');
+    assert.ok(m);
+    assert.equal(m.differKind, 'content');
+  });
+
+  test('blockquote 内インラインコードの「移動」（blockquote 内→外）が検出される', () => {
+    // blockquote 内 `foo` + 通常 `bar` (inlineCodes=2) → blockquote 外 `foo` + 通常 `bar` (inlineCodes=2)
+    // inlineCodes 総数は同じだが blockquote 内インラインコードの count が異なる
+    const source = '> 引用 `foo`\n\n通常 `bar`\n';
+    const target = '通常 `bar` と `foo` を移動\n';
+    const result = validateStructure(source, target);
+    assert.equal(result.ok, false);
+    const m = result.mismatches.find((x) => x.kind === 'blockquoteInlineCodeContent');
+    assert.ok(m);
+    assert.equal(m.differKind, 'count');
+  });
+
   test('blockquote 内コードが追加・削除された → ng (blockquoteCodeContent, count)', () => {
     const source = '> ```ts\n> const a = 1;\n> ```\n';
     const target = '> ```ts\n> const a = 1;\n> ```\n\n> ```ts\n> const b = 2;\n> ```\n';

--- a/tools/auto-translate/structure-validator.spec.ts
+++ b/tools/auto-translate/structure-validator.spec.ts
@@ -175,6 +175,25 @@ describe('validateStructure', () => {
     assert.equal(result.ok, true);
   });
 
+  test('blockquote 内のリンク・画像・インラインコードは通常カウントに含まれる（LLM が直接扱うため）', () => {
+    const md = '> 引用文中の `foo` と [link](https://example.com) と ![img](/x.png)\n';
+    const counts = countStructure(md);
+    // blockquote 内でも image/link/inlineCode はカウント対象
+    assert.equal(counts.inlineCodes, 1);
+    assert.equal(counts.links, 1);
+    assert.equal(counts.images, 1);
+    // ただし code（コードブロック）は blockquote 内では別経路で検証されるためカウント対象外
+    assert.equal(counts.codeBlocks, 0);
+  });
+
+  test('blockquote 内のリンク数不一致を検出する', () => {
+    const source = '> [a](https://a) と [b](https://b) を参考にする\n';
+    const target = '> see [a](https://a)\n';
+    const result = validateStructure(source, target);
+    assert.equal(result.ok, false);
+    assert.ok(result.mismatches.some((m) => m.kind === 'links'));
+  });
+
   test('blockquote 内コードのコメントが翻訳されている → ng (blockquoteCodeContent)', () => {
     // blockquote 内コードは LLM が直接見るためコメントを翻訳するリスクがある。byte 一致を強制
     const source = '> ```ts\n> // 元コメント\n> const x = 1;\n> ```\n';

--- a/tools/auto-translate/structure-validator.spec.ts
+++ b/tools/auto-translate/structure-validator.spec.ts
@@ -168,22 +168,6 @@ describe('validateStructure', () => {
     assert.equal(result.ok, true);
   });
 
-  test('インラインコードが byte 一致 → ok', () => {
-    const source = 'use `decoding="async"` for X.\n';
-    const target = 'X uses `decoding="async"` here.\n';
-    const result = validateStructure(source, target);
-    assert.equal(result.ok, true);
-  });
-
-  test('インラインコードの引用符が変換されている → ng (inlineCodeContent)', () => {
-    const source = 'use `decoding="async"` for X.\n';
-    // target の右引用符は Unicode RIGHT DOUBLE QUOTATION MARK (U+201D)。詳細は前テスト参照
-    const target = 'X uses `decoding="async”` here.\n';
-    const result = validateStructure(source, target);
-    assert.equal(result.ok, false);
-    assert.ok(result.mismatches.some((m) => m.kind === 'inlineCodeContent'));
-  });
-
   test('翻訳結果に source にないインラインコードが追加されている → ng (inlineCodes count)', () => {
     const source = 'plain text\n';
     const target = 'translated `extra` text\n';

--- a/tools/auto-translate/structure-validator.spec.ts
+++ b/tools/auto-translate/structure-validator.spec.ts
@@ -205,6 +205,15 @@ describe('validateStructure', () => {
     assert.equal(m.differKind, 'content');
   });
 
+  test('blockquote 内コードの fence 種別が変えられた → ng (blockquoteCodeContent, content)', () => {
+    // remark は ``` と ~~~ を同一 code ノードに正規化するが、生 markdown レベルでは別物なので検出する
+    const source = '> ```ts\n> const x = 1;\n> ```\n';
+    const target = '> ~~~ts\n> const x = 1;\n> ~~~\n';
+    const result = validateStructure(source, target);
+    assert.equal(result.ok, false);
+    assert.ok(result.mismatches.some((m) => m.kind === 'blockquoteCodeContent'));
+  });
+
   test('blockquote 内インラインコードの内容が一致 → ok', () => {
     const source = '> 引用文中の `foo` という識別子\n';
     const target = '> Quoted text contains `foo` identifier\n';

--- a/tools/auto-translate/structure-validator.spec.ts
+++ b/tools/auto-translate/structure-validator.spec.ts
@@ -168,6 +168,22 @@ describe('validateStructure', () => {
     assert.equal(result.ok, true);
   });
 
+  test('blockquote 内コードブロックの内容が一致 → ok', () => {
+    const source = '> ```ts\n> const x = 1;\n> ```\n';
+    const target = '> ```ts\n> const x = 1;\n> ```\n';
+    const result = validateStructure(source, target);
+    assert.equal(result.ok, true);
+  });
+
+  test('blockquote 内コードのコメントが翻訳されている → ng (blockquoteCodeContent)', () => {
+    // blockquote 内コードは LLM が直接見るためコメントを翻訳するリスクがある。byte 一致を強制
+    const source = '> ```ts\n> // 元コメント\n> const x = 1;\n> ```\n';
+    const target = '> ```ts\n> // translated comment\n> const x = 1;\n> ```\n';
+    const result = validateStructure(source, target);
+    assert.equal(result.ok, false);
+    assert.ok(result.mismatches.some((m) => m.kind === 'blockquoteCodeContent'));
+  });
+
   test('翻訳結果に source にないインラインコードが追加されている → ng (inlineCodes count)', () => {
     const source = 'plain text\n';
     const target = 'translated `extra` text\n';

--- a/tools/auto-translate/structure-validator.spec.ts
+++ b/tools/auto-translate/structure-validator.spec.ts
@@ -159,29 +159,13 @@ describe('validateStructure', () => {
     assert.ok(result.mismatches.length >= 3);
   });
 
-  test('コードブロック内容が source と一致 → ok', () => {
-    const source = '```ts\nconst a = 1;\n```\n';
-    const target = '```ts\nconst a = 1;\n```\n';
-    const result = validateStructure(source, target);
-    assert.equal(result.ok, true);
-  });
-
-  test('コードブロック内容が翻訳されている → ng (codeBlockContent)', () => {
+  test('コードブロック内容の差分は許容される（コメント翻訳のため意図的に byte 差分が出る）', () => {
+    // 新アーキテクチャ: LLM はコードを見ないが、別経路でコメントだけ翻訳されて挿入される。
+    // コードブロックの内容は ja と en で byte 異なるのが正常
     const source = '```ts\n// 元のコメント\nconst a = 1;\n```\n';
     const target = '```ts\n// translated comment\nconst a = 1;\n```\n';
     const result = validateStructure(source, target);
-    assert.equal(result.ok, false);
-    assert.ok(result.mismatches.some((m) => m.kind === 'codeBlockContent'));
-  });
-
-  test('コードブロック内の引用符が変換されている → ng (codeBlockContent)', () => {
-    const source = '```html\n<img src="x" />\n```\n';
-    // target の右引用符は Unicode RIGHT DOUBLE QUOTATION MARK (U+201D)。視覚的には ASCII " と区別困難なため
-    // 編集時に誤って ASCII " に置き換えると検証ロジックを通り抜けるテストになる
-    const target = '```html\n<img src="x” />\n```\n';
-    const result = validateStructure(source, target);
-    assert.equal(result.ok, false);
-    assert.ok(result.mismatches.some((m) => m.kind === 'codeBlockContent'));
+    assert.equal(result.ok, true);
   });
 
   test('インラインコードが byte 一致 → ok', () => {

--- a/tools/auto-translate/structure-validator.spec.ts
+++ b/tools/auto-translate/structure-validator.spec.ts
@@ -194,13 +194,25 @@ describe('validateStructure', () => {
     assert.ok(result.mismatches.some((m) => m.kind === 'links'));
   });
 
-  test('blockquote 内コードのコメントが翻訳されている → ng (blockquoteCodeContent)', () => {
+  test('blockquote 内コードのコメントが翻訳されている → ng (blockquoteCodeContent, content)', () => {
     // blockquote 内コードは LLM が直接見るためコメントを翻訳するリスクがある。byte 一致を強制
     const source = '> ```ts\n> // 元コメント\n> const x = 1;\n> ```\n';
     const target = '> ```ts\n> // translated comment\n> const x = 1;\n> ```\n';
     const result = validateStructure(source, target);
     assert.equal(result.ok, false);
-    assert.ok(result.mismatches.some((m) => m.kind === 'blockquoteCodeContent'));
+    const m = result.mismatches.find((x) => x.kind === 'blockquoteCodeContent');
+    assert.ok(m);
+    assert.equal(m.differKind, 'content');
+  });
+
+  test('blockquote 内コードが追加・削除された → ng (blockquoteCodeContent, count)', () => {
+    const source = '> ```ts\n> const a = 1;\n> ```\n';
+    const target = '> ```ts\n> const a = 1;\n> ```\n\n> ```ts\n> const b = 2;\n> ```\n';
+    const result = validateStructure(source, target);
+    assert.equal(result.ok, false);
+    const m = result.mismatches.find((x) => x.kind === 'blockquoteCodeContent');
+    assert.ok(m);
+    assert.equal(m.differKind, 'count');
   });
 
   test('翻訳結果に source にないインラインコードが追加されている → ng (inlineCodes count)', () => {

--- a/tools/auto-translate/structure-validator.spec.ts
+++ b/tools/auto-translate/structure-validator.spec.ts
@@ -205,6 +205,22 @@ describe('validateStructure', () => {
     assert.equal(m.differKind, 'content');
   });
 
+  test('blockquote 内インラインコードの内容が一致 → ok', () => {
+    const source = '> 引用文中の `foo` という識別子\n';
+    const target = '> Quoted text contains `foo` identifier\n';
+    const result = validateStructure(source, target);
+    assert.equal(result.ok, true);
+  });
+
+  test('blockquote 内インラインコードの内容が改変された → ng (blockquoteInlineCodeContent)', () => {
+    const source = '> 引用文中の `foo` という識別子\n';
+    // LLM が `foo` を `bar` に変更
+    const target = '> Quoted text contains `bar` identifier\n';
+    const result = validateStructure(source, target);
+    assert.equal(result.ok, false);
+    assert.ok(result.mismatches.some((m) => m.kind === 'blockquoteInlineCodeContent'));
+  });
+
   test('blockquote 内コードが追加・削除された → ng (blockquoteCodeContent, count)', () => {
     const source = '> ```ts\n> const a = 1;\n> ```\n';
     const target = '> ```ts\n> const a = 1;\n> ```\n\n> ```ts\n> const b = 2;\n> ```\n';

--- a/tools/auto-translate/structure-validator.ts
+++ b/tools/auto-translate/structure-validator.ts
@@ -18,6 +18,12 @@ export interface StructureMismatch {
   kind: StructureMismatchKind;
   source: number;
   target: number;
+  /**
+   * blockquoteCodeContent でのみ使用:
+   * - 'count': source/target の個数自体が異なる
+   * - 'content': 個数は同じだが内容が異なる
+   */
+  differKind?: 'count' | 'content';
 }
 
 export interface ValidationResult {
@@ -68,7 +74,7 @@ function snapshotStructureInternal(markdown: string): StructureSnapshotInternal 
       // blockquote 内の code は別途内容比較対象として保持し、通常カウントには含めない
       // （別経路の byte-identical 検証で扱う）
       if (node.type === 'code') {
-        blockquoteCodeContents.push((node as { value?: string }).value ?? '');
+        blockquoteCodeContents.push(node.value);
         return;
       }
       // image / link / inlineCode は LLM が直接扱うので、blockquote 内でも通常カウントに含める。
@@ -123,14 +129,23 @@ export function validateStructure(source: string, target: string): ValidationRes
   // カウント一致は codeBlocks / inlineCodes で担保済み
 
   // blockquote 内コードはプレースホルダ化されず LLM プロンプトに直接渡るため、byte 一致を検証する。
-  // 順序を含めた完全一致を要求（contents 配列の長さ・各要素の byte 一致）
+  // 順序を含めた完全一致を要求（contents 配列の長さ・各要素の byte 一致）。
+  // count 差異と content 差異は別物なので differKind で区別する（フィードバックメッセージで使い分け）
   const srcBq = src.blockquoteCodeContents;
   const tgtBq = tgt.blockquoteCodeContents;
-  if (srcBq.length !== tgtBq.length || srcBq.some((v, i) => v !== tgtBq[i])) {
+  if (srcBq.length !== tgtBq.length) {
     mismatches.push({
       kind: 'blockquoteCodeContent',
       source: srcBq.length,
       target: tgtBq.length,
+      differKind: 'count',
+    });
+  } else if (srcBq.some((v, i) => v !== tgtBq[i])) {
+    mismatches.push({
+      kind: 'blockquoteCodeContent',
+      source: srcBq.length,
+      target: tgtBq.length,
+      differKind: 'content',
     });
   }
 

--- a/tools/auto-translate/structure-validator.ts
+++ b/tools/auto-translate/structure-validator.ts
@@ -65,11 +65,14 @@ function snapshotStructureInternal(markdown: string): StructureSnapshotInternal 
 
   visitParents(tree, (node, ancestors: Parent[]) => {
     if (isInBlockquote(ancestors)) {
-      // blockquote 内の code は別途内容比較対象として保持する
+      // blockquote 内の code は別途内容比較対象として保持し、通常カウントには含めない
+      // （別経路の byte-identical 検証で扱う）
       if (node.type === 'code') {
         blockquoteCodeContents.push((node as { value?: string }).value ?? '');
+        return;
       }
-      return;
+      // image / link / inlineCode は LLM が直接扱うので、blockquote 内でも通常カウントに含める。
+      // fall-through して下のカウントロジックへ
     }
 
     if (node.type === 'code') {

--- a/tools/auto-translate/structure-validator.ts
+++ b/tools/auto-translate/structure-validator.ts
@@ -11,7 +11,7 @@ export interface StructureCounts {
   bareUrlParagraphs: number;
 }
 
-export type StructureMismatchKind = keyof StructureCounts | 'inlineCodeContent';
+export type StructureMismatchKind = keyof StructureCounts;
 
 export interface StructureMismatch {
   kind: StructureMismatchKind;
@@ -38,9 +38,6 @@ function isBareUrlParagraph(node: Paragraph): boolean {
 
 interface StructureSnapshot {
   counts: StructureCounts;
-  // コードブロックの内容比較は実施しないため codeContents は保持しない（コメント翻訳で byte 差分が出るため）。
-  // インラインコードは識別子なので翻訳されず、引き続き byte 比較する
-  inlineCodeContents: string[];
 }
 
 // remark プロセッサはプラグイン初期化のコストがあるためモジュールレベルで一度だけ生成
@@ -53,14 +50,12 @@ function snapshotStructure(markdown: string): StructureSnapshot {
   let images = 0;
   let links = 0;
   let bareUrlParagraphs = 0;
-  const inlineCodeContents: string[] = [];
 
   visit(tree, (node, _index, parent) => {
     if (node.type === 'code') {
       codeBlocks++;
     } else if (node.type === 'inlineCode') {
       inlineCodes++;
-      inlineCodeContents.push(node.value);
     } else if (node.type === 'image') images++;
     else if (node.type === 'link') links++;
     // remark-embed と一致させるため、ルート直下の paragraph のみを bare URL paragraph として数える
@@ -71,28 +66,11 @@ function snapshotStructure(markdown: string): StructureSnapshot {
 
   return {
     counts: { codeBlocks, inlineCodes, images, links, bareUrlParagraphs },
-    inlineCodeContents,
   };
 }
 
 export function countStructure(markdown: string): StructureCounts {
   return snapshotStructure(markdown).counts;
-}
-
-// マルチセット差分: 順序を問わず、source の各要素が target に同数存在するか検証
-function diffMultiset(source: string[], target: string[]): { ok: boolean; missingFromTarget: string[] } {
-  const remaining = new Map<string, number>();
-  for (const v of target) remaining.set(v, (remaining.get(v) ?? 0) + 1);
-  const missing: string[] = [];
-  for (const v of source) {
-    const c = remaining.get(v) ?? 0;
-    if (c === 0) {
-      missing.push(v);
-    } else {
-      remaining.set(v, c - 1);
-    }
-  }
-  return { ok: missing.length === 0, missingFromTarget: missing };
 }
 
 export function validateStructure(source: string, target: string): ValidationResult {
@@ -107,23 +85,12 @@ export function validateStructure(source: string, target: string): ValidationRes
     }
   }
 
-  // コードブロックの内容比較は実施しない:
-  // 新アーキテクチャでは LLM に code を渡さず、別経路でコメントのみ翻訳してから restoreCode で挿入する。
-  // 結果としてコードブロックの byte 内容は ja と en で意図的に異なる（コメントが翻訳されているため）。
-  // カウントの一致は codeBlocks フィールドで担保済み
-
-  // インラインコードは識別子（`foo` 等）なので翻訳されない想定。byte 一致を引き続き検証する
-  if (src.counts.inlineCodes === tgt.counts.inlineCodes) {
-    const inlineDiff = diffMultiset(src.inlineCodeContents, tgt.inlineCodeContents);
-    if (!inlineDiff.ok) {
-      mismatches.push({
-        kind: 'inlineCodeContent',
-        source: src.inlineCodeContents.length,
-        target: tgt.inlineCodeContents.length,
-        detail: `inline code modified: ${JSON.stringify(inlineDiff.missingFromTarget[0]?.slice(0, 80))}`,
-      });
-    }
-  }
+  // コードブロック・インラインコードの内容比較は実施しない:
+  // 新アーキテクチャでは LLM に code を渡さず、translator 側で extractCode → restoreCode する。
+  // - コードブロック: 別経路でコメントのみ翻訳されるため byte 内容は意図的に異なる
+  // - インラインコード: ja のものを byte 一致で復元するため、validateStructure では常に一致する
+  //   （ここで内容比較しても dead code。restoreCode のテストで動作保証）
+  // カウント一致は codeBlocks / inlineCodes で担保済み
 
   return { ok: mismatches.length === 0, source: src.counts, target: tgt.counts, mismatches };
 }

--- a/tools/auto-translate/structure-validator.ts
+++ b/tools/auto-translate/structure-validator.ts
@@ -12,7 +12,7 @@ export interface StructureCounts {
   bareUrlParagraphs: number;
 }
 
-export type StructureMismatchKind = keyof StructureCounts;
+export type StructureMismatchKind = keyof StructureCounts | 'blockquoteCodeContent';
 
 export interface StructureMismatch {
   kind: StructureMismatchKind;
@@ -47,18 +47,30 @@ function isInBlockquote(ancestors: readonly Parent[]): boolean {
   return ancestors.some((a) => a.type === 'blockquote');
 }
 
-function snapshotStructure(markdown: string): StructureSnapshot {
+interface StructureSnapshotInternal {
+  counts: StructureCounts;
+  // blockquote 内コードは code-extractor で抽出されないため LLM プロンプトに直接渡る。
+  // byte-identical 保持を検証するため、内容を保持して validateStructure で比較する
+  blockquoteCodeContents: string[];
+}
+
+function snapshotStructureInternal(markdown: string): StructureSnapshotInternal {
   const tree = remarkProcessor.parse(markdown);
   let codeBlocks = 0;
   let inlineCodes = 0;
   let images = 0;
   let links = 0;
   let bareUrlParagraphs = 0;
+  const blockquoteCodeContents: string[] = [];
 
   visitParents(tree, (node, ancestors: Parent[]) => {
-    // blockquote 内の要素は code-extractor 側でも抽出対象外。
-    // ja/en 両方で同じ条件で数える限り、validateStructure の対称性は崩れない
-    if (isInBlockquote(ancestors)) return;
+    if (isInBlockquote(ancestors)) {
+      // blockquote 内の code は別途内容比較対象として保持する
+      if (node.type === 'code') {
+        blockquoteCodeContents.push((node as { value?: string }).value ?? '');
+      }
+      return;
+    }
 
     if (node.type === 'code') {
       codeBlocks++;
@@ -78,7 +90,12 @@ function snapshotStructure(markdown: string): StructureSnapshot {
 
   return {
     counts: { codeBlocks, inlineCodes, images, links, bareUrlParagraphs },
+    blockquoteCodeContents,
   };
+}
+
+function snapshotStructure(markdown: string): StructureSnapshot {
+  return { counts: snapshotStructureInternal(markdown).counts };
 }
 
 export function countStructure(markdown: string): StructureCounts {
@@ -86,8 +103,8 @@ export function countStructure(markdown: string): StructureCounts {
 }
 
 export function validateStructure(source: string, target: string): ValidationResult {
-  const src = snapshotStructure(source);
-  const tgt = snapshotStructure(target);
+  const src = snapshotStructureInternal(source);
+  const tgt = snapshotStructureInternal(target);
   const mismatches: StructureMismatch[] = [];
 
   const kinds: (keyof StructureCounts)[] = ['codeBlocks', 'inlineCodes', 'images', 'links', 'bareUrlParagraphs'];
@@ -97,12 +114,22 @@ export function validateStructure(source: string, target: string): ValidationRes
     }
   }
 
-  // コードブロック・インラインコードの内容比較は実施しない:
-  // 新アーキテクチャでは LLM に code を渡さず、translator 側で extractCode → restoreCode する。
-  // - コードブロック: 別経路でコメントのみ翻訳されるため byte 内容は意図的に異なる
-  // - インラインコード: ja のものを byte 一致で復元するため、validateStructure では常に一致する
-  //   （ここで内容比較しても dead code。restoreCode のテストで動作保証）
+  // コードブロック（blockquote 外）・インラインコードの内容比較は実施しない:
+  // - コードブロック: code-translator でコメントのみ翻訳されるため byte 内容は意図的に異なる
+  // - インラインコード: extractCode → restoreCode で ja のものを byte 一致で復元するため常に一致
   // カウント一致は codeBlocks / inlineCodes で担保済み
+
+  // blockquote 内コードはプレースホルダ化されず LLM プロンプトに直接渡るため、byte 一致を検証する。
+  // 順序を含めた完全一致を要求（contents 配列の長さ・各要素の byte 一致）
+  const srcBq = src.blockquoteCodeContents;
+  const tgtBq = tgt.blockquoteCodeContents;
+  if (srcBq.length !== tgtBq.length || srcBq.some((v, i) => v !== tgtBq[i])) {
+    mismatches.push({
+      kind: 'blockquoteCodeContent',
+      source: srcBq.length,
+      target: tgtBq.length,
+    });
+  }
 
   return { ok: mismatches.length === 0, source: src.counts, target: tgt.counts, mismatches };
 }

--- a/tools/auto-translate/structure-validator.ts
+++ b/tools/auto-translate/structure-validator.ts
@@ -13,18 +13,22 @@ export interface StructureCounts {
   bareUrlParagraphs: number;
 }
 
-export type StructureMismatchKind = keyof StructureCounts | 'blockquoteCodeContent';
+export type StructureMismatchKind = keyof StructureCounts | 'blockquoteCodeContent' | 'blockquoteInlineCodeContent';
 
 export interface StructureMismatch {
   kind: StructureMismatchKind;
+  /** ソース文書のカウント */
   source: number;
+  /** ターゲット文書のカウント */
   target: number;
   /**
-   * blockquoteCodeContent でのみ使用:
+   * `blockquoteCodeContent` でのみ使用。差異の種類を識別する:
    * - 'count': source/target の個数自体が異なる
-   * - 'content': 個数は同じだが内容が異なる
+   * - 'content': 個数は同じだが内容が異なる。`differingCount` に差異のあるブロック数が入る
    */
   differKind?: 'count' | 'content';
+  /** content 差異時のみ設定。source 全体のうち何ブロックで差異が出たか */
+  differingCount?: number;
 }
 
 export interface ValidationResult {
@@ -48,9 +52,10 @@ const remarkProcessor = remark().use(remarkGfm);
 
 interface StructureSnapshotInternal {
   counts: StructureCounts;
-  // blockquote 内コードは code-extractor で抽出されないため LLM プロンプトに直接渡る。
+  // blockquote 内のコード関連は code-extractor で抽出されないため LLM プロンプトに直接渡る。
   // byte-identical 保持を検証するため、内容を保持して validateStructure で比較する
   blockquoteCodeContents: string[];
+  blockquoteInlineCodeContents: string[];
 }
 
 function snapshotStructureInternal(markdown: string): StructureSnapshotInternal {
@@ -61,17 +66,21 @@ function snapshotStructureInternal(markdown: string): StructureSnapshotInternal 
   let links = 0;
   let bareUrlParagraphs = 0;
   const blockquoteCodeContents: string[] = [];
+  const blockquoteInlineCodeContents: string[] = [];
 
   visitParents(tree, (node, ancestors: Parent[]) => {
     if (hasBlockquoteAncestor(ancestors)) {
-      // blockquote 内の code は別途内容比較対象として保持し、通常カウントには含めない
-      // （別経路の byte-identical 検証で扱う）
+      // blockquote 内の code は通常カウント対象外、別経路で byte-identical 検証
       if (node.type === 'code') {
         blockquoteCodeContents.push(node.value);
         return;
       }
-      // image / link / inlineCode は LLM が直接扱うので、blockquote 内でも通常カウントに含める。
-      // fall-through して下のカウントロジックへ
+      // blockquote 内のインラインコードは通常カウントにも含めるが、
+      // code-extractor も抽出対象外で LLM が直接扱うため、内容も別途 byte 比較する
+      if (node.type === 'inlineCode') {
+        blockquoteInlineCodeContents.push(node.value);
+        // fall-through して通常 inlineCodes カウントもインクリメント
+      }
     }
 
     if (node.type === 'code') {
@@ -93,6 +102,7 @@ function snapshotStructureInternal(markdown: string): StructureSnapshotInternal 
   return {
     counts: { codeBlocks, inlineCodes, images, links, bareUrlParagraphs },
     blockquoteCodeContents,
+    blockquoteInlineCodeContents,
   };
 }
 
@@ -135,12 +145,31 @@ export function validateStructure(source: string, target: string): ValidationRes
     if (differingIndices.length > 0) {
       mismatches.push({
         kind: 'blockquoteCodeContent',
-        source: differingIndices.length, // content 差異時の source/target は「差異のあるブロック数」「全体ブロック数」
-        target: srcBq.length,
+        source: srcBq.length,
+        target: tgtBq.length,
         differKind: 'content',
+        differingCount: differingIndices.length,
       });
     }
   }
+
+  // blockquote 内インラインコードも code-extractor で抽出されないため LLM が直接扱う。
+  // 内容を byte 比較する（順序依存）。inlineCodes の通常カウントは別途検証済み
+  const srcBqInline = src.blockquoteInlineCodeContents;
+  const tgtBqInline = tgt.blockquoteInlineCodeContents;
+  if (srcBqInline.length === tgtBqInline.length) {
+    const differingInline = srcBqInline.map((v, i) => (v !== tgtBqInline[i] ? i : -1)).filter((i) => i >= 0);
+    if (differingInline.length > 0) {
+      mismatches.push({
+        kind: 'blockquoteInlineCodeContent',
+        source: srcBqInline.length,
+        target: tgtBqInline.length,
+        differKind: 'content',
+        differingCount: differingInline.length,
+      });
+    }
+  }
+  // count 差異は inlineCodes 全体カウントで検出されるため、ここでは検出不要
 
   return { ok: mismatches.length === 0, source: src.counts, target: tgt.counts, mismatches };
 }

--- a/tools/auto-translate/structure-validator.ts
+++ b/tools/auto-translate/structure-validator.ts
@@ -18,7 +18,6 @@ export interface StructureMismatch {
   kind: StructureMismatchKind;
   source: number;
   target: number;
-  detail?: string;
 }
 
 export interface ValidationResult {

--- a/tools/auto-translate/structure-validator.ts
+++ b/tools/auto-translate/structure-validator.ts
@@ -72,7 +72,10 @@ function snapshotStructureInternal(markdown: string): StructureSnapshotInternal 
     if (hasBlockquoteAncestor(ancestors)) {
       // blockquote 内の code は通常カウント対象外、別経路で byte-identical 検証
       if (node.type === 'code') {
-        blockquoteCodeContents.push(node.value);
+        // 言語タグ (node.lang) も byte 比較対象に含める。LLM が ```ts → ```javascript と
+        // 書き換えても検出できるよう、{lang}:\n{value} の形式で連結する
+        const lang = node.lang ?? '';
+        blockquoteCodeContents.push(`${lang}:\n${node.value}`);
         return;
       }
       // blockquote 内のインラインコードは通常カウントにも含めるが、
@@ -154,10 +157,19 @@ export function validateStructure(source: string, target: string): ValidationRes
   }
 
   // blockquote 内インラインコードも code-extractor で抽出されないため LLM が直接扱う。
-  // 内容を byte 比較する（順序依存）。inlineCodes の通常カウントは別途検証済み
+  // 内容を byte 比較する（順序依存）。
+  // count 差異も明示的に報告する: blockquote 内/外でインラインコードが移動するケース
+  // （例: blockquote 内 `foo` 削除 + 外で 1 個追加で総数同じ）は inlineCodes カウントだけでは検出できない
   const srcBqInline = src.blockquoteInlineCodeContents;
   const tgtBqInline = tgt.blockquoteInlineCodeContents;
-  if (srcBqInline.length === tgtBqInline.length) {
+  if (srcBqInline.length !== tgtBqInline.length) {
+    mismatches.push({
+      kind: 'blockquoteInlineCodeContent',
+      source: srcBqInline.length,
+      target: tgtBqInline.length,
+      differKind: 'count',
+    });
+  } else {
     const differingInline = srcBqInline.map((v, i) => (v !== tgtBqInline[i] ? i : -1)).filter((i) => i >= 0);
     if (differingInline.length > 0) {
       mismatches.push({
@@ -169,7 +181,6 @@ export function validateStructure(source: string, target: string): ValidationRes
       });
     }
   }
-  // count 差異は inlineCodes 全体カウントで検出されるため、ここでは検出不要
 
   return { ok: mismatches.length === 0, source: src.counts, target: tgt.counts, mismatches };
 }

--- a/tools/auto-translate/structure-validator.ts
+++ b/tools/auto-translate/structure-validator.ts
@@ -1,7 +1,8 @@
 import { remark } from 'remark';
 import remarkGfm from 'remark-gfm';
 import type { Paragraph } from 'mdast';
-import { visit } from 'unist-util-visit';
+import type { Parent } from 'unist';
+import { visitParents } from 'unist-util-visit-parents';
 
 export interface StructureCounts {
   codeBlocks: number;
@@ -43,6 +44,10 @@ interface StructureSnapshot {
 // remark プロセッサはプラグイン初期化のコストがあるためモジュールレベルで一度だけ生成
 const remarkProcessor = remark().use(remarkGfm);
 
+function isInBlockquote(ancestors: readonly Parent[]): boolean {
+  return ancestors.some((a) => a.type === 'blockquote');
+}
+
 function snapshotStructure(markdown: string): StructureSnapshot {
   const tree = remarkProcessor.parse(markdown);
   let codeBlocks = 0;
@@ -51,7 +56,11 @@ function snapshotStructure(markdown: string): StructureSnapshot {
   let links = 0;
   let bareUrlParagraphs = 0;
 
-  visit(tree, (node, _index, parent) => {
+  visitParents(tree, (node, ancestors: Parent[]) => {
+    // blockquote 内の要素は code-extractor 側でも抽出対象外。
+    // ja/en 両方で同じ条件で数える限り、validateStructure の対称性は崩れない
+    if (isInBlockquote(ancestors)) return;
+
     if (node.type === 'code') {
       codeBlocks++;
     } else if (node.type === 'inlineCode') {
@@ -59,7 +68,11 @@ function snapshotStructure(markdown: string): StructureSnapshot {
     } else if (node.type === 'image') images++;
     else if (node.type === 'link') links++;
     // remark-embed と一致させるため、ルート直下の paragraph のみを bare URL paragraph として数える
-    else if (node.type === 'paragraph' && parent?.type === 'root' && isBareUrlParagraph(node)) {
+    else if (
+      node.type === 'paragraph' &&
+      ancestors[ancestors.length - 1]?.type === 'root' &&
+      isBareUrlParagraph(node)
+    ) {
       bareUrlParagraphs++;
     }
   });

--- a/tools/auto-translate/structure-validator.ts
+++ b/tools/auto-translate/structure-validator.ts
@@ -6,7 +6,12 @@ import { visitParents } from 'unist-util-visit-parents';
 import { hasBlockquoteAncestor } from './ast-utils.ts';
 
 export interface StructureCounts {
+  /**
+   * blockquote 外のコードブロック数のみ。
+   * blockquote 内コードブロックは別途 blockquoteCodeContents で内容比較される
+   */
   codeBlocks: number;
+  /** インラインコード総数（blockquote 内外両方を含む） */
   inlineCodes: number;
   images: number;
   links: number;

--- a/tools/auto-translate/structure-validator.ts
+++ b/tools/auto-translate/structure-validator.ts
@@ -3,6 +3,7 @@ import remarkGfm from 'remark-gfm';
 import type { Paragraph } from 'mdast';
 import type { Parent } from 'unist';
 import { visitParents } from 'unist-util-visit-parents';
+import { hasBlockquoteAncestor } from './ast-utils.ts';
 
 export interface StructureCounts {
   codeBlocks: number;
@@ -42,16 +43,8 @@ function isBareUrlParagraph(node: Paragraph): boolean {
   return linkText === link.url;
 }
 
-interface StructureSnapshot {
-  counts: StructureCounts;
-}
-
 // remark プロセッサはプラグイン初期化のコストがあるためモジュールレベルで一度だけ生成
 const remarkProcessor = remark().use(remarkGfm);
-
-function isInBlockquote(ancestors: readonly Parent[]): boolean {
-  return ancestors.some((a) => a.type === 'blockquote');
-}
 
 interface StructureSnapshotInternal {
   counts: StructureCounts;
@@ -70,7 +63,7 @@ function snapshotStructureInternal(markdown: string): StructureSnapshotInternal 
   const blockquoteCodeContents: string[] = [];
 
   visitParents(tree, (node, ancestors: Parent[]) => {
-    if (isInBlockquote(ancestors)) {
+    if (hasBlockquoteAncestor(ancestors)) {
       // blockquote 内の code は別途内容比較対象として保持し、通常カウントには含めない
       // （別経路の byte-identical 検証で扱う）
       if (node.type === 'code') {
@@ -103,12 +96,8 @@ function snapshotStructureInternal(markdown: string): StructureSnapshotInternal 
   };
 }
 
-function snapshotStructure(markdown: string): StructureSnapshot {
-  return { counts: snapshotStructureInternal(markdown).counts };
-}
-
 export function countStructure(markdown: string): StructureCounts {
-  return snapshotStructure(markdown).counts;
+  return snapshotStructureInternal(markdown).counts;
 }
 
 export function validateStructure(source: string, target: string): ValidationResult {

--- a/tools/auto-translate/structure-validator.ts
+++ b/tools/auto-translate/structure-validator.ts
@@ -119,7 +119,8 @@ export function validateStructure(source: string, target: string): ValidationRes
 
   // blockquote 内コードはプレースホルダ化されず LLM プロンプトに直接渡るため、byte 一致を検証する。
   // 順序を含めた完全一致を要求（contents 配列の長さ・各要素の byte 一致）。
-  // count 差異と content 差異は別物なので differKind で区別する（フィードバックメッセージで使い分け）
+  // count 差異と content 差異は別物なので differKind で区別する（フィードバックメッセージで使い分け）。
+  // content 差異の場合は差異件数を source/target に格納して LLM が修正範囲を把握できるようにする
   const srcBq = src.blockquoteCodeContents;
   const tgtBq = tgt.blockquoteCodeContents;
   if (srcBq.length !== tgtBq.length) {
@@ -129,13 +130,16 @@ export function validateStructure(source: string, target: string): ValidationRes
       target: tgtBq.length,
       differKind: 'count',
     });
-  } else if (srcBq.some((v, i) => v !== tgtBq[i])) {
-    mismatches.push({
-      kind: 'blockquoteCodeContent',
-      source: srcBq.length,
-      target: tgtBq.length,
-      differKind: 'content',
-    });
+  } else {
+    const differingIndices = srcBq.map((v, i) => (v !== tgtBq[i] ? i : -1)).filter((i) => i >= 0);
+    if (differingIndices.length > 0) {
+      mismatches.push({
+        kind: 'blockquoteCodeContent',
+        source: differingIndices.length, // content 差異時の source/target は「差異のあるブロック数」「全体ブロック数」
+        target: srcBq.length,
+        differKind: 'content',
+      });
+    }
   }
 
   return { ok: mismatches.length === 0, source: src.counts, target: tgt.counts, mismatches };

--- a/tools/auto-translate/structure-validator.ts
+++ b/tools/auto-translate/structure-validator.ts
@@ -77,10 +77,21 @@ function snapshotStructureInternal(markdown: string): StructureSnapshotInternal 
     if (hasBlockquoteAncestor(ancestors)) {
       // blockquote 内の code は通常カウント対象外、別経路で byte-identical 検証
       if (node.type === 'code') {
-        // 言語タグ (node.lang) も byte 比較対象に含める。LLM が ```ts → ```javascript と
-        // 書き換えても検出できるよう、{lang}:\n{value} の形式で連結する
+        // 言語タグ (node.lang) と fence 種別 (``` か ~~~) も比較対象に含める。
+        // LLM が ```ts → ```javascript / ```ts → ~~~ts のように書き換えても検出できる。
+        // remark は ``` と ~~~ を同一 code ノードに正規化するため、AST 値だけでは fence 種別の差を見抜けない。
+        // markdown.slice() で生テキストを取得して fence 文字を判定する
         const lang = node.lang ?? '';
-        blockquoteCodeContents.push(`${lang}:\n${node.value}`);
+        const startOffset = node.position?.start.offset;
+        const endOffset = node.position?.end.offset;
+        let fenceChar = '`';
+        if (startOffset != null && endOffset != null) {
+          // blockquote 内では `> ` プレフィックスが混じるため、最初の ` または ~ を探す
+          const raw = markdown.slice(startOffset, endOffset);
+          const m = /[`~]/.exec(raw);
+          if (m) fenceChar = m[0];
+        }
+        blockquoteCodeContents.push(`${fenceChar}:${lang}:\n${node.value}`);
         return;
       }
       // blockquote 内のインラインコードは通常カウントにも含めるが、

--- a/tools/auto-translate/structure-validator.ts
+++ b/tools/auto-translate/structure-validator.ts
@@ -11,7 +11,7 @@ export interface StructureCounts {
   bareUrlParagraphs: number;
 }
 
-export type StructureMismatchKind = keyof StructureCounts | 'codeBlockContent' | 'inlineCodeContent';
+export type StructureMismatchKind = keyof StructureCounts | 'inlineCodeContent';
 
 export interface StructureMismatch {
   kind: StructureMismatchKind;
@@ -38,7 +38,8 @@ function isBareUrlParagraph(node: Paragraph): boolean {
 
 interface StructureSnapshot {
   counts: StructureCounts;
-  codeContents: string[];
+  // コードブロックの内容比較は実施しないため codeContents は保持しない（コメント翻訳で byte 差分が出るため）。
+  // インラインコードは識別子なので翻訳されず、引き続き byte 比較する
   inlineCodeContents: string[];
 }
 
@@ -52,13 +53,11 @@ function snapshotStructure(markdown: string): StructureSnapshot {
   let images = 0;
   let links = 0;
   let bareUrlParagraphs = 0;
-  const codeContents: string[] = [];
   const inlineCodeContents: string[] = [];
 
   visit(tree, (node, _index, parent) => {
     if (node.type === 'code') {
       codeBlocks++;
-      codeContents.push(node.value);
     } else if (node.type === 'inlineCode') {
       inlineCodes++;
       inlineCodeContents.push(node.value);
@@ -72,7 +71,6 @@ function snapshotStructure(markdown: string): StructureSnapshot {
 
   return {
     counts: { codeBlocks, inlineCodes, images, links, bareUrlParagraphs },
-    codeContents,
     inlineCodeContents,
   };
 }

--- a/tools/auto-translate/structure-validator.ts
+++ b/tools/auto-translate/structure-validator.ts
@@ -109,20 +109,12 @@ export function validateStructure(source: string, target: string): ValidationRes
     }
   }
 
-  // コードブロックの中身は byte 単位で source と一致しなければならない（コメント翻訳・引用符変換等を検出）
-  if (src.counts.codeBlocks === tgt.counts.codeBlocks) {
-    const diff = diffMultiset(src.codeContents, tgt.codeContents);
-    if (!diff.ok) {
-      mismatches.push({
-        kind: 'codeBlockContent',
-        source: src.codeContents.length,
-        target: tgt.codeContents.length,
-        detail: `code block content modified: ${JSON.stringify(diff.missingFromTarget[0]?.slice(0, 80))}`,
-      });
-    }
-  }
+  // コードブロックの内容比較は実施しない:
+  // 新アーキテクチャでは LLM に code を渡さず、別経路でコメントのみ翻訳してから restoreCode で挿入する。
+  // 結果としてコードブロックの byte 内容は ja と en で意図的に異なる（コメントが翻訳されているため）。
+  // カウントの一致は codeBlocks フィールドで担保済み
 
-  // インラインコードも同様（カウント一致時のみ content チェック。カウント不一致は inlineCodes で報告済み）
+  // インラインコードは識別子（`foo` 等）なので翻訳されない想定。byte 一致を引き続き検証する
   if (src.counts.inlineCodes === tgt.counts.inlineCodes) {
     const inlineDiff = diffMultiset(src.inlineCodeContents, tgt.inlineCodeContents);
     if (!inlineDiff.ok) {

--- a/tools/auto-translate/translator.spec.ts
+++ b/tools/auto-translate/translator.spec.ts
@@ -462,6 +462,39 @@ describe('translateOne', () => {
       assert.equal(result.kind, 'translated');
     });
 
+    test('実コメント翻訳シナリオ（ja コメント → en コメント）で proofreader が ok を返し採用される', async () => {
+      // 「ja に日本語コメント入りコード、en に英語コメント入りコード」という本番運用パスを再現。
+      // proofreader 指示文は「コードコメントの差分は flag するな」と明記しているため、
+      // 翻訳済みコメントを見ても false-positive を生成せず採用されることを確認する
+      const jaWithJaComment = buildJaContent({
+        body: '前文。\n\n```ts\n// 日本語コメント\nconst x = 1;\n```\n',
+      });
+      // codeTranslator が実際にコメントを翻訳
+      const codeTranslatorClient: CodeTranslatorClient = mock.fn((code) =>
+        Promise.resolve(code.replace('// 日本語コメント', '// English comment')),
+      );
+      // translator (Gemini) は prose 翻訳のみ、コードはプレースホルダで保持
+      const geminiClient: GeminiClient = mock.fn(() =>
+        Promise.resolve({
+          title_en: 'Title',
+          body_en: 'Preface.\n\n⟨⟨BLOCK_0⟩⟩\n',
+        }),
+      );
+      // proofreader: 翻訳済みコメントを見て「コメント差分は flag しない」運用が正しく動くか
+      let proofCalls = 0;
+      const proofreaderClient: ProofreaderClient = mock.fn((input) => {
+        proofCalls++;
+        // 渡される en には英訳済みコメントが入っているはず
+        assert.match(input.enTranslation, /\/\/ English comment/);
+        return Promise.resolve({ ok: true, issues: [] });
+      });
+      const result = await translateOne(
+        makeArgs({ jaContent: jaWithJaComment, geminiClient, codeTranslatorClient, proofreaderClient }),
+      );
+      assert.equal(result.kind, 'translated');
+      assert.equal(proofCalls, 1);
+    });
+
     test('proofreader が throw → fail open で採用される（翻訳全体は止まらない）', async () => {
       const geminiClient = makeOkClient();
       const proofreaderClient: ProofreaderClient = mock.fn(() => Promise.reject(new Error('proofread API down')));

--- a/tools/auto-translate/translator.spec.ts
+++ b/tools/auto-translate/translator.spec.ts
@@ -11,6 +11,10 @@ import {
   type TranslateOneArgs,
 } from './translator.ts';
 import { buildEnFrontmatter } from './frontmatter.ts';
+import type { ProofreaderClient } from './proofreader.ts';
+
+// テスト用デフォルト proofreader: 常に ok を返す（proofread の動作はそれ自身の spec で検証）
+const okProofreader: ProofreaderClient = () => Promise.resolve({ ok: true, issues: [] });
 
 const MODEL = 'test-model';
 
@@ -202,6 +206,7 @@ describe('translateOne', () => {
       jaContent: JA_CONTENT_BASIC,
       enContent: null,
       geminiClient: makeOkClient(),
+      proofreaderClient: okProofreader,
       model: MODEL,
       ...overrides,
     };
@@ -328,6 +333,61 @@ describe('translateOne', () => {
       // 数値だけでなく具体的な差分内容（detail）が含まれている
       assert.match(feedback, /codeBlockContent/);
       assert.match(feedback, /code block content modified/);
+    });
+  });
+
+  describe('proofread リトライ', () => {
+    test('proofread が ng → 2 回目で ok → 採用、translate 呼び出し 2 回 + proofread 呼び出し 2 回', async () => {
+      const geminiClient = makeOkClient();
+      let proofCount = 0;
+      const proofreaderClient: ProofreaderClient = mock.fn(() => {
+        proofCount++;
+        if (proofCount === 1) {
+          return Promise.resolve({
+            ok: false,
+            issues: [{ location: 'p2', problem: 'wrong variable name', suggestion: 'use waiting not active' }],
+          });
+        }
+        return Promise.resolve({ ok: true, issues: [] });
+      });
+      const result = await translateOne(makeArgs({ geminiClient, proofreaderClient }));
+      assert.equal(result.kind, 'translated');
+      assert.equal((geminiClient as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 2);
+      assert.equal((proofreaderClient as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 2);
+    });
+
+    test('proofread が常に ng → 4 試行後 failed', async () => {
+      const geminiClient = makeOkClient();
+      const proofreaderClient: ProofreaderClient = mock.fn(() =>
+        Promise.resolve({
+          ok: false,
+          issues: [{ location: 'p1', problem: 'persistent', suggestion: 'fix' }],
+        }),
+      );
+      const result = await translateOne(makeArgs({ geminiClient, proofreaderClient }));
+      assert.equal(result.kind, 'failed');
+      assert.equal((geminiClient as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 4);
+      assert.equal((proofreaderClient as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 4);
+    });
+
+    test('構造検証 NG の attempt では proofread を呼ばない（ローカル検証で先に reject）', async () => {
+      let count = 0;
+      const geminiClient: GeminiClient = mock.fn(() => {
+        count++;
+        if (count === 1) return Promise.resolve({ title_en: 'Title', body_en: TRANSLATED_BODY_BROKEN });
+        return Promise.resolve({ title_en: 'Title', body_en: TRANSLATED_BODY_OK });
+      });
+      const proofreaderClient: ProofreaderClient = mock.fn(() => Promise.resolve({ ok: true, issues: [] }));
+      await translateOne(makeArgs({ geminiClient, proofreaderClient }));
+      // 1 回目は構造 NG なので proofread 呼ばれない、2 回目で proofread 呼ばれる
+      assert.equal((proofreaderClient as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 1);
+    });
+
+    test('proofreader が throw → fail open で採用される（翻訳全体は止まらない）', async () => {
+      const geminiClient = makeOkClient();
+      const proofreaderClient: ProofreaderClient = mock.fn(() => Promise.reject(new Error('proofread API down')));
+      const result = await translateOne(makeArgs({ geminiClient, proofreaderClient }));
+      assert.equal(result.kind, 'translated');
     });
   });
 

--- a/tools/auto-translate/translator.spec.ts
+++ b/tools/auto-translate/translator.spec.ts
@@ -274,7 +274,7 @@ describe('translateOne', () => {
     });
   });
 
-  describe('構造検証とリトライ', () => {
+  describe('リトライパス（placeholder/structure/proofread）', () => {
     test('1 回目 OK → そのまま採用、API 呼び出し 1 回', async () => {
       const client = makeOkClient();
       const result = await translateOne(makeArgs({ geminiClient: client }));
@@ -282,7 +282,7 @@ describe('translateOne', () => {
       assert.equal((client as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 1);
     });
 
-    test('2 回連続 NG → 3 回目 OK → 採用、API 呼び出し 3 回', async () => {
+    test('placeholder 復元 NG が 2 回連続 → 3 回目 OK → 採用、API 呼び出し 3 回', async () => {
       let count = 0;
       const client: GeminiClient = mock.fn(() => {
         count++;
@@ -294,7 +294,7 @@ describe('translateOne', () => {
       assert.equal((client as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 3);
     });
 
-    test('1 回目 NG → 2 回目 OK → 採用、API 呼び出し 2 回', async () => {
+    test('placeholder 復元 1 回目 NG → 2 回目 OK → 採用、API 呼び出し 2 回', async () => {
       let count = 0;
       const client: GeminiClient = mock.fn(() => {
         count++;
@@ -306,7 +306,7 @@ describe('translateOne', () => {
       assert.equal((client as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 2);
     });
 
-    test('4 試行全て NG → failed、API 呼び出し 4 回', async () => {
+    test('placeholder 復元 4 試行全て NG → failed、API 呼び出し 4 回', async () => {
       const client: GeminiClient = mock.fn(() =>
         Promise.resolve({ title_en: 'Title', body_en: TRANSLATED_BODY_BROKEN }),
       );
@@ -551,6 +551,20 @@ describe('translateOne', () => {
       const secondIdx = result.enContent.indexOf('// second block');
       assert.ok(firstIdx > 0);
       assert.ok(secondIdx > firstIdx);
+    });
+  });
+
+  describe('extractCode 例外（escape 文字衝突）の伝播', () => {
+    test('ja に予約 escape 文字 ⟪⟪ が含まれる → translateOne は failed を返し API は呼ばれない', async () => {
+      const jaWithReserved = buildJaContent({
+        body: 'reserved char ⟪⟪ marker\n\n```ts\nconst x = 1;\n```\n',
+      });
+      const geminiClient = makeOkClient();
+      const result = await translateOne(makeArgs({ jaContent: jaWithReserved, geminiClient }));
+      assert.equal(result.kind, 'failed');
+      assert.ok('reason' in result && result.reason.includes('reserved escape sequence'));
+      // extractCode は callWithRetries の冒頭で実行されるため、API は一切呼ばれない
+      assert.equal((geminiClient as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 0);
     });
   });
 

--- a/tools/auto-translate/translator.spec.ts
+++ b/tools/auto-translate/translator.spec.ts
@@ -331,6 +331,44 @@ describe('translateOne', () => {
       assert.match(feedback, /code/i);
     });
 
+    test('構造検証 NG（プレースホルダは保持されたが prose の bare URL paragraph が消失）→ リトライで復旧', async () => {
+      // プレースホルダを保持しているので restoreCode は通過する。が、ja の bareUrlParagraphs 数が
+      // 合わず validateStructure が ng を返す → buildFeedback でリトライ
+      const calls: { feedback?: string }[] = [];
+      let count = 0;
+      const client: GeminiClient = mock.fn((input) => {
+        calls.push({ feedback: input.feedback });
+        count++;
+        if (count === 1) {
+          // bare URL paragraph (https://example.com の単独行) が prose に巻き込まれた
+          return Promise.resolve({
+            title_en: 'Title',
+            body_en: 'Paragraph 1.\n\n⟨⟨BLOCK_0⟩⟩\n\nSee this link: https://example.com here.\n',
+          });
+        }
+        return Promise.resolve({ title_en: 'Title', body_en: TRANSLATED_BODY_OK_TEMPLATE });
+      });
+      const result = await translateOne(makeArgs({ geminiClient: client }));
+      assert.equal(result.kind, 'translated');
+      assert.equal((client as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 2);
+      // 2 回目の feedback は buildFeedback 由来（structure mismatch の説明を含む）
+      assert.ok(calls[1].feedback);
+      assert.match(calls[1].feedback, /bareUrlParagraphs|structural/i);
+    });
+
+    test('構造検証が継続失敗 → failed.reason に "structure validation failed" が含まれる', async () => {
+      // プレースホルダは保持するが bareUrlParagraphs カウントが常に合わない出力を返す
+      const client: GeminiClient = mock.fn(() =>
+        Promise.resolve({
+          title_en: 'Title',
+          body_en: 'Paragraph.\n\n⟨⟨BLOCK_0⟩⟩\n\nSee link https://example.com here.\n',
+        }),
+      );
+      const result = await translateOne(makeArgs({ geminiClient: client }));
+      assert.equal(result.kind, 'failed');
+      assert.ok('reason' in result && result.reason.includes('structure validation failed'));
+    });
+
     test('placeholder drop（LLM がプレースホルダを消失） → リトライで復旧', async () => {
       // 新アーキテクチャ: LLM には code を見せず ⟨⟨BLOCK_N⟩⟩ のみ渡す。LLM がプレースホルダを drop した場合、
       // restoreCode が throw して translator が retry する

--- a/tools/auto-translate/translator.spec.ts
+++ b/tools/auto-translate/translator.spec.ts
@@ -441,6 +441,27 @@ describe('translateOne', () => {
       assert.equal((proofreaderClient as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 1);
     });
 
+    test('proofreader が ok=false かつ issues=[] → accept（fail-open: feedback なしでリトライしても無意味）', async () => {
+      const geminiClient = makeOkClient();
+      const proofreaderClient: ProofreaderClient = mock.fn(() => Promise.resolve({ ok: false, issues: [] }));
+      const result = await translateOne(makeArgs({ geminiClient, proofreaderClient }));
+      assert.equal(result.kind, 'translated');
+      // 1 回で採用される（リトライ消費しない）
+      assert.equal((geminiClient as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 1);
+    });
+
+    test('proofreader が ok=true かつ issues 非空 → accept（proofreader 自身の判断を尊重）', async () => {
+      const geminiClient = makeOkClient();
+      const proofreaderClient: ProofreaderClient = mock.fn(() =>
+        Promise.resolve({
+          ok: true,
+          issues: [{ location: 'p1', problem: 'minor', suggestion: 'no action' }],
+        }),
+      );
+      const result = await translateOne(makeArgs({ geminiClient, proofreaderClient }));
+      assert.equal(result.kind, 'translated');
+    });
+
     test('proofreader が throw → fail open で採用される（翻訳全体は止まらない）', async () => {
       const geminiClient = makeOkClient();
       const proofreaderClient: ProofreaderClient = mock.fn(() => Promise.reject(new Error('proofread API down')));

--- a/tools/auto-translate/translator.spec.ts
+++ b/tools/auto-translate/translator.spec.ts
@@ -562,8 +562,10 @@ describe('translateOne', () => {
       const geminiClient = makeOkClient();
       const result = await translateOne(makeArgs({ jaContent: jaWithReserved, geminiClient }));
       assert.equal(result.kind, 'failed');
+      // extractCode の専用 failure reason として返される（unexpected error ではない）
+      assert.ok('reason' in result && result.reason.startsWith('code extraction failed'));
       assert.ok('reason' in result && result.reason.includes('reserved escape sequence'));
-      // extractCode は callWithRetries の冒頭で実行されるため、API は一切呼ばれない
+      // extractCode は translateOne 内で実行されるため、API は一切呼ばれない
       assert.equal((geminiClient as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 0);
     });
   });

--- a/tools/auto-translate/translator.spec.ts
+++ b/tools/auto-translate/translator.spec.ts
@@ -12,9 +12,12 @@ import {
 } from './translator.ts';
 import { buildEnFrontmatter } from './frontmatter.ts';
 import type { ProofreaderClient } from './proofreader.ts';
+import type { CodeTranslatorClient } from './code-translator.ts';
 
 // テスト用デフォルト proofreader: 常に ok を返す（proofread の動作はそれ自身の spec で検証）
 const okProofreader: ProofreaderClient = () => Promise.resolve({ ok: true, issues: [] });
+// テスト用デフォルト codeTranslator: 入力をそのまま返す（コメント翻訳しない = no-op）
+const noopCodeTranslator: CodeTranslatorClient = (code) => Promise.resolve(code);
 
 const MODEL = 'test-model';
 
@@ -38,6 +41,16 @@ const a = 1;
 https://example.com
 `;
 
+// 翻訳結果は placeholder protocol に従う:
+// LLM は code を見ず ⟨⟨BLOCK_N⟩⟩ ⟨⟨INLINE_N⟩⟩ をそのまま返す。translator が restoreCode で復元する
+const TRANSLATED_BODY_OK_TEMPLATE = `Paragraph 1.
+
+⟨⟨BLOCK_0⟩⟩
+
+https://example.com
+`;
+
+// restore 後の最終形（テストの期待値として使用）
 const TRANSLATED_BODY_OK = `Paragraph 1.
 
 \`\`\`ts
@@ -47,6 +60,7 @@ const a = 1;
 https://example.com
 `;
 
+// 構造破壊された翻訳: code block placeholder ⟨⟨BLOCK_0⟩⟩ を消失させた
 const TRANSLATED_BODY_BROKEN = `Paragraph 1 with code: const a = 1; included.
 
 https://example.com
@@ -92,7 +106,9 @@ function buildEnContent(bodyHash: string, body = TRANSLATED_BODY_OK, extraFm: Re
   return joinFrontmatter(fm, body);
 }
 
-function makeOkClient(output = { title_en: 'Title', body_en: TRANSLATED_BODY_OK }): GeminiClient {
+// LLM 動作のモック: 受け取った body はプレースホルダ入り。返り値もプレースホルダ入りで返す
+// （実 LLM の契約: ⟨⟨BLOCK_N⟩⟩ などをそのまま preserve する）
+function makeOkClient(output = { title_en: 'Title', body_en: TRANSLATED_BODY_OK_TEMPLATE }): GeminiClient {
   return mock.fn(() => Promise.resolve(output));
 }
 
@@ -207,6 +223,7 @@ describe('translateOne', () => {
       enContent: null,
       geminiClient: makeOkClient(),
       proofreaderClient: okProofreader,
+      codeTranslatorClient: noopCodeTranslator,
       model: MODEL,
       ...overrides,
     };
@@ -270,7 +287,7 @@ describe('translateOne', () => {
       const client: GeminiClient = mock.fn(() => {
         count++;
         if (count <= 2) return Promise.resolve({ title_en: 'Title', body_en: TRANSLATED_BODY_BROKEN });
-        return Promise.resolve({ title_en: 'Title', body_en: TRANSLATED_BODY_OK });
+        return Promise.resolve({ title_en: 'Title', body_en: TRANSLATED_BODY_OK_TEMPLATE });
       });
       const result = await translateOne(makeArgs({ geminiClient: client }));
       assert.equal(result.kind, 'translated');
@@ -282,7 +299,7 @@ describe('translateOne', () => {
       const client: GeminiClient = mock.fn(() => {
         count++;
         if (count === 1) return Promise.resolve({ title_en: 'Title', body_en: TRANSLATED_BODY_BROKEN });
-        return Promise.resolve({ title_en: 'Title', body_en: TRANSLATED_BODY_OK });
+        return Promise.resolve({ title_en: 'Title', body_en: TRANSLATED_BODY_OK_TEMPLATE });
       });
       const result = await translateOne(makeArgs({ geminiClient: client }));
       assert.equal(result.kind, 'translated');
@@ -305,7 +322,7 @@ describe('translateOne', () => {
         calls.push({ feedback: input.feedback });
         count++;
         if (count === 1) return Promise.resolve({ title_en: 'Title', body_en: TRANSLATED_BODY_BROKEN });
-        return Promise.resolve({ title_en: 'Title', body_en: TRANSLATED_BODY_OK });
+        return Promise.resolve({ title_en: 'Title', body_en: TRANSLATED_BODY_OK_TEMPLATE });
       });
       await translateOne(makeArgs({ geminiClient: client }));
       assert.equal(calls[0].feedback, undefined);
@@ -314,25 +331,26 @@ describe('translateOne', () => {
       assert.match(feedback, /code/i);
     });
 
-    test('codeBlockContent 不一致時、フィードバックに detail（具体的な差分内容）が含まれる', async () => {
+    test('placeholder drop（LLM がプレースホルダを消失） → リトライで復旧', async () => {
+      // 新アーキテクチャ: LLM には code を見せず ⟨⟨BLOCK_N⟩⟩ のみ渡す。LLM がプレースホルダを drop した場合、
+      // restoreCode が throw して translator が retry する
       const calls: { feedback?: string }[] = [];
-      const jaWithCode = buildJaContent({ body: '本文\n\n```\nfoo\n```\n' });
-      // ターゲットはコード数同数だが内容が違う → codeBlockContent ミスマッチ
-      const brokenWithDifferentCode = '\nParagraph.\n\n```\nbar\n```\n';
       let count = 0;
       const client: GeminiClient = mock.fn((input) => {
         calls.push({ feedback: input.feedback });
         count++;
-        if (count === 1) return Promise.resolve({ title_en: 'Title', body_en: brokenWithDifferentCode });
-        // 2 回目は source と同じ本文に直す
-        return Promise.resolve({ title_en: 'Title', body_en: '\nParagraph.\n\n```\nfoo\n```\n' });
+        if (count === 1) {
+          // プレースホルダを drop した出力（restoreCode で throw する）
+          return Promise.resolve({ title_en: 'Title', body_en: 'Paragraph.\n\nhttps://example.com\n' });
+        }
+        return Promise.resolve({ title_en: 'Title', body_en: TRANSLATED_BODY_OK_TEMPLATE });
       });
-      await translateOne(makeArgs({ jaContent: jaWithCode, geminiClient: client }));
-      const feedback = calls[1].feedback;
-      assert.ok(feedback);
-      // 数値だけでなく具体的な差分内容（detail）が含まれている
-      assert.match(feedback, /codeBlockContent/);
-      assert.match(feedback, /code block content modified/);
+      const result = await translateOne(makeArgs({ geminiClient: client }));
+      assert.equal(result.kind, 'translated');
+      assert.equal((client as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 2);
+      // 2 回目の feedback にプレースホルダ保全の指示が含まれる
+      assert.ok(calls[1].feedback);
+      assert.match(calls[1].feedback, /placeholder/i);
     });
   });
 
@@ -375,7 +393,7 @@ describe('translateOne', () => {
       const geminiClient: GeminiClient = mock.fn(() => {
         count++;
         if (count === 1) return Promise.resolve({ title_en: 'Title', body_en: TRANSLATED_BODY_BROKEN });
-        return Promise.resolve({ title_en: 'Title', body_en: TRANSLATED_BODY_OK });
+        return Promise.resolve({ title_en: 'Title', body_en: TRANSLATED_BODY_OK_TEMPLATE });
       });
       const proofreaderClient: ProofreaderClient = mock.fn(() => Promise.resolve({ ok: true, issues: [] }));
       await translateOne(makeArgs({ geminiClient, proofreaderClient }));

--- a/tools/auto-translate/translator.spec.ts
+++ b/tools/auto-translate/translator.spec.ts
@@ -500,6 +500,33 @@ describe('translateOne', () => {
       assert.equal((codeTranslatorClient as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 1);
     });
 
+    test('prose 中に ⟨⟨ 文字列が含まれていても escape 経由で正しく復元される（衝突回避）', async () => {
+      // 「auto-translate ⟨⟨BLOCK_0⟩⟩ という記法を使う」のように prose に
+      // プレースホルダ風文字列がある記事の end-to-end テスト
+      const ja = buildJaContent({
+        body: 'システムは ⟨⟨BLOCK_0⟩⟩ で識別する。\n\n```ts\nconst x = 1;\n```\n',
+      });
+      // LLM は escape 後の prose（⟨⟨ → ⟪⟪）を受け取り、それをそのまま英訳して返す（escape は保持）
+      const geminiClient: GeminiClient = mock.fn((input) => {
+        // input.body には escape された ⟪⟪ が含まれているはず
+        assert.match(input.body, /⟪⟪BLOCK_0⟫⟫/);
+        return Promise.resolve({
+          title_en: 'Title',
+          body_en: 'The system identifies via ⟪⟪BLOCK_0⟫⟫.\n\n⟨⟨BLOCK_0⟩⟩\n',
+        });
+      });
+      const result = await translateOne(makeArgs({ jaContent: ja, geminiClient }));
+      assert.equal(result.kind, 'translated');
+      assert.ok('enContent' in result);
+      // 最終 en では escape が復元されて元の ⟨⟨BLOCK_0⟩⟩ 文字列に戻る
+      assert.match(result.enContent, /via ⟨⟨BLOCK_0⟩⟩/);
+      // コードブロックも正しく復元されている
+      assert.match(result.enContent, /const x = 1;/);
+      // ⟪⟪ が最終出力に残らない
+      assert.ok(!result.enContent.includes('⟪⟪'));
+      assert.ok(!result.enContent.includes('⟫⟫'));
+    });
+
     test('codeTranslator が複数ブロックを処理してインデックスずれせず復元される', async () => {
       const jaTwoBlocks = buildJaContent({
         body: '前文。\n\n```ts\n// 一つ目\nconst a = 1;\n```\n\n途中。\n\n```ts\n// 二つ目\nconst b = 2;\n```\n',

--- a/tools/auto-translate/translator.spec.ts
+++ b/tools/auto-translate/translator.spec.ts
@@ -388,16 +388,18 @@ describe('translateOne', () => {
       assert.equal((proofreaderClient as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 4);
     });
 
-    test('構造検証 NG の attempt では proofread を呼ばない（ローカル検証で先に reject）', async () => {
+    test('placeholder 復元 NG の attempt では proofread を呼ばない（ローカル検証で先に reject）', async () => {
       let count = 0;
       const geminiClient: GeminiClient = mock.fn(() => {
         count++;
+        // TRANSLATED_BODY_BROKEN は ⟨⟨BLOCK_0⟩⟩ を含まないため restoreCode が throw して
+        // placeholder 復元失敗となり、proofread には到達しない
         if (count === 1) return Promise.resolve({ title_en: 'Title', body_en: TRANSLATED_BODY_BROKEN });
         return Promise.resolve({ title_en: 'Title', body_en: TRANSLATED_BODY_OK_TEMPLATE });
       });
       const proofreaderClient: ProofreaderClient = mock.fn(() => Promise.resolve({ ok: true, issues: [] }));
       await translateOne(makeArgs({ geminiClient, proofreaderClient }));
-      // 1 回目は構造 NG なので proofread 呼ばれない、2 回目で proofread 呼ばれる
+      // 1 回目は placeholder 復元 NG なので proofread 呼ばれない、2 回目で呼ばれる
       assert.equal((proofreaderClient as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 1);
     });
 
@@ -406,6 +408,63 @@ describe('translateOne', () => {
       const proofreaderClient: ProofreaderClient = mock.fn(() => Promise.reject(new Error('proofread API down')));
       const result = await translateOne(makeArgs({ geminiClient, proofreaderClient }));
       assert.equal(result.kind, 'translated');
+    });
+  });
+
+  describe('コメント翻訳統合', () => {
+    test('codeTranslator がコメントを翻訳した場合、最終 en にその翻訳が反映される', async () => {
+      // ja: 日本語コメント入りコードブロック
+      const jaWithJaComment = buildJaContent({
+        body: '前文。\n\n```ts\n// 日本語コメント\nconst a = 1;\n```\n\nhttps://example.com\n',
+      });
+      // codeTranslator は日本語コメントを英訳して返す
+      const codeTranslatorClient: CodeTranslatorClient = mock.fn((code) =>
+        Promise.resolve(code.replace('// 日本語コメント', '// translated comment')),
+      );
+      // translator (Gemini) は prose を翻訳して body_en を返す（プレースホルダは保持）
+      const geminiClient: GeminiClient = mock.fn(() =>
+        Promise.resolve({
+          title_en: 'Title',
+          body_en: 'Preface.\n\n⟨⟨BLOCK_0⟩⟩\n\nhttps://example.com\n',
+        }),
+      );
+      const result = await translateOne(makeArgs({ jaContent: jaWithJaComment, geminiClient, codeTranslatorClient }));
+      assert.equal(result.kind, 'translated');
+      assert.ok('enContent' in result);
+      // 出力 en に英訳されたコメントが含まれる（インデックスずれや差し替え漏れがないこと）
+      assert.match(result.enContent, /\/\/ translated comment/);
+      // 元の日本語コメントは含まれない
+      assert.ok(!result.enContent.includes('// 日本語コメント'));
+      // コードブロックの非コメント部分（const a = 1;）は保持
+      assert.match(result.enContent, /const a = 1;/);
+      // codeTranslator が呼ばれていること
+      assert.equal((codeTranslatorClient as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 1);
+    });
+
+    test('codeTranslator が複数ブロックを処理してインデックスずれせず復元される', async () => {
+      const jaTwoBlocks = buildJaContent({
+        body: '前文。\n\n```ts\n// 一つ目\nconst a = 1;\n```\n\n途中。\n\n```ts\n// 二つ目\nconst b = 2;\n```\n',
+      });
+      // 各ブロックを「コメント翻訳済み」に変換
+      const codeTranslatorClient: CodeTranslatorClient = mock.fn((code) => {
+        if (code.includes('一つ目')) return Promise.resolve(code.replace('// 一つ目', '// first block'));
+        if (code.includes('二つ目')) return Promise.resolve(code.replace('// 二つ目', '// second block'));
+        return Promise.resolve(code);
+      });
+      const geminiClient: GeminiClient = mock.fn(() =>
+        Promise.resolve({
+          title_en: 'Title',
+          body_en: 'Preface.\n\n⟨⟨BLOCK_0⟩⟩\n\nMiddle.\n\n⟨⟨BLOCK_1⟩⟩\n',
+        }),
+      );
+      const result = await translateOne(makeArgs({ jaContent: jaTwoBlocks, geminiClient, codeTranslatorClient }));
+      assert.equal(result.kind, 'translated');
+      assert.ok('enContent' in result);
+      // BLOCK_0 と BLOCK_1 が正しい順序で復元されている
+      const firstIdx = result.enContent.indexOf('// first block');
+      const secondIdx = result.enContent.indexOf('// second block');
+      assert.ok(firstIdx > 0);
+      assert.ok(secondIdx > firstIdx);
     });
   });
 

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -88,7 +88,7 @@ function buildFeedback(validation: ValidationResult): string {
   }
   lines.push('');
   lines.push(
-    'Please retranslate ensuring all code blocks, links, images, and bare URL paragraphs from the source are preserved exactly. Do not omit, merge, or wrap any URL into prose. Code blocks and inline code must be kept BYTE-FOR-BYTE identical to the source — do not change any quotation marks, dashes, or whitespace.',
+    'Please retranslate ensuring all links, images, and bare URL paragraphs from the source are preserved exactly. Do not omit, merge, or wrap any URL into prose. Each placeholder ⟨⟨BLOCK_N⟩⟩ and ⟨⟨INLINE_N⟩⟩ must appear exactly once in your output, verbatim — do not modify, drop, or duplicate them.',
   );
   return lines.join('\n');
 }

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -6,12 +6,9 @@ import { buildEnFrontmatter, getAutoTranslatedFrom, isAutoTranslated, type Front
 import { proofread, formatProofIssues, type ProofreaderClient } from './proofreader.ts';
 import { validateStructure, type ValidationResult } from './structure-validator.ts';
 
-// PROMPT_VERSION:
-// 4: proofreader 導入
-// 5: code 抽出/プレースホルダ翻訳/code 復元方式に変更
-// 6: 各コードブロックを個別翻訳してからマージ（コメント翻訳のため）
-// 7: proofreader を「翻訳由来の不整合のみ flag」に修正（原文の不整合を誤検出していた）
-export const PROMPT_VERSION = 7;
+// PROMPT_VERSION: プロンプト/モデル/構造検証ロジックが変わったらインクリメントしてキャッシュを invalidate する。
+// バージョン履歴は git log で追える（変更時はコミットメッセージに「PROMPT_VERSION N → N+1」と記載）
+export const PROMPT_VERSION = 4;
 // preview だが最新世代品質を採用。GEMINI_MODEL env で stable (gemini-2.5-flash 等) に切替可能
 // 参考: https://ai.google.dev/gemini-api/docs/models
 export const DEFAULT_MODEL = 'gemini-3-flash-preview';
@@ -77,14 +74,7 @@ export function joinFrontmatter(frontmatter: Frontmatter, body: string): string 
 function buildFeedback(validation: ValidationResult): string {
   const lines = ['The translation has structural mismatches with the source:'];
   for (const m of validation.mismatches) {
-    // count 差異と content 差異でフォーマットを分ける:
-    // - count 差異（codeBlocks 等）: 数値で表示（"source has 3, translation has 2"）
-    // - content 差異（inlineCodeContent）: 数値は同値なので detail のみ表示
-    if (m.kind === 'inlineCodeContent') {
-      lines.push(`- ${m.kind}: ${m.detail ?? 'content modified from source'}`);
-    } else {
-      lines.push(`- ${m.kind}: source has ${m.source}, translation has ${m.target}`);
-    }
+    lines.push(`- ${m.kind}: source has ${m.source}, translation has ${m.target}`);
   }
   lines.push('');
   lines.push(
@@ -96,14 +86,7 @@ function buildFeedback(validation: ValidationResult): string {
 const TOTAL_ATTEMPTS = MAX_RETRIES + 1;
 
 function summarizeStructureMismatch(validation: ValidationResult): string {
-  return validation.mismatches
-    .map((m) => {
-      if (m.kind === 'inlineCodeContent') {
-        return `${m.kind}: ${m.detail ?? 'content modified'}`;
-      }
-      return `${m.kind} ja=${m.source} en=${m.target}`;
-    })
-    .join(', ');
+  return validation.mismatches.map((m) => `${m.kind} ja=${m.source} en=${m.target}`).join(', ');
 }
 
 type RetryFailureReason =

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -9,7 +9,8 @@ import { validateStructure, type ValidationResult } from './structure-validator.
 // PROMPT_VERSION: プロンプト/モデル/構造検証ロジックが変わったらインクリメントしてキャッシュを invalidate する。
 // バージョン履歴は git log で追える（変更時はコミットメッセージに「PROMPT_VERSION N → N+1」と記載）
 export const PROMPT_VERSION = 4;
-// preview だが最新世代品質を採用。GEMINI_MODEL env で stable (gemini-2.5-flash 等) に切替可能
+// Gemini 3 Flash の preview モデル。本番運用中（2026-04 時点で stable な 3 系 flash モデルは未提供）。
+// 将来 stable 移行・廃止時は GEMINI_MODEL env で適切な ID（例: gemini-3-flash 等の後継 GA 名）に切替可能。
 // 参考: https://ai.google.dev/gemini-api/docs/models
 export const DEFAULT_MODEL = 'gemini-3-flash-preview';
 export const MAX_RETRIES = 3;

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -103,7 +103,7 @@ async function callWithRetries(
   slug: string,
 ): Promise<
   | { ok: true; output: GeminiOutput; attempts: number }
-  | { ok: false; attempts: number; lastFailure: RetryFailureReason }
+  | { ok: false; attempts: number; lastFailure: RetryFailureReason | undefined }
   | { ok: false; attempts: number; thrownAt: number; cause: Error }
 > {
   // ja body から code を抽出してプレースホルダ化。LLM には template だけ渡す。
@@ -125,7 +125,8 @@ async function callWithRetries(
   }
 
   let feedback: string | undefined;
-  let lastFailure: RetryFailureReason = { kind: 'structure' }; // 初期値は便宜上 structure（実際には到達前に上書きされる）
+  // lastFailure は最終試行の失敗種別を保持。失敗パスを通る前に return する場合は undefined のまま
+  let lastFailure: RetryFailureReason | undefined;
   for (let attempt = 1; attempt <= TOTAL_ATTEMPTS; attempt++) {
     let output: GeminiOutput;
     try {
@@ -287,6 +288,7 @@ export async function translateOne(args: TranslateOneArgs): Promise<TranslateRes
       };
     }
     const lastReason = (() => {
+      if (!outcome.lastFailure) return 'unknown failure';
       switch (outcome.lastFailure.kind) {
         case 'placeholder':
           return 'placeholder restoration failed';

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -91,7 +91,7 @@ function buildFeedback(validation: ValidationResult): string {
   );
   if (hasBlockquoteCodeIssue) {
     lines.push(
-      'Code blocks inside blockquotes (lines starting with `> `) must be preserved BYTE-FOR-BYTE — do NOT translate their comments and do NOT change any character.',
+      'Code blocks inside blockquotes (lines starting with "> ") must be preserved BYTE-FOR-BYTE — do NOT translate their comments and do NOT change any character.',
     );
   }
   return lines.join('\n');
@@ -303,13 +303,19 @@ export async function translateOne(args: TranslateOneArgs): Promise<TranslateRes
     }
     const lastReason = (() => {
       if (!outcome.lastFailure) return 'unknown failure';
-      switch (outcome.lastFailure.kind) {
+      const kind = outcome.lastFailure.kind;
+      switch (kind) {
         case 'placeholder':
           return 'placeholder restoration failed';
         case 'structure':
           return 'structure validation failed';
         case 'proofread':
           return 'proofread issues';
+        default: {
+          // 新しい kind が増えた場合に型エラーで気づくための exhaustive check
+          const _exhaustive: never = kind;
+          throw new Error(`Unhandled RetryFailureReason kind: ${String(_exhaustive)}`);
+        }
       }
     })();
     return {

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -76,10 +76,16 @@ function buildFeedback(validation: ValidationResult): string {
   let hasBlockquoteCodeIssue = false;
   for (const m of validation.mismatches) {
     if (m.kind === 'blockquoteCodeContent') {
-      // count 一致 + 内容不一致のケースが通常で、数値表示は LLM を混乱させるため専用メッセージにする
-      lines.push(
-        `- ${m.kind}: a code block inside a blockquote (> \`\`\` ... \`\`\`) was modified. The content must remain BYTE-FOR-BYTE identical to the source.`,
-      );
+      // count 差異と内容差異で別メッセージにする
+      if (m.differKind === 'count') {
+        lines.push(
+          `- ${m.kind}: a code block inside a blockquote was added or removed (source has ${m.source}, translation has ${m.target}).`,
+        );
+      } else {
+        lines.push(
+          `- ${m.kind}: a code block inside a blockquote was modified. The content must remain BYTE-FOR-BYTE identical to the source.`,
+        );
+      }
       hasBlockquoteCodeIssue = true;
     } else {
       lines.push(`- ${m.kind}: source has ${m.source}, translation has ${m.target}`);
@@ -100,7 +106,15 @@ function buildFeedback(validation: ValidationResult): string {
 const TOTAL_ATTEMPTS = MAX_RETRIES + 1;
 
 function summarizeStructureMismatch(validation: ValidationResult): string {
-  return validation.mismatches.map((m) => `${m.kind} ja=${m.source} en=${m.target}`).join(', ');
+  return validation.mismatches
+    .map((m) => {
+      if (m.kind === 'blockquoteCodeContent') {
+        // count 同値の場合は数だけだと「ja=2 en=2」と一見問題なく見えるため明示する
+        return `${m.kind} (${m.differKind ?? 'differ'}) ja=${m.source} en=${m.target}`;
+      }
+      return `${m.kind} ja=${m.source} en=${m.target}`;
+    })
+    .join(', ');
 }
 
 type RetryFailureReason =

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -1,9 +1,11 @@
 import { createHash } from 'node:crypto';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { buildEnFrontmatter, getAutoTranslatedFrom, isAutoTranslated, type Frontmatter } from './frontmatter.ts';
+import { proofread, formatProofIssues, type ProofreaderClient } from './proofreader.ts';
 import { validateStructure, type ValidationResult } from './structure-validator.ts';
 
-export const PROMPT_VERSION = 3;
+// proofreader（校正）を追加。translator が出した訳を別人格 LLM が意味整合性を検査する
+export const PROMPT_VERSION = 4;
 // preview だが最新世代品質を採用。GEMINI_MODEL env で stable (gemini-2.5-flash 等) に切替可能
 // 参考: https://ai.google.dev/gemini-api/docs/models
 export const DEFAULT_MODEL = 'gemini-3-flash-preview';
@@ -28,6 +30,7 @@ export interface TranslateOneArgs {
   jaContent: string;
   enContent: string | null;
   geminiClient: GeminiClient;
+  proofreaderClient: ProofreaderClient;
   model: string;
   slug?: string; // ログ識別用。省略時は jaPath の basename を使う
 }
@@ -85,8 +88,20 @@ function buildFeedback(validation: ValidationResult): string {
 
 const TOTAL_ATTEMPTS = MAX_RETRIES + 1;
 
+function summarizeStructureMismatch(validation: ValidationResult): string {
+  return validation.mismatches
+    .map((m) => {
+      if (m.kind === 'codeBlockContent' || m.kind === 'inlineCodeContent') {
+        return `${m.kind}: ${m.detail ?? 'content modified'}`;
+      }
+      return `${m.kind} ja=${m.source} en=${m.target}`;
+    })
+    .join(', ');
+}
+
 async function callWithRetries(
   client: GeminiClient,
+  proofreaderClient: ProofreaderClient,
   model: string,
   input: { title: string; body: string },
   slug: string,
@@ -104,27 +119,39 @@ async function callWithRetries(
       // 試行中に API がエラー（ネットワーク・5xx・429 等）。試行番号を保持して呼び出し元へ
       return { ok: false, attempts: attempt, thrownAt: attempt, cause: e as Error };
     }
+
+    // (1) 構造検証（ローカル、コスト 0）
     const validation = validateStructure(input.body, output.body_en);
-    if (validation.ok) {
+    if (!validation.ok) {
+      if (attempt < TOTAL_ATTEMPTS) {
+        console.warn(
+          `[auto-translate] structure mismatch (attempt ${attempt}/${TOTAL_ATTEMPTS}) for ${slug}: ${summarizeStructureMismatch(validation)} — retrying`,
+        );
+        feedback = buildFeedback(validation);
+      }
+      continue;
+    }
+
+    // (2) proofread（別人格 LLM、API コール 1 回）。意味・整合性をチェック
+    const proof = await proofread({
+      jaSource: input.body,
+      enTranslation: output.body_en,
+      client: proofreaderClient,
+      model,
+    });
+    if (proof.ok) {
       if (attempt > 1) {
-        console.info(`[auto-translate] structure validation passed on attempt ${attempt} for ${slug}`);
+        console.info(`[auto-translate] translation accepted on attempt ${attempt} for ${slug}`);
       }
       return { ok: true, output, attempts: attempt };
     }
+
     if (attempt < TOTAL_ATTEMPTS) {
-      const mismatchSummary = validation.mismatches
-        .map((m) => {
-          // content 差異は数値が同値で混乱を招くため detail のみ表示
-          if (m.kind === 'codeBlockContent' || m.kind === 'inlineCodeContent') {
-            return `${m.kind}: ${m.detail ?? 'content modified'}`;
-          }
-          return `${m.kind} ja=${m.source} en=${m.target}`;
-        })
-        .join(', ');
+      const issuesSummary = proof.issues.map((i) => `[${i.location}] ${i.problem}`).join('; ');
       console.warn(
-        `[auto-translate] structure mismatch (attempt ${attempt}/${TOTAL_ATTEMPTS}) for ${slug}: ${mismatchSummary} — retrying`,
+        `[auto-translate] proofread issues (attempt ${attempt}/${TOTAL_ATTEMPTS}) for ${slug}: ${issuesSummary} — retrying`,
       );
-      feedback = buildFeedback(validation);
+      feedback = formatProofIssues(proof.issues);
     }
     // 最終試行失敗時は呼び出し元（main.ts）で error ログを出すため、ここでは出力しない（重複防止）
   }
@@ -132,7 +159,7 @@ async function callWithRetries(
 }
 
 export async function translateOne(args: TranslateOneArgs): Promise<TranslateResult> {
-  const { jaContent, enContent, geminiClient, model, jaPath } = args;
+  const { jaContent, enContent, geminiClient, proofreaderClient, model, jaPath } = args;
   const slug = args.slug ?? jaPath.split('/').pop() ?? jaPath;
 
   let ja: { frontmatter: Frontmatter; body: string };
@@ -194,7 +221,7 @@ export async function translateOne(args: TranslateOneArgs): Promise<TranslateRes
   // ここでの try-catch は予期せぬ例外（実装バグ等）の保険のみ
   let outcome: Awaited<ReturnType<typeof callWithRetries>>;
   try {
-    outcome = await callWithRetries(geminiClient, model, { title: jaTitle, body: ja.body }, slug);
+    outcome = await callWithRetries(geminiClient, proofreaderClient, model, { title: jaTitle, body: ja.body }, slug);
   } catch (e) {
     return { kind: 'failed', reason: `unexpected error: ${(e as Error).message}` };
   }
@@ -208,7 +235,7 @@ export async function translateOne(args: TranslateOneArgs): Promise<TranslateRes
     }
     return {
       kind: 'failed',
-      reason: `structure mismatch persisted after ${outcome.attempts} attempts, keeping existing .en.md`,
+      reason: `structure or proofread issues persisted after ${outcome.attempts} attempts, keeping existing .en.md`,
     };
   }
 

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -122,8 +122,8 @@ const TOTAL_ATTEMPTS = MAX_RETRIES + 1;
 function summarizeStructureMismatch(validation: ValidationResult): string {
   return validation.mismatches
     .map((m) => {
-      if (m.kind === 'blockquoteCodeContent') {
-        // count 同値の場合は数だけだと「ja=2 en=2」と一見問題なく見えるため明示する
+      if (m.kind === 'blockquoteCodeContent' || m.kind === 'blockquoteInlineCodeContent') {
+        // count 同値の場合は数だけだと「ja=2 en=2」と一見問題なく見えるため differKind を明示する
         return `${m.kind} (${m.differKind ?? 'differ'}) ja=${m.source} en=${m.target}`;
       }
       return `${m.kind} ja=${m.source} en=${m.target}`;

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -192,7 +192,16 @@ async function callWithRetries(
       client: proofreaderClient,
       model,
     });
-    if (proof.ok) {
+    // ok と issues のクロスバリデーション:
+    // - ok=true: issues があっても accept（proofreader が「許容範囲の指摘」とみなした）
+    // - ok=false かつ issues=[]: 不整合な応答。リトライしても feedback が無く改善見込みがないため accept する（fail-open）
+    // - ok=false かつ issues 非空: 通常の retry 経路
+    if (proof.ok || proof.issues.length === 0) {
+      if (!proof.ok) {
+        console.warn(
+          `[auto-translate] proofreader returned ok=false but no issues for ${slug} — treating as accept (cannot retry without feedback)`,
+        );
+      }
       if (attempt > 1) {
         console.info(`[auto-translate] translation accepted on attempt ${attempt} for ${slug}`);
       }

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
-import { extractCode, restoreCode } from './code-extractor.ts';
+import { extractCode, restoreCode, type PlaceholderRef } from './code-extractor.ts';
 import { translateCodeBlock, type CodeTranslatorClient } from './code-translator.ts';
 import { buildEnFrontmatter, getAutoTranslatedFrom, isAutoTranslated, type Frontmatter } from './frontmatter.ts';
 import { proofread, formatProofIssues, type ProofreaderClient } from './proofreader.ts';
@@ -142,7 +142,14 @@ interface CallWithRetriesArgs {
   proofreaderClient: ProofreaderClient;
   codeTranslatorClient: CodeTranslatorClient;
   model: string;
-  input: { title: string; body: string; jaTemplate: string; codeBlocks: string[]; inlineCodes: string[] };
+  input: {
+    title: string;
+    body: string;
+    jaTemplate: string;
+    codeBlocks: string[];
+    inlineCodes: string[];
+    placeholderSequence: readonly PlaceholderRef[];
+  };
   slug: string;
 }
 
@@ -154,7 +161,7 @@ async function callWithRetries(
   | { ok: false; attempts: number; thrownAt: number; cause: Error }
 > {
   const { geminiClient: client, proofreaderClient, codeTranslatorClient, model, input, slug } = args;
-  const { jaTemplate, codeBlocks, inlineCodes } = input;
+  const { jaTemplate, codeBlocks, inlineCodes, placeholderSequence } = input;
 
   // 各コードブロックを個別翻訳（コメントのみ）。インラインコードは識別子なので翻訳しない。
   // ブロック間は独立しているため Promise.all で並列化する
@@ -186,7 +193,7 @@ async function callWithRetries(
     // 翻訳結果（プレースホルダ入り）を、コメント翻訳済みのコードブロック + インラインコードで復元する
     let restoredBody: string;
     try {
-      restoredBody = restoreCode(output.body_en, translatedCodeBlocks, inlineCodes);
+      restoredBody = restoreCode(output.body_en, translatedCodeBlocks, inlineCodes, placeholderSequence);
     } catch (e) {
       // LLM がプレースホルダを drop / 幻覚した場合に到達。retry で改善する可能性
       lastFailure = { kind: 'placeholder' };
@@ -335,6 +342,7 @@ export async function translateOne(args: TranslateOneArgs): Promise<TranslateRes
         jaTemplate: extracted.template,
         codeBlocks: extracted.codeBlocks,
         inlineCodes: extracted.inlineCodes,
+        placeholderSequence: extracted.placeholderSequence,
       },
       slug,
     });

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -82,8 +82,9 @@ function buildFeedback(validation: ValidationResult): string {
           `- ${m.kind}: a code block inside a blockquote was added or removed (source has ${m.source}, translation has ${m.target}).`,
         );
       } else {
+        // content 差異時、source = 差異のあるブロック数、target = 全体ブロック数
         lines.push(
-          `- ${m.kind}: a code block inside a blockquote was modified. The content must remain BYTE-FOR-BYTE identical to the source.`,
+          `- ${m.kind}: ${m.source} of ${m.target} code blocks inside blockquotes were modified. The content must remain BYTE-FOR-BYTE identical to the source.`,
         );
       }
       hasBlockquoteCodeIssue = true;

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -73,13 +73,27 @@ export function joinFrontmatter(frontmatter: Frontmatter, body: string): string 
 
 function buildFeedback(validation: ValidationResult): string {
   const lines = ['The translation has structural mismatches with the source:'];
+  let hasBlockquoteCodeIssue = false;
   for (const m of validation.mismatches) {
-    lines.push(`- ${m.kind}: source has ${m.source}, translation has ${m.target}`);
+    if (m.kind === 'blockquoteCodeContent') {
+      // count 一致 + 内容不一致のケースが通常で、数値表示は LLM を混乱させるため専用メッセージにする
+      lines.push(
+        `- ${m.kind}: a code block inside a blockquote (> \`\`\` ... \`\`\`) was modified. The content must remain BYTE-FOR-BYTE identical to the source.`,
+      );
+      hasBlockquoteCodeIssue = true;
+    } else {
+      lines.push(`- ${m.kind}: source has ${m.source}, translation has ${m.target}`);
+    }
   }
   lines.push('');
   lines.push(
     'Please retranslate ensuring all links, images, and bare URL paragraphs from the source are preserved exactly. Do not omit, merge, or wrap any URL into prose. Each placeholder ⟨⟨BLOCK_N⟩⟩ and ⟨⟨INLINE_N⟩⟩ must appear exactly once in your output, verbatim — do not modify, drop, or duplicate them.',
   );
+  if (hasBlockquoteCodeIssue) {
+    lines.push(
+      'Code blocks inside blockquotes (lines starting with `> `) must be preserved BYTE-FOR-BYTE — do NOT translate their comments and do NOT change any character.',
+    );
+  }
   return lines.join('\n');
 }
 

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -106,6 +106,11 @@ function summarizeStructureMismatch(validation: ValidationResult): string {
     .join(', ');
 }
 
+type RetryFailureReason =
+  | { kind: 'placeholder' } // restoreCode が throw（drop / 重複 / 幻覚）
+  | { kind: 'structure' } // structure-validator NG
+  | { kind: 'proofread' }; // proofreader NG
+
 async function callWithRetries(
   client: GeminiClient,
   proofreaderClient: ProofreaderClient,
@@ -115,7 +120,7 @@ async function callWithRetries(
   slug: string,
 ): Promise<
   | { ok: true; output: GeminiOutput; attempts: number }
-  | { ok: false; attempts: number }
+  | { ok: false; attempts: number; lastFailure: RetryFailureReason }
   | { ok: false; attempts: number; thrownAt: number; cause: Error }
 > {
   // ja body から code を抽出してプレースホルダ化。LLM には template だけ渡す。
@@ -137,6 +142,7 @@ async function callWithRetries(
   }
 
   let feedback: string | undefined;
+  let lastFailure: RetryFailureReason = { kind: 'structure' }; // 初期値は便宜上 structure（実際には到達前に上書きされる）
   for (let attempt = 1; attempt <= TOTAL_ATTEMPTS; attempt++) {
     let output: GeminiOutput;
     try {
@@ -153,6 +159,7 @@ async function callWithRetries(
       restoredBody = restoreCode(output.body_en, translatedCodeBlocks, inlineCodes);
     } catch (e) {
       // LLM がプレースホルダを drop / 幻覚した場合に到達。retry で改善する可能性
+      lastFailure = { kind: 'placeholder' };
       if (attempt < TOTAL_ATTEMPTS) {
         console.warn(
           `[auto-translate] placeholder restoration failed (attempt ${attempt}/${TOTAL_ATTEMPTS}) for ${slug}: ${(e as Error).message} — retrying`,
@@ -167,6 +174,7 @@ async function callWithRetries(
     // 万一一致しないケース（LLM が prose 中で markdown 構造を破壊した等）への保険として残す
     const validation = validateStructure(input.body, restoredOutput.body_en);
     if (!validation.ok) {
+      lastFailure = { kind: 'structure' };
       if (attempt < TOTAL_ATTEMPTS) {
         console.warn(
           `[auto-translate] structure mismatch (attempt ${attempt}/${TOTAL_ATTEMPTS}) for ${slug}: ${summarizeStructureMismatch(validation)} — retrying`,
@@ -191,6 +199,7 @@ async function callWithRetries(
       return { ok: true, output: restoredOutput, attempts: attempt };
     }
 
+    lastFailure = { kind: 'proofread' };
     if (attempt < TOTAL_ATTEMPTS) {
       const issuesSummary = proof.issues.map((i) => `[${i.location}] ${i.problem}`).join('; ');
       console.warn(
@@ -200,7 +209,7 @@ async function callWithRetries(
     }
     // 最終試行失敗時は呼び出し元（main.ts）で error ログを出すため、ここでは出力しない（重複防止）
   }
-  return { ok: false, attempts: TOTAL_ATTEMPTS };
+  return { ok: false, attempts: TOTAL_ATTEMPTS, lastFailure };
 }
 
 export async function translateOne(args: TranslateOneArgs): Promise<TranslateResult> {
@@ -285,9 +294,19 @@ export async function translateOne(args: TranslateOneArgs): Promise<TranslateRes
         reason: `Gemini API error on attempt ${outcome.thrownAt}/${TOTAL_ATTEMPTS}: ${outcome.cause.message}`,
       };
     }
+    const lastReason = (() => {
+      switch (outcome.lastFailure.kind) {
+        case 'placeholder':
+          return 'placeholder restoration failed';
+        case 'structure':
+          return 'structure validation failed';
+        case 'proofread':
+          return 'proofread issues';
+      }
+    })();
     return {
       kind: 'failed',
-      reason: `structure or proofread issues persisted after ${outcome.attempts} attempts, keeping existing .en.md`,
+      reason: `${lastReason} persisted after ${outcome.attempts} attempts, keeping existing .en.md`,
     };
   }
 

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -135,16 +135,14 @@ async function callWithRetries(
   proofreaderClient: ProofreaderClient,
   codeTranslatorClient: CodeTranslatorClient,
   model: string,
-  input: { title: string; body: string },
+  input: { title: string; body: string; jaTemplate: string; codeBlocks: string[]; inlineCodes: string[] },
   slug: string,
 ): Promise<
   | { ok: true; output: GeminiOutput; attempts: number }
   | { ok: false; attempts: number; lastFailure: RetryFailureReason | undefined }
   | { ok: false; attempts: number; thrownAt: number; cause: Error }
 > {
-  // ja body から code を抽出してプレースホルダ化。LLM には template だけ渡す。
-  // 各コードブロックは個別に翻訳（コメントのみ訳す）し、最終的に restoreCode でマージする
-  const { template: jaTemplate, codeBlocks, inlineCodes } = extractCode(input.body);
+  const { jaTemplate, codeBlocks, inlineCodes } = input;
 
   // 各コードブロックを個別翻訳（コメントのみ）。インラインコードは識別子なので翻訳しない。
   // ブロック間は独立しているため Promise.all で並列化する
@@ -300,6 +298,16 @@ export async function translateOne(args: TranslateOneArgs): Promise<TranslateRes
     return { kind: 'frontmatter-only', enContent: newEnContent };
   }
 
+  // ja body から code を抽出してプレースホルダ化。LLM には template だけ渡す。
+  // extractCode は予約 escape 文字（⟪⟪/⟫⟫）が markdown 中にあると throw する既知の失敗モードがあるため、
+  // unexpected error ではなく専用 reason で扱う
+  let extracted: ReturnType<typeof extractCode>;
+  try {
+    extracted = extractCode(ja.body);
+  } catch (e) {
+    return { kind: 'failed', reason: `code extraction failed: ${(e as Error).message}` };
+  }
+
   // API 呼ぶ（リトライ込み）。callWithRetries は API 例外を内部 catch して outcome に変換するため、
   // ここでの try-catch は予期せぬ例外（実装バグ等）の保険のみ
   let outcome: Awaited<ReturnType<typeof callWithRetries>>;
@@ -309,7 +317,13 @@ export async function translateOne(args: TranslateOneArgs): Promise<TranslateRes
       proofreaderClient,
       codeTranslatorClient,
       model,
-      { title: jaTitle, body: ja.body },
+      {
+        title: jaTitle,
+        body: ja.body,
+        jaTemplate: extracted.template,
+        codeBlocks: extracted.codeBlocks,
+        inlineCodes: extracted.inlineCodes,
+      },
       slug,
     );
   } catch (e) {

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -79,8 +79,8 @@ function buildFeedback(validation: ValidationResult): string {
   for (const m of validation.mismatches) {
     // count 差異と content 差異でフォーマットを分ける:
     // - count 差異（codeBlocks 等）: 数値で表示（"source has 3, translation has 2"）
-    // - content 差異（codeBlockContent / inlineCodeContent）: 数値は同値なので detail のみ表示
-    if (m.kind === 'codeBlockContent' || m.kind === 'inlineCodeContent') {
+    // - content 差異（inlineCodeContent）: 数値は同値なので detail のみ表示
+    if (m.kind === 'inlineCodeContent') {
       lines.push(`- ${m.kind}: ${m.detail ?? 'content modified from source'}`);
     } else {
       lines.push(`- ${m.kind}: source has ${m.source}, translation has ${m.target}`);
@@ -98,7 +98,7 @@ const TOTAL_ATTEMPTS = MAX_RETRIES + 1;
 function summarizeStructureMismatch(validation: ValidationResult): string {
   return validation.mismatches
     .map((m) => {
-      if (m.kind === 'codeBlockContent' || m.kind === 'inlineCodeContent') {
+      if (m.kind === 'inlineCodeContent') {
         return `${m.kind}: ${m.detail ?? 'content modified'}`;
       }
       return `${m.kind} ja=${m.source} en=${m.target}`;
@@ -122,12 +122,11 @@ async function callWithRetries(
   // 各コードブロックは個別に翻訳（コメントのみ訳す）し、最終的に restoreCode でマージする
   const { template: jaTemplate, codeBlocks, inlineCodes } = extractCode(input.body);
 
-  // 各コードブロックを個別翻訳（コメントのみ）。インラインコードは識別子なので翻訳しない
-  const translatedCodeBlocks: string[] = [];
-  for (let i = 0; i < codeBlocks.length; i++) {
-    const t = await translateCodeBlock({ code: codeBlocks[i], client: codeTranslatorClient, model });
-    translatedCodeBlocks.push(t);
-  }
+  // 各コードブロックを個別翻訳（コメントのみ）。インラインコードは識別子なので翻訳しない。
+  // ブロック間は独立しているため Promise.all で並列化する
+  const translatedCodeBlocks = await Promise.all(
+    codeBlocks.map((code) => translateCodeBlock({ code, client: codeTranslatorClient, model })),
+  );
   if (codeBlocks.length > 0) {
     const translatedCount = translatedCodeBlocks.filter((t, i) => t !== codeBlocks[i]).length;
     if (translatedCount > 0) {

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+import { errorMessage } from './ast-utils.ts';
 import { extractCode, restoreCode, type PlaceholderRef } from './code-extractor.ts';
 import { translateCodeBlock, type CodeTranslatorClient } from './code-translator.ts';
 import { buildEnFrontmatter, getAutoTranslatedFrom, isAutoTranslated, type Frontmatter } from './frontmatter.ts';
@@ -158,7 +159,7 @@ async function callWithRetries(
 ): Promise<
   | { ok: true; output: GeminiOutput; attempts: number }
   | { ok: false; attempts: number; lastFailure: RetryFailureReason | undefined }
-  | { ok: false; attempts: number; thrownAt: number; cause: Error }
+  | { ok: false; attempts: number; thrownAt: number; cause: unknown }
 > {
   const { geminiClient: client, proofreaderClient, codeTranslatorClient, model, input, slug } = args;
   const { jaTemplate, codeBlocks, inlineCodes, placeholderSequence } = input;
@@ -187,7 +188,7 @@ async function callWithRetries(
       output = await client({ title: input.title, body: jaTemplate, feedback }, model);
     } catch (e) {
       // 試行中に API がエラー（ネットワーク・5xx・429 等）。試行番号を保持して呼び出し元へ
-      return { ok: false, attempts: attempt, thrownAt: attempt, cause: e as Error };
+      return { ok: false, attempts: attempt, thrownAt: attempt, cause: e };
     }
 
     // 翻訳結果（プレースホルダ入り）を、コメント翻訳済みのコードブロック + インラインコードで復元する
@@ -199,7 +200,7 @@ async function callWithRetries(
       lastFailure = { kind: 'placeholder' };
       if (attempt < TOTAL_ATTEMPTS) {
         console.warn(
-          `[auto-translate] placeholder restoration failed (attempt ${attempt}/${TOTAL_ATTEMPTS}) for ${slug}: ${(e as Error).message} — retrying`,
+          `[auto-translate] placeholder restoration failed (attempt ${attempt}/${TOTAL_ATTEMPTS}) for ${slug}: ${errorMessage(e)} — retrying`,
         );
         feedback = `Your previous response did not preserve all code placeholders correctly. Each placeholder ⟨⟨BLOCK_N⟩⟩ and ⟨⟨INLINE_N⟩⟩ from the source MUST appear exactly once in your output, in a position that makes sense for the translation. Do not invent new placeholders. Do not omit any.`;
       }
@@ -266,7 +267,7 @@ export async function translateOne(args: TranslateOneArgs): Promise<TranslateRes
   try {
     ja = splitFrontmatter(jaContent);
   } catch (e) {
-    return { kind: 'failed', reason: `ja frontmatter parse error: ${(e as Error).message}` };
+    return { kind: 'failed', reason: `ja frontmatter parse error: ${errorMessage(e)}` };
   }
 
   const jaTitleRaw = ja.frontmatter.title;
@@ -285,7 +286,7 @@ export async function translateOne(args: TranslateOneArgs): Promise<TranslateRes
       // パース不能な en が手動翻訳かどうか区別できない。上書きリスクを避け失敗扱い。
       // main.ts は parse-error を事前に検出して translateOne を呼ばないが、defense-in-depth として
       // 直接呼び出された場合にも安全側に倒す
-      return { kind: 'failed', reason: `existing en parse error: ${(e as Error).message}` };
+      return { kind: 'failed', reason: `existing en parse error: ${errorMessage(e)}` };
     }
     if (isAutoTranslated(en.frontmatter)) {
       existingEnHash = getAutoTranslatedFrom(en.frontmatter);
@@ -324,7 +325,7 @@ export async function translateOne(args: TranslateOneArgs): Promise<TranslateRes
   try {
     extracted = extractCode(ja.body);
   } catch (e) {
-    return { kind: 'failed', reason: `code extraction failed: ${(e as Error).message}` };
+    return { kind: 'failed', reason: `code extraction failed: ${errorMessage(e)}` };
   }
 
   // API 呼ぶ（リトライ込み）。callWithRetries は API 例外を内部 catch して outcome に変換するため、
@@ -347,14 +348,14 @@ export async function translateOne(args: TranslateOneArgs): Promise<TranslateRes
       slug,
     });
   } catch (e) {
-    return { kind: 'failed', reason: `unexpected error: ${(e as Error).message}` };
+    return { kind: 'failed', reason: `unexpected error: ${errorMessage(e)}` };
   }
 
   if (!outcome.ok) {
     if ('thrownAt' in outcome) {
       return {
         kind: 'failed',
-        reason: `Gemini API error on attempt ${outcome.thrownAt}/${TOTAL_ATTEMPTS}: ${outcome.cause.message}`,
+        reason: `Gemini API error on attempt ${outcome.thrownAt}/${TOTAL_ATTEMPTS}: ${errorMessage(outcome.cause)}`,
       };
     }
     const lastReason = (() => {

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -137,18 +137,23 @@ type RetryFailureReason =
   | { kind: 'structure' } // structure-validator NG
   | { kind: 'proofread' }; // proofreader NG
 
+interface CallWithRetriesArgs {
+  geminiClient: GeminiClient;
+  proofreaderClient: ProofreaderClient;
+  codeTranslatorClient: CodeTranslatorClient;
+  model: string;
+  input: { title: string; body: string; jaTemplate: string; codeBlocks: string[]; inlineCodes: string[] };
+  slug: string;
+}
+
 async function callWithRetries(
-  client: GeminiClient,
-  proofreaderClient: ProofreaderClient,
-  codeTranslatorClient: CodeTranslatorClient,
-  model: string,
-  input: { title: string; body: string; jaTemplate: string; codeBlocks: string[]; inlineCodes: string[] },
-  slug: string,
+  args: CallWithRetriesArgs,
 ): Promise<
   | { ok: true; output: GeminiOutput; attempts: number }
   | { ok: false; attempts: number; lastFailure: RetryFailureReason | undefined }
   | { ok: false; attempts: number; thrownAt: number; cause: Error }
 > {
+  const { geminiClient: client, proofreaderClient, codeTranslatorClient, model, input, slug } = args;
   const { jaTemplate, codeBlocks, inlineCodes } = input;
 
   // 各コードブロックを個別翻訳（コメントのみ）。インラインコードは識別子なので翻訳しない。
@@ -319,12 +324,12 @@ export async function translateOne(args: TranslateOneArgs): Promise<TranslateRes
   // ここでの try-catch は予期せぬ例外（実装バグ等）の保険のみ
   let outcome: Awaited<ReturnType<typeof callWithRetries>>;
   try {
-    outcome = await callWithRetries(
+    outcome = await callWithRetries({
       geminiClient,
       proofreaderClient,
       codeTranslatorClient,
       model,
-      {
+      input: {
         title: jaTitle,
         body: ja.body,
         jaTemplate: extracted.template,
@@ -332,7 +337,7 @@ export async function translateOne(args: TranslateOneArgs): Promise<TranslateRes
         inlineCodes: extracted.inlineCodes,
       },
       slug,
-    );
+    });
   } catch (e) {
     return { kind: 'failed', reason: `unexpected error: ${(e as Error).message}` };
   }

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -82,11 +82,18 @@ function buildFeedback(validation: ValidationResult): string {
           `- ${m.kind}: a code block inside a blockquote was added or removed (source has ${m.source}, translation has ${m.target}).`,
         );
       } else {
-        // content 差異時、source = 差異のあるブロック数、target = 全体ブロック数
+        // content 差異: differingCount が差異のあるブロック数、source が全体数
+        const differing = m.differingCount ?? 0;
         lines.push(
-          `- ${m.kind}: ${m.source} of ${m.target} code blocks inside blockquotes were modified. The content must remain BYTE-FOR-BYTE identical to the source.`,
+          `- ${m.kind}: ${differing} of ${m.source} code blocks inside blockquotes were modified. The content must remain BYTE-FOR-BYTE identical to the source.`,
         );
       }
+      hasBlockquoteCodeIssue = true;
+    } else if (m.kind === 'blockquoteInlineCodeContent') {
+      const differing = m.differingCount ?? 0;
+      lines.push(
+        `- ${m.kind}: ${differing} of ${m.source} inline code spans inside blockquotes were modified. Inline code inside blockquotes must remain BYTE-FOR-BYTE identical to the source.`,
+      );
       hasBlockquoteCodeIssue = true;
     } else {
       lines.push(`- ${m.kind}: source has ${m.source}, translation has ${m.target}`);

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -1,11 +1,17 @@
 import { createHash } from 'node:crypto';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+import { extractCode, restoreCode } from './code-extractor.ts';
+import { translateCodeBlock, type CodeTranslatorClient } from './code-translator.ts';
 import { buildEnFrontmatter, getAutoTranslatedFrom, isAutoTranslated, type Frontmatter } from './frontmatter.ts';
 import { proofread, formatProofIssues, type ProofreaderClient } from './proofreader.ts';
 import { validateStructure, type ValidationResult } from './structure-validator.ts';
 
-// proofreader（校正）を追加。translator が出した訳を別人格 LLM が意味整合性を検査する
-export const PROMPT_VERSION = 4;
+// PROMPT_VERSION:
+// 4: proofreader 導入
+// 5: code 抽出/プレースホルダ翻訳/code 復元方式に変更
+// 6: 各コードブロックを個別翻訳してからマージ（コメント翻訳のため）
+// 7: proofreader を「翻訳由来の不整合のみ flag」に修正（原文の不整合を誤検出していた）
+export const PROMPT_VERSION = 7;
 // preview だが最新世代品質を採用。GEMINI_MODEL env で stable (gemini-2.5-flash 等) に切替可能
 // 参考: https://ai.google.dev/gemini-api/docs/models
 export const DEFAULT_MODEL = 'gemini-3-flash-preview';
@@ -31,6 +37,7 @@ export interface TranslateOneArgs {
   enContent: string | null;
   geminiClient: GeminiClient;
   proofreaderClient: ProofreaderClient;
+  codeTranslatorClient: CodeTranslatorClient;
   model: string;
   slug?: string; // ログ識別用。省略時は jaPath の basename を使う
 }
@@ -102,6 +109,7 @@ function summarizeStructureMismatch(validation: ValidationResult): string {
 async function callWithRetries(
   client: GeminiClient,
   proofreaderClient: ProofreaderClient,
+  codeTranslatorClient: CodeTranslatorClient,
   model: string,
   input: { title: string; body: string },
   slug: string,
@@ -110,18 +118,55 @@ async function callWithRetries(
   | { ok: false; attempts: number }
   | { ok: false; attempts: number; thrownAt: number; cause: Error }
 > {
+  // ja body から code を抽出してプレースホルダ化。LLM には template だけ渡す。
+  // 各コードブロックは個別に翻訳（コメントのみ訳す）し、最終的に restoreCode でマージする
+  const { template: jaTemplate, codeBlocks, inlineCodes } = extractCode(input.body);
+
+  // 各コードブロックを個別翻訳（コメントのみ）。インラインコードは識別子なので翻訳しない
+  const translatedCodeBlocks: string[] = [];
+  for (let i = 0; i < codeBlocks.length; i++) {
+    const t = await translateCodeBlock({ code: codeBlocks[i], client: codeTranslatorClient, model });
+    translatedCodeBlocks.push(t);
+  }
+  if (codeBlocks.length > 0) {
+    const translatedCount = translatedCodeBlocks.filter((t, i) => t !== codeBlocks[i]).length;
+    if (translatedCount > 0) {
+      console.info(
+        `[auto-translate] code block comments translated for ${slug}: ${translatedCount}/${codeBlocks.length} blocks`,
+      );
+    }
+  }
+
   let feedback: string | undefined;
   for (let attempt = 1; attempt <= TOTAL_ATTEMPTS; attempt++) {
     let output: GeminiOutput;
     try {
-      output = await client({ title: input.title, body: input.body, feedback }, model);
+      // body は jaTemplate（プレースホルダ入り）を渡す
+      output = await client({ title: input.title, body: jaTemplate, feedback }, model);
     } catch (e) {
       // 試行中に API がエラー（ネットワーク・5xx・429 等）。試行番号を保持して呼び出し元へ
       return { ok: false, attempts: attempt, thrownAt: attempt, cause: e as Error };
     }
 
-    // (1) 構造検証（ローカル、コスト 0）
-    const validation = validateStructure(input.body, output.body_en);
+    // 翻訳結果（プレースホルダ入り）を、コメント翻訳済みのコードブロック + インラインコードで復元する
+    let restoredBody: string;
+    try {
+      restoredBody = restoreCode(output.body_en, translatedCodeBlocks, inlineCodes);
+    } catch (e) {
+      // LLM がプレースホルダを drop / 幻覚した場合に到達。retry で改善する可能性
+      if (attempt < TOTAL_ATTEMPTS) {
+        console.warn(
+          `[auto-translate] placeholder restoration failed (attempt ${attempt}/${TOTAL_ATTEMPTS}) for ${slug}: ${(e as Error).message} — retrying`,
+        );
+        feedback = `Your previous response did not preserve all code placeholders correctly. Each placeholder ⟨⟨BLOCK_N⟩⟩ and ⟨⟨INLINE_N⟩⟩ from the source MUST appear exactly once in your output, in a position that makes sense for the translation. Do not invent new placeholders. Do not omit any.`;
+      }
+      continue;
+    }
+    const restoredOutput: GeminiOutput = { title_en: output.title_en, body_en: restoredBody };
+
+    // (1) 構造検証（ローカル、コスト 0）。code は復元済みなので構造一致は trivial に成立する想定。
+    // 万一一致しないケース（LLM が prose 中で markdown 構造を破壊した等）への保険として残す
+    const validation = validateStructure(input.body, restoredOutput.body_en);
     if (!validation.ok) {
       if (attempt < TOTAL_ATTEMPTS) {
         console.warn(
@@ -132,10 +177,11 @@ async function callWithRetries(
       continue;
     }
 
-    // (2) proofread（別人格 LLM、API コール 1 回）。意味・整合性をチェック
+    // (2) proofread（別人格 LLM、API コール 1 回）。意味・整合性をチェック。
+    // 完全な en（code 復元済み）を渡すことで proofreader が prose-code 整合をチェックできる
     const proof = await proofread({
       jaSource: input.body,
-      enTranslation: output.body_en,
+      enTranslation: restoredOutput.body_en,
       client: proofreaderClient,
       model,
     });
@@ -143,7 +189,7 @@ async function callWithRetries(
       if (attempt > 1) {
         console.info(`[auto-translate] translation accepted on attempt ${attempt} for ${slug}`);
       }
-      return { ok: true, output, attempts: attempt };
+      return { ok: true, output: restoredOutput, attempts: attempt };
     }
 
     if (attempt < TOTAL_ATTEMPTS) {
@@ -159,7 +205,7 @@ async function callWithRetries(
 }
 
 export async function translateOne(args: TranslateOneArgs): Promise<TranslateResult> {
-  const { jaContent, enContent, geminiClient, proofreaderClient, model, jaPath } = args;
+  const { jaContent, enContent, geminiClient, proofreaderClient, codeTranslatorClient, model, jaPath } = args;
   const slug = args.slug ?? jaPath.split('/').pop() ?? jaPath;
 
   let ja: { frontmatter: Frontmatter; body: string };
@@ -221,7 +267,14 @@ export async function translateOne(args: TranslateOneArgs): Promise<TranslateRes
   // ここでの try-catch は予期せぬ例外（実装バグ等）の保険のみ
   let outcome: Awaited<ReturnType<typeof callWithRetries>>;
   try {
-    outcome = await callWithRetries(geminiClient, proofreaderClient, model, { title: jaTitle, body: ja.body }, slug);
+    outcome = await callWithRetries(
+      geminiClient,
+      proofreaderClient,
+      codeTranslatorClient,
+      model,
+      { title: jaTitle, body: ja.body },
+      slug,
+    );
   } catch (e) {
     return { kind: 'failed', reason: `unexpected error: ${(e as Error).message}` };
   }

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -90,10 +90,16 @@ function buildFeedback(validation: ValidationResult): string {
       }
       hasBlockquoteCodeIssue = true;
     } else if (m.kind === 'blockquoteInlineCodeContent') {
-      const differing = m.differingCount ?? 0;
-      lines.push(
-        `- ${m.kind}: ${differing} of ${m.source} inline code spans inside blockquotes were modified. Inline code inside blockquotes must remain BYTE-FOR-BYTE identical to the source.`,
-      );
+      if (m.differKind === 'count') {
+        lines.push(
+          `- ${m.kind}: an inline code span inside a blockquote was added or removed (source has ${m.source}, translation has ${m.target}).`,
+        );
+      } else {
+        const differing = m.differingCount ?? 0;
+        lines.push(
+          `- ${m.kind}: ${differing} of ${m.source} inline code spans inside blockquotes were modified. Inline code inside blockquotes must remain BYTE-FOR-BYTE identical to the source.`,
+        );
+      }
       hasBlockquoteCodeIssue = true;
     } else {
       lines.push(`- ${m.kind}: source has ${m.source}, translation has ${m.target}`);


### PR DESCRIPTION
## Summary

Production 稼働後、prose の変数名と code 識別子の不整合（例: \`active\` vs \`waiting\`）など、構造検証では検出できない意味的な翻訳ミスが発見された ([#1568 のコンテンツレビュー](https://github.com/lacolaco/blog.lacolaco.net/pull/1568#issuecomment-4323370151))。

translator が出した訳をそのまま採用するのは品質が不足するため、別人格 LLM による proofread ステージを追加する。

## アーキテクチャ

```
translator → 候補 en
              ↓
            structure-validator（ローカル、コスト 0）
              ↓ ok
            proofreader（別ロール LLM、API コール 1 回）
              ↓ ok → 採用
              ↓ ng → feedback で次 attempt へ
```

リトライループは構造検証と proofread の両方を統合（既存の MAX_RETRIES=3 を流用）。

## 役割分離

- **translator**: 訳す役。voice/hedging/style を保つ
- **proofreader**: 整合性チェック役。識別子不整合・反転意味・捏造・欠落・誤った技術用語のみ検出
- **structure-validator**: ローカルでカウント・byte 比較

## 実 API smoke 確認

\`tools/auto-translate/8892acbcdb0e.md\` で proofreader が attempt 1 に identifier 不整合（\`Image\` vs \`AstroImage\`）を検出してリトライ要求 → attempt 3 で採用。

## Test plan

- [x] 178 ユニットテスト pass
- [x] lint・format clean
- [x] 実 API smoke で proofreader 動作確認
- [ ] マージ後、production cron で稼働確認
- [ ] 1568 で発見された typo 類似ケース（\`active\` vs \`waiting\`）が再現しないか観察

🤖 Generated with [Claude Code](https://claude.com/claude-code)