### PR TITLE
fix(auto-translate): include specific restoreCode error in retry feedback

### DIFF
--- a/tools/auto-translate/translator.spec.ts
+++ b/tools/auto-translate/translator.spec.ts
@@ -390,6 +390,42 @@ describe('translateOne', () => {
       assert.ok(calls[1].feedback);
       assert.match(calls[1].feedback, /placeholder/i);
     });
+
+    test('placeholder order swap → 2 回目の feedback に restoreCode の具体的なエラー（位置・期待・実際）と order 強調が含まれる', async () => {
+      // 本番 angular-debounced-resource.md で再現した症状: LLM が連続する INLINE 系 placeholder を
+      // 並び替えてしまう（英語として自然な語順に変えるバイアス）。汎用 feedback では改善しないため、
+      // restoreCode の具体的なエラーメッセージ（"position N: expected X but found Y"）と
+      // 「順序を保て」という明示的な指示を 2 回目の feedback に含める必要がある
+      const ja = buildJaContent({
+        body: '`a` と `b` の話。\n\n```ts\nconst x = 1;\n```\n\nhttps://example.com\n',
+      });
+      const calls: { feedback?: string }[] = [];
+      let count = 0;
+      const client: GeminiClient = mock.fn((input) => {
+        calls.push({ feedback: input.feedback });
+        count++;
+        if (count === 1) {
+          // INLINE_0 と INLINE_1 を入れ替えた出力（restoreCode の order check で throw）
+          return Promise.resolve({
+            title_en: 'Title',
+            body_en: 'About ⟨⟨INLINE_1⟩⟩ and ⟨⟨INLINE_0⟩⟩.\n\n⟨⟨BLOCK_0⟩⟩\n\nhttps://example.com\n',
+          });
+        }
+        return Promise.resolve({
+          title_en: 'Title',
+          body_en: 'About ⟨⟨INLINE_0⟩⟩ and ⟨⟨INLINE_1⟩⟩.\n\n⟨⟨BLOCK_0⟩⟩\n\nhttps://example.com\n',
+        });
+      });
+      const result = await translateOne(makeArgs({ jaContent: ja, geminiClient: client }));
+      assert.equal(result.kind, 'translated');
+      assert.ok(calls[1].feedback);
+      // 具体的なエラー本文が含まれる（restoreCode の "position N: expected ⟨⟨INLINE_X⟩⟩ but found ⟨⟨INLINE_Y⟩⟩"
+      // がそのまま埋め込まれているか確認）。/position/i 単体だと他の feedback パスと区別できないため
+      // expected/found プレースホルダ表記まで含めて検証する
+      assert.match(calls[1].feedback, /position \d+: expected ⟨⟨INLINE_\d+⟩⟩ but found ⟨⟨INLINE_\d+⟩⟩/);
+      // 順序保持の明示（SAME ORDER キーワード）
+      assert.match(calls[1].feedback, /SAME ORDER/);
+    });
   });
 
   describe('proofread リトライ', () => {

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -73,6 +73,25 @@ export function joinFrontmatter(frontmatter: Frontmatter, body: string): string 
   return `---\n${yaml}---\n\n${body}`;
 }
 
+// restoreCode が throw した詳細メッセージ（"placeholder order mismatch at position N: expected X but found Y"
+// など）を再翻訳プロンプトに含めるための feedback ビルダー。汎用文言だけだと LLM が「英語として自然な
+// 語順」へ並び替えるバイアスを修正できないため、具体的なエラーと order 保持を明示する。
+//
+// インジェクション安全性: error 文字列は restoreCode 内のハードコード文言 + プレースホルダ名（kind は
+// `BLOCK|INLINE` のリテラル、idx は parseInt 済みの数値）のみから構成され、LLM の自由文字列が
+// そのまま埋め込まれることはない。したがって LLM 経由でのプロンプト書き換えは不可能
+function buildPlaceholderFeedback(error: string): string {
+  return [
+    `Your previous response did not preserve code placeholders correctly: ${error}`,
+    '',
+    'CRITICAL placeholder rules:',
+    '- Each ⟨⟨BLOCK_N⟩⟩ and ⟨⟨INLINE_N⟩⟩ from the source MUST appear exactly once in your output, verbatim.',
+    '- Placeholders MUST appear in the SAME ORDER as in the source. Do NOT reorder them even if it feels more natural in English.',
+    '- If two adjacent ⟨⟨INLINE_N⟩⟩ placeholders appear in source order N then N+1, they MUST appear in the same order in your translation. Restructure the sentence if needed to preserve order.',
+    '- Do not invent new placeholders. Do not omit any. Do not modify or duplicate them.',
+  ].join('\n');
+}
+
 function buildFeedback(validation: ValidationResult): string {
   const lines = ['The translation has structural mismatches with the source:'];
   let hasBlockquoteCodeIssue = false;
@@ -202,7 +221,7 @@ async function callWithRetries(
         console.warn(
           `[auto-translate] placeholder restoration failed (attempt ${attempt}/${TOTAL_ATTEMPTS}) for ${slug}: ${errorMessage(e)} — retrying`,
         );
-        feedback = `Your previous response did not preserve all code placeholders correctly. Each placeholder ⟨⟨BLOCK_N⟩⟩ and ⟨⟨INLINE_N⟩⟩ from the source MUST appear exactly once in your output, in a position that makes sense for the translation. Do not invent new placeholders. Do not omit any.`;
+        feedback = buildPlaceholderFeedback(errorMessage(e));
       }
       continue;
     }


### PR DESCRIPTION
## Summary

- 本番 \`angular-debounced-resource.md\` で 4 試行連続 placeholder order swap が発生していた問題を修正
- 汎用 retry feedback を、restoreCode の具体的なエラー（\"position N: expected X but found Y\"）+ SAME ORDER 強調を含む \`buildPlaceholderFeedback\` に置換
- LLM の「英語として自然な語順」バイアスを矯正する明示指示を追加

## 背景

PR #1569 マージ後の notion-sync 再トリガー (run 24980633922) で:
- 326 件 cache hit
- 1 件 failed: \`angular-debounced-resource.md\` (INLINE_3/INLINE_4 入れ替えが 4 試行連続発生)

既存 retry feedback は \"Each placeholder MUST appear exactly once...\" のみで、ORDER 保持に言及していなかった。LLM はエラーの具体内容を知らされないため毎回同じ swap を再現していた。

## Test plan

- [x] \`pnpm test:tools\` (245 pass)
- [x] \`pnpm lint\`, \`pnpm format\`
- [ ] CI code-review pass
- [ ] 次回 sync-with-notion 実行時に該当記事が成功すること（ランタイム検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)