### PR TITLE
fix(auto-translate): add basic English grammar checks to proofreader

### DIFF
--- a/tools/auto-translate/main.ts
+++ b/tools/auto-translate/main.ts
@@ -60,6 +60,10 @@ Detect:
 3. Translation-induced hallucinations: facts/terms/claims in the translation that are not in the source.
 4. Translation-induced omissions: significant content from the source missing in the translation.
 5. Wrong technical terminology drift: e.g., source uses "debounce" but translation says "throttle"; source uses "object" but translation says "instance".
+6. Basic English grammar errors that distract the reader, including but not limited to:
+   - Indefinite article agreement (a/an) — must match the PHONETIC sound of the following word, not its spelling. "an HTTP" is correct (vowel sound /eɪ/); "an \`loading\`" is WRONG ("loading" starts with consonant /l/, must be "a"); "a hour" is WRONG (silent h, must be "an"). When the article precedes a backtick-wrapped identifier, evaluate the identifier's first phonetic sound.
+   - Subject-verb agreement (e.g., "the data is" vs "the data are" — match the source's grammatical number).
+   - Sentence fragments that lack a subject or verb, when the source had a complete sentence.
 
 Do NOT flag:
 - Style or tone preferences (the translator handles voice).


### PR DESCRIPTION
## Summary

- PR #1575 の content-review で検出された a/an 不定冠詞誤用 (\`an \`loading\` state\`) を proofreader が見逃した
- PROOFREADER_INSTRUCTION の Detect リストに「basic English grammar errors」項を追加
- 不定冠詞は phonetic sound に従う（"an HTTP" 正、"an \`loading\`" 誤）旨を明示し、backtick 識別子直前の冠詞は識別子の発音で判定するよう指示

## 背景

PR #1575 で auto-generated \`angular-debounced-resource.en.md\` が "in an \`loading\` state" を含み content-review が NG になった。proofreader は translation-induced semantic defect 中心で basic grammar をスコープ外にしていたため見逃した。

## Test plan

- [x] \`pnpm test:tools\` (245 pass)
- [x] \`pnpm lint\`, \`pnpm format\`
- [ ] CI code-review pass
- [ ] 次回 sync で類似の a/an 誤用が proofreader でブロックされること（runtime 検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)