### PR TITLE
fix(auto-translate): bump MAX_RETRIES 3→5 for persistent placeholder swap

### DIFF
--- a/tools/auto-translate/translator.spec.ts
+++ b/tools/auto-translate/translator.spec.ts
@@ -6,10 +6,13 @@ import {
   translateOne,
   joinFrontmatter,
   splitFrontmatter,
+  MAX_RETRIES,
   PROMPT_VERSION,
   type GeminiClient,
   type TranslateOneArgs,
 } from './translator.ts';
+
+const TOTAL_ATTEMPTS = MAX_RETRIES + 1;
 import { buildEnFrontmatter } from './frontmatter.ts';
 import type { ProofreaderClient } from './proofreader.ts';
 import type { CodeTranslatorClient } from './code-translator.ts';
@@ -306,13 +309,13 @@ describe('translateOne', () => {
       assert.equal((client as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 2);
     });
 
-    test('placeholder 復元 4 試行全て NG → failed、API 呼び出し 4 回', async () => {
+    test('placeholder 復元 全 TOTAL_ATTEMPTS 試行 NG → failed、API 呼び出し TOTAL_ATTEMPTS 回', async () => {
       const client: GeminiClient = mock.fn(() =>
         Promise.resolve({ title_en: 'Title', body_en: TRANSLATED_BODY_BROKEN }),
       );
       const result = await translateOne(makeArgs({ geminiClient: client }));
       assert.equal(result.kind, 'failed');
-      assert.equal((client as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 4);
+      assert.equal((client as unknown as { mock: { calls: unknown[] } }).mock.calls.length, TOTAL_ATTEMPTS);
     });
 
     test('リトライ時のフィードバックメッセージに差分情報が含まれる', async () => {
@@ -448,7 +451,7 @@ describe('translateOne', () => {
       assert.equal((proofreaderClient as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 2);
     });
 
-    test('proofread が常に ng → 4 試行後 failed', async () => {
+    test('proofread が常に ng → TOTAL_ATTEMPTS 試行後 failed', async () => {
       const geminiClient = makeOkClient();
       const proofreaderClient: ProofreaderClient = mock.fn(() =>
         Promise.resolve({
@@ -458,8 +461,8 @@ describe('translateOne', () => {
       );
       const result = await translateOne(makeArgs({ geminiClient, proofreaderClient }));
       assert.equal(result.kind, 'failed');
-      assert.equal((geminiClient as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 4);
-      assert.equal((proofreaderClient as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 4);
+      assert.equal((geminiClient as unknown as { mock: { calls: unknown[] } }).mock.calls.length, TOTAL_ATTEMPTS);
+      assert.equal((proofreaderClient as unknown as { mock: { calls: unknown[] } }).mock.calls.length, TOTAL_ATTEMPTS);
     });
 
     test('placeholder 復元 NG の attempt では proofread を呼ばない（ローカル検証で先に reject）', async () => {
@@ -689,7 +692,7 @@ describe('translateOne', () => {
       assert.equal(result.kind, 'failed');
       assert.ok('reason' in result);
       // 2 回目（リトライ）で throw したことが reason から分かる
-      assert.match(result.reason, /attempt 2\/4/);
+      assert.match(result.reason, new RegExp(`attempt 2\\/${TOTAL_ATTEMPTS}`));
       assert.match(result.reason, /rate limit/);
     });
   });

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -14,7 +14,11 @@ export const PROMPT_VERSION = 5;
 // 将来 stable 移行・廃止時は GEMINI_MODEL env で適切な ID（例: gemini-3-flash 等の後継 GA 名）に切替可能。
 // 参考: https://ai.google.dev/gemini-api/docs/models
 export const DEFAULT_MODEL = 'gemini-3-flash-preview';
-export const MAX_RETRIES = 3;
+// MAX_RETRIES + 1 = TOTAL_ATTEMPTS. 観測実績: angular-debounced-resource.md は LLM が
+// 高頻度で placeholder swap を起こし、4 attempts では確率的に失敗するケースがあった
+// (sync run 24987177820 で 4/4 swap fail)。retry feedback で recover はできるが
+// 試行回数が足りない。6 attempts に増やしてカバー率を上げる
+export const MAX_RETRIES = 5;
 
 export interface GeminiInput {
   title: string;


### PR DESCRIPTION
## 課題

run 24987177820 で \`angular-debounced-resource.md\` が 4/4 attempts 全てで placeholder swap して fail (\`translated: 0, failed: 1\`)。

各 attempt のエラー:
- attempt 1: position 3 (INLINE_3 ↔ INLINE_4)
- attempt 2: position 12 (INLINE_9 ↔ INLINE_10)
- attempt 3: position 3 (INLINE_3 ↔ INLINE_4)
- attempt 4: 同様の swap (final fail)

LLM (gemini-3-flash-preview) は当該記事の sentence 構造で placeholder 順序を高頻度で swap する系統的バイアスがある。SYSTEM_INSTRUCTION の order rule (PR #1579) と retry feedback (PR #1574) は機能しているが、4 attempts では確率的にカバーしきれない。

## 改善

\`MAX_RETRIES\` を 3 → 5 に引き上げ (TOTAL_ATTEMPTS 4 → 6)。コスト増は当該記事のような困難ケースのみ発生。

テストの hardcoded \`4\` を \`TOTAL_ATTEMPTS\` 定数経由に置換、定数変更に追従できるようにした。

## Test plan

- [x] \`pnpm test:tools\` (245 pass)
- [x] \`pnpm lint\`, \`pnpm format\`
- [ ] CI code-review pass
- [ ] マージ後の sync で \`angular-debounced-resource.md\` の翻訳が成功すること（runtime 検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)