### PR TITLE
feat(claude): protect Notion-sourced content via hook + rule 2b

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/tools/protect-notion-content.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,21 @@ NEVER delete files/directories without user saying "yes, delete".
 - "Check compatibility" ≠ permission to delete
 - Show what will be deleted → Wait for approval → Then delete
 
+### 2b. Notion-Sourced Content (.md / .en.md) は絶対に編集しない
+**TRIGGER**: `src/content/post/notion/*.md` または `*.en.md` の typo / 文法 / 内容に問題を見つけたとき
+
+- これらのファイルは **すべて自動生成** (`.md` = Notion → notion-sync、`.en.md` = ja → auto-translate)
+- 直接編集すると次回 sync で上書きされる。content-review NG を見て直接 .md を直すのは **二重の違反** (DO NOT EDIT 違反 + 上流の真のソースを直さない)
+- 正しい対応:
+  - `.md` の問題 → ユーザに「Notion で修正してください」と報告し待つ。**勝手に直さない**
+  - `.en.md` の問題 → auto-translate パイプライン（prompt / proofreader / validator）の改善で対応
+- **sync-with-notion ブランチへの force-push は sync workflow が常時行う正常動作**。「自分の修正が消された」と誤認して再 push するな。force-push されたら **それが新しい真実** として再観測してから動け
+- 一次データ確認: ユーザが Notion を編集中の可能性があるなら、ローカル snapshot ではなく **最新の origin/sync-with-notion を fetch して確認** してから判断する
+
+失敗例 (PR #1575):
+- ❌ content-review NG → `.md` の typo を直接修正コミット → sync が上書き → reset+force-push → さらに sync が上書き → 古いデータで暴走
+- ✅ content-review NG → 「Notion で修正してください」と報告 → ユーザが Notion 修正 → 次回 sync で反映 → CI pass
+
 ### 3. TDD is Mandatory
 Kent Beck style. Tests = spec. Fix implementation, not tests.
 - 設計フェーズで検証方法を自然言語ではなく実行可能なテストコードとして書け

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,20 +25,13 @@ NEVER delete files/directories without user saying "yes, delete".
 - "Check compatibility" ≠ permission to delete
 - Show what will be deleted → Wait for approval → Then delete
 
-### 2b. Notion-Sourced Content (.md / .en.md) は絶対に編集しない
-**TRIGGER**: `src/content/post/notion/*.md` または `*.en.md` の typo / 文法 / 内容に問題を見つけたとき
+### 2b. Notion-Sourced Content (.md / .en.md) は編集しない
 
-- これらのファイルは **すべて自動生成** (`.md` = Notion → notion-sync、`.en.md` = ja → auto-translate)
-- 直接編集すると次回 sync で上書きされる。content-review NG を見て直接 .md を直すのは **二重の違反** (DO NOT EDIT 違反 + 上流の真のソースを直さない)
-- 正しい対応:
-  - `.md` の問題 → ユーザに「Notion で修正してください」と報告し待つ。**勝手に直さない**
-  - `.en.md` の問題 → auto-translate パイプライン（prompt / proofreader / validator）の改善で対応
-- **sync-with-notion ブランチへの force-push は sync workflow が常時行う正常動作**。「自分の修正が消された」と誤認して再 push するな。force-push されたら **それが新しい真実** として再観測してから動け
-- 一次データ確認: ユーザが Notion を編集中の可能性があるなら、ローカル snapshot ではなく **最新の origin/sync-with-notion を fetch して確認** してから判断する
+`src/content/post/notion/**/*.md` への Edit/Write は `tools/protect-notion-content.sh` PreToolUse hook が自動ブロック (`.claude/settings.json` で登録)。原則:
 
-失敗例 (PR #1575):
-- ❌ content-review NG → `.md` の typo を直接修正コミット → sync が上書き → reset+force-push → さらに sync が上書き → 古いデータで暴走
-- ✅ content-review NG → 「Notion で修正してください」と報告 → ユーザが Notion 修正 → 次回 sync で反映 → CI pass
+- `.md` (Notion → notion-sync) の問題 → **Notion で修正依頼**。勝手に直さない
+- `.en.md` (auto-translate 生成) の問題 → `tools/auto-translate/` パイプライン (prompt / proofreader / validator) で対応
+- **sync-with-notion への force-push は sync workflow の正常動作**。「自分の修正が消された」と誤認して再 push せず、`origin/sync-with-notion` を fetch して**新しい真実として再観測**してから動く
 
 ### 3. TDD is Mandatory
 Kent Beck style. Tests = spec. Fix implementation, not tests.

--- a/tools/protect-notion-content.sh
+++ b/tools/protect-notion-content.sh
@@ -3,11 +3,18 @@
 # Blocks edits to Notion-sourced content (.md / .en.md under src/content/post/notion/)
 # Rationale: these files are auto-generated (Notion → notion-sync, ja → auto-translate).
 # Direct edits get overwritten on next sync. Content fixes belong upstream (Notion / pipeline).
+#
+# Exit codes are managed explicitly (no `set -e`): unexpected non-zero exits would be
+# interpreted as undefined hook behavior by Claude Code. Always exit 0 (allow) on
+# environment issues (missing jq, malformed input) — fail-open is safer here than blocking
+# legitimate edits because of a tool-environment problem.
 
-set -e
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
 
 input=$(cat)
-file_path=$(echo "$input" | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty')
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty' 2>/dev/null)
 
 if [ -z "$file_path" ]; then
   exit 0

--- a/tools/protect-notion-content.sh
+++ b/tools/protect-notion-content.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# PreToolUse hook for Edit/Write/MultiEdit/NotebookEdit
+# Blocks edits to Notion-sourced content (.md / .en.md under src/content/post/notion/)
+# Rationale: these files are auto-generated (Notion → notion-sync, ja → auto-translate).
+# Direct edits get overwritten on next sync. Content fixes belong upstream (Notion / pipeline).
+
+set -e
+
+input=$(cat)
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty')
+
+if [ -z "$file_path" ]; then
+  exit 0
+fi
+
+# Match src/content/post/notion/**/*.md (both .md and .en.md)
+case "$file_path" in
+  */src/content/post/notion/*.md)
+    cat <<EOF >&2
+Cannot edit Notion-sourced content directly: $file_path
+
+These files are auto-generated:
+  - .md      → Notion (via notion-sync). Fix in Notion.
+  - .en.md   → ja .md (via auto-translate). Fix in tools/auto-translate/ pipeline (prompt / proofreader / validator).
+
+Direct edits are overwritten on next sync. See CLAUDE.md rule 2b.
+EOF
+    exit 2
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
## Summary

PR #1575 で発生した重大失敗（Notion 由来 .md を直接編集 + force-push 競合）の retrospective 結果。

## 改善実装

**Step 2: Deterministic Guardrail** (採用)
- `tools/protect-notion-content.sh`: PreToolUse hook — \`src/content/post/notion/**/*.md\` への Edit/Write/MultiEdit/NotebookEdit を exit 2 でブロック
- \`.claude/settings.json\`: hook を shared 設定として登録

**Step 5: CLAUDE.md ルール 2b** (補完)
- guardrail が一次防衛、ルール 2b は principle と remediation path の参照

## 学習要点

- `.md` (Notion → notion-sync) の問題 → Notion で修正
- `.en.md` (auto-translate 生成) の問題 → パイプライン改善
- sync-with-notion への force-push は正常動作、`origin/sync-with-notion` を fetch して「新しい真実」として再観測する

## Test plan

- [x] hook script が `.md` / `.en.md` をブロック、他は通過することを単体検証
- [x] `pnpm lint` / `pnpm format` pass
- [ ] CI code-review pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)