### PR TITLE
fix(auto-translate): drop inline code placeholder (root-cause fix for ja-en word order)

### DIFF
--- a/tools/auto-translate/code-extractor.spec.ts
+++ b/tools/auto-translate/code-extractor.spec.ts
@@ -14,23 +14,24 @@ describe('extractCode', () => {
     assert.equal(codeBlocks[0], '```ts\nconst a = 1;\n```');
   });
 
-  test('インラインコードを ⟨⟨INLINE_N⟩⟩ に置換する', () => {
+  test('インラインコードは抽出対象外（ja→en では既に英語/コードなので翻訳されない）', () => {
+    // ja → en 翻訳では inline code (`Signal` 等) は既に target language。
+    // placeholder 化するとja-en 語順差を「LLM の swap」と誤検出する原因になるため、
+    // inline は template にそのまま残し LLM に渡す。LLM は backtick 識別子を保持する想定
     const md = 'use `foo` and `bar` here\n';
     const { template, inlineCodes } = extractCode(md);
-    assert.equal(inlineCodes.length, 2);
-    assert.equal(template, 'use ⟨⟨INLINE_0⟩⟩ and ⟨⟨INLINE_1⟩⟩ here\n');
-    assert.equal(inlineCodes[0], '`foo`');
-    assert.equal(inlineCodes[1], '`bar`');
+    assert.equal(inlineCodes.length, 0);
+    assert.equal(template, 'use `foo` and `bar` here\n');
   });
 
-  test('コードブロック・インラインコードが混在', () => {
+  test('コードブロックは抽出する、インラインはそのまま残す', () => {
     const md = 'use `foo`\n\n```\ncode\n```\n\nthen `bar`\n';
     const { template, codeBlocks, inlineCodes } = extractCode(md);
     assert.equal(codeBlocks.length, 1);
-    assert.equal(inlineCodes.length, 2);
-    assert.match(template, /⟨⟨INLINE_0⟩⟩/);
+    assert.equal(inlineCodes.length, 0);
+    assert.match(template, /use `foo`/);
     assert.match(template, /⟨⟨BLOCK_0⟩⟩/);
-    assert.match(template, /⟨⟨INLINE_1⟩⟩/);
+    assert.match(template, /then `bar`/);
   });
 
   test('複数コードブロックは順番に番号付け', () => {

--- a/tools/auto-translate/code-extractor.spec.ts
+++ b/tools/auto-translate/code-extractor.spec.ts
@@ -5,9 +5,8 @@ import { extractCode, restoreCode } from './code-extractor.ts';
 describe('extractCode', () => {
   test('コードブロックを ⟨⟨BLOCK_N⟩⟩ に置換する', () => {
     const md = 'before\n\n```ts\nconst a = 1;\n```\n\nafter\n';
-    const { template, codeBlocks, inlineCodes } = extractCode(md);
+    const { template, codeBlocks } = extractCode(md);
     assert.equal(codeBlocks.length, 1);
-    assert.equal(inlineCodes.length, 0);
     assert.match(template, /⟨⟨BLOCK_0⟩⟩/);
     assert.match(template, /^before/);
     assert.match(template, /after\n$/);
@@ -16,19 +15,18 @@ describe('extractCode', () => {
 
   test('インラインコードは抽出対象外（ja→en では既に英語/コードなので翻訳されない）', () => {
     // ja → en 翻訳では inline code (`Signal` 等) は既に target language。
-    // placeholder 化するとja-en 語順差を「LLM の swap」と誤検出する原因になるため、
+    // placeholder 化すると ja-en 語順差を「LLM の swap」と誤検出する原因になるため、
     // inline は template にそのまま残し LLM に渡す。LLM は backtick 識別子を保持する想定
     const md = 'use `foo` and `bar` here\n';
-    const { template, inlineCodes } = extractCode(md);
-    assert.equal(inlineCodes.length, 0);
+    const { template, codeBlocks } = extractCode(md);
+    assert.equal(codeBlocks.length, 0);
     assert.equal(template, 'use `foo` and `bar` here\n');
   });
 
   test('コードブロックは抽出する、インラインはそのまま残す', () => {
     const md = 'use `foo`\n\n```\ncode\n```\n\nthen `bar`\n';
-    const { template, codeBlocks, inlineCodes } = extractCode(md);
+    const { template, codeBlocks } = extractCode(md);
     assert.equal(codeBlocks.length, 1);
-    assert.equal(inlineCodes.length, 0);
     assert.match(template, /use `foo`/);
     assert.match(template, /⟨⟨BLOCK_0⟩⟩/);
     assert.match(template, /then `bar`/);
@@ -43,11 +41,10 @@ describe('extractCode', () => {
     assert.match(template, /⟨⟨BLOCK_0⟩⟩[\s\S]*⟨⟨BLOCK_1⟩⟩/);
   });
 
-  test('コードがないと codeBlocks/inlineCodes は空、template は元と同じ', () => {
+  test('コードがないと codeBlocks は空、template は元と同じ', () => {
     const md = 'plain prose\n';
-    const { template, codeBlocks, inlineCodes } = extractCode(md);
+    const { template, codeBlocks } = extractCode(md);
     assert.equal(codeBlocks.length, 0);
-    assert.equal(inlineCodes.length, 0);
     assert.equal(template, md);
   });
 
@@ -59,12 +56,12 @@ describe('extractCode', () => {
 
   test('チルダフェンス (~~~) でも抽出と round-trip が成立する', () => {
     const md = 'before\n\n~~~ts\nconst x = 1;\n~~~\n\nafter\n';
-    const { template, codeBlocks, inlineCodes } = extractCode(md);
+    const { template, codeBlocks } = extractCode(md);
     assert.equal(codeBlocks.length, 1);
     assert.equal(codeBlocks[0], '~~~ts\nconst x = 1;\n~~~');
     assert.match(template, /⟨⟨BLOCK_0⟩⟩/);
     // round-trip
-    assert.equal(restoreCode(template, codeBlocks, inlineCodes), md);
+    assert.equal(restoreCode(template, codeBlocks), md);
   });
 
   test('コードブロック内の引用符・特殊文字をそのまま保持', () => {
@@ -78,30 +75,28 @@ describe('extractCode', () => {
     // プレースホルダ化すると下流の translateCodeBlock の fence 検証が壊れて silent failure になる。
     // よって code-extractor は blockquote 内 code を抽出対象外にし、template に残して LLM の prose 翻訳に委ねる
     const md = '前置き\n\n> ```ts\n> const x = 1;\n> ```\n\n後置き\n';
-    const { template, codeBlocks, inlineCodes } = extractCode(md);
+    const { template, codeBlocks } = extractCode(md);
     assert.equal(codeBlocks.length, 0);
-    assert.equal(inlineCodes.length, 0);
     assert.equal(template, md);
     // 念のため round-trip も確認
-    assert.equal(restoreCode(template, codeBlocks, inlineCodes), md);
+    assert.equal(restoreCode(template, codeBlocks), md);
   });
 
   test('blockquote 内のインラインコードも抽出対象外', () => {
     const md = '> 引用文中の `foo` という識別子\n';
-    const { template, codeBlocks, inlineCodes } = extractCode(md);
+    const { template, codeBlocks } = extractCode(md);
     assert.equal(codeBlocks.length, 0);
-    assert.equal(inlineCodes.length, 0);
     assert.equal(template, md);
   });
 
   test('prose 中にプレースホルダ風文字列があっても衝突しない（escape による退避）', () => {
     // このシステム自体を解説する記事を想定: prose 中で「⟨⟨BLOCK_0⟩⟩」を文字列として参照
     const md = '解説: ⟨⟨BLOCK_0⟩⟩ という記法を使う。\n\n```ts\nconst x = 1;\n```\n';
-    const { template, codeBlocks, inlineCodes } = extractCode(md);
+    const { template, codeBlocks } = extractCode(md);
     // template には実際のプレースホルダだけが exactly 1 回だけ出現する
     assert.equal(codeBlocks.length, 1);
     // round-trip で元に戻る
-    const restored = restoreCode(template, codeBlocks, inlineCodes);
+    const restored = restoreCode(template, codeBlocks);
     assert.equal(restored, md);
   });
 
@@ -121,70 +116,42 @@ describe('extractCode', () => {
 });
 
 describe('restoreCode', () => {
-  test('プレースホルダを元の code で置換する', () => {
-    const template = 'use ⟨⟨INLINE_0⟩⟩\n\n⟨⟨BLOCK_0⟩⟩\n';
-    const result = restoreCode(template, ['```\nA\n```'], ['`foo`']);
+  test('BLOCK プレースホルダを元の code で置換する', () => {
+    const template = 'use `foo`\n\n⟨⟨BLOCK_0⟩⟩\n';
+    const result = restoreCode(template, ['```\nA\n```']);
     assert.equal(result, 'use `foo`\n\n```\nA\n```\n');
   });
 
-  test('複数プレースホルダを順番通りに置換', () => {
-    const template = '⟨⟨INLINE_0⟩⟩ and ⟨⟨INLINE_1⟩⟩';
-    const result = restoreCode(template, [], ['`a`', '`b`']);
-    assert.equal(result, '`a` and `b`');
-  });
-
   test('extractCode → restoreCode が round-trip で元に戻る', () => {
-    const md = 'use `foo` and `bar`\n\n```ts\nconst a = 1;\n```\n\nthen ```inline``` ?\n';
-    const { template, codeBlocks, inlineCodes } = extractCode(md);
-    const restored = restoreCode(template, codeBlocks, inlineCodes);
+    const md = 'use `foo` and `bar`\n\n```ts\nconst a = 1;\n```\n\nthen `inline` ?\n';
+    const { template, codeBlocks } = extractCode(md);
+    const restored = restoreCode(template, codeBlocks);
     assert.equal(restored, md);
   });
 
-  test('プレースホルダが残っていたら throw（LLM が消失させた場合の検知）', () => {
-    const template = '⟨⟨INLINE_0⟩⟩'; // INLINE_0 だけだが inlineCodes には 2 個
-    assert.throws(() => restoreCode(template, [], ['`a`', '`b`']), /placeholder/i);
+  test('プレースホルダが消失していたら throw（LLM が drop した場合の検知）', () => {
+    // codeBlocks は 2 個だが template には BLOCK_0 しかない
+    const template = '⟨⟨BLOCK_0⟩⟩';
+    assert.throws(() => restoreCode(template, ['```\nA\n```', '```\nB\n```']), /missing/i);
   });
 
-  test('テンプレートに余分なプレースホルダがあれば throw（LLM が幻覚した場合の検知）', () => {
-    const template = '⟨⟨INLINE_0⟩⟩ ⟨⟨INLINE_5⟩⟩'; // INLINE_5 はそもそも extract されていない
-    assert.throws(() => restoreCode(template, [], ['`a`']), /placeholder/i);
+  test('テンプレートに extract されていない番号のプレースホルダがあれば throw（LLM 幻覚）', () => {
+    // BLOCK_5 は extract されていない。順序チェックが先に走るため order mismatch で reject される
+    const template = '⟨⟨BLOCK_0⟩⟩ ⟨⟨BLOCK_5⟩⟩';
+    assert.throws(() => restoreCode(template, ['```\nA\n```']), /placeholder/i);
   });
 
-  test('プレースホルダの順序が入れ替わっていたら throw（LLM が swap した場合の検知）', () => {
-    // template 内で BLOCK_1 が BLOCK_0 より先に現れる順序入れ替えケース
+  test('プレースホルダの順序が入れ替わっていたら throw（block code の論理順序保護）', () => {
+    // template 内で BLOCK_1 が BLOCK_0 より先に現れる順序入れ替え。
+    // block code の段落順序が swap = 記事の論理構造の破壊なので reject する
+    // (inline と異なり block は文中での自由な reorder が起きないため)
     const template = '前置き ⟨⟨BLOCK_1⟩⟩\n\n後置き ⟨⟨BLOCK_0⟩⟩';
-    assert.throws(() => restoreCode(template, ['```\nA\n```', '```\nB\n```'], []), /placeholder order mismatch/i);
+    assert.throws(() => restoreCode(template, ['```\nA\n```', '```\nB\n```']), /placeholder order mismatch/i);
   });
 
-  test('BLOCK と INLINE のクロス順序入れ替えを検出（expectedSequence 渡し）', () => {
-    // 元のドキュメント順: INLINE_0 → BLOCK_0
-    // LLM が反転: BLOCK_0 → INLINE_0
-    const md = 'use `foo`\n\n```\nA\n```\n';
-    const { codeBlocks, inlineCodes, placeholderSequence } = extractCode(md);
-    // template を意図的に反転させる
-    const swappedTemplate = '⟨⟨BLOCK_0⟩⟩\n\nuse ⟨⟨INLINE_0⟩⟩\n';
-    assert.throws(
-      () => restoreCode(swappedTemplate, codeBlocks, inlineCodes, placeholderSequence),
-      /placeholder order mismatch/i,
-    );
-  });
-
-  test('expectedSequence 通りの順序なら restoreCode 成功', () => {
-    const md = 'use `foo`\n\n```\nA\n```\n';
-    const extracted = extractCode(md);
-    const restored = restoreCode(
-      extracted.template,
-      extracted.codeBlocks,
-      extracted.inlineCodes,
-      extracted.placeholderSequence,
-    );
-    assert.equal(restored, md);
-  });
-
-  test('プレースホルダが重複していたら throw（LLM が duplicate した場合の検知）', () => {
-    // テンプレート内で ⟨⟨BLOCK_0⟩⟩ が 2 回出現 → コード重複挿入のリスク
+  test('プレースホルダが重複していたら throw（LLM duplicate 検知）', () => {
     const template = '⟨⟨BLOCK_0⟩⟩\n\n再掲: ⟨⟨BLOCK_0⟩⟩';
-    assert.throws(() => restoreCode(template, ['```\nA\n```'], []), /appears 2 times/i);
+    assert.throws(() => restoreCode(template, ['```\nA\n```']), /appears 2 times/i);
   });
 
   test('コードブロックの内容にプレースホルダ風の文字列が含まれても誤検知しない', () => {
@@ -193,7 +160,7 @@ describe('restoreCode', () => {
     // 誤って throw してしまうため、このケースで正常に復元できることを保証する
     const template = '解説: ⟨⟨BLOCK_0⟩⟩';
     const codeWithPlaceholderText = '```ts\n// プレースホルダ ⟨⟨BLOCK_1⟩⟩ について\n```';
-    const result = restoreCode(template, [codeWithPlaceholderText], []);
+    const result = restoreCode(template, [codeWithPlaceholderText]);
     assert.equal(result, '解説: ' + codeWithPlaceholderText);
   });
 });

--- a/tools/auto-translate/code-extractor.ts
+++ b/tools/auto-translate/code-extractor.ts
@@ -1,6 +1,11 @@
-// LLM に code を見せず prose だけ翻訳させるための extractor / restorer。
-// LLM に code byte-fidelity を要求するのは無理筋なので、コードを抽出してプレースホルダ ⟨⟨BLOCK_N⟩⟩ /
-// ⟨⟨INLINE_N⟩⟩ に置換し、翻訳後にプログラムで復元する。これにより code は LLM を経由しない。
+// LLM に block code を見せず prose だけ翻訳させるための extractor / restorer。
+// block code (multi-line / indent / syntax) は LLM の byte-fidelity が信用できないので
+// プレースホルダ ⟨⟨BLOCK_N⟩⟩ に置換し翻訳後に復元する。
+//
+// inline code (backtick 識別子) は抽出しない。理由: 翻訳方向は常に ja → en で、inline code
+// (`Signal` `Resource` 等) は元から英語/識別子。LLM に翻訳圧力がかからないため改変リスクが
+// 元々低い。逆に placeholder 化すると ja-en の語順差を「LLM の swap」と誤検出してしまい、
+// 自然な英訳 (例: ja `Signal`→`Resource` 順 vs en `Resource`→`Signal` 順) を reject する。
 
 import { remark } from 'remark';
 import remarkGfm from 'remark-gfm';
@@ -97,12 +102,8 @@ export function extractCode(markdown: string): ExtractedCode {
       codeBlocks.push(escapedMarkdown.slice(start, end));
       replacements.push({ start, end, replacement: BLOCK_PLACEHOLDER(idx) });
       placeholderSequence.push({ kind: 'BLOCK', idx });
-    } else if (node.type === 'inlineCode') {
-      const idx = inlineCodes.length;
-      inlineCodes.push(escapedMarkdown.slice(start, end));
-      replacements.push({ start, end, replacement: INLINE_PLACEHOLDER(idx) });
-      placeholderSequence.push({ kind: 'INLINE', idx });
     }
+    // inlineCode は抽出しない（top-level のコメント参照）
   });
 
   // 右から左へ置換することでオフセットがズレないようにする

--- a/tools/auto-translate/code-extractor.ts
+++ b/tools/auto-translate/code-extractor.ts
@@ -16,10 +16,9 @@ import { hasBlockquoteAncestor } from './ast-utils.ts';
 const remarkProcessor = remark().use(remarkGfm);
 
 const BLOCK_PLACEHOLDER = (i: number) => `⟨⟨BLOCK_${i}⟩⟩`;
-const INLINE_PLACEHOLDER = (i: number) => `⟨⟨INLINE_${i}⟩⟩`;
 // g フラグ付きモジュール定数は exec() ループで lastIndex が残留する落とし穴があるため、
 // パターンは source 文字列で保持して使用箇所で new RegExp する
-const PLACEHOLDER_PATTERN_SOURCE = '⟨⟨(BLOCK|INLINE)_(\\d+)⟩⟩';
+const PLACEHOLDER_PATTERN_SOURCE = '⟨⟨BLOCK_(\\d+)⟩⟩';
 
 // prose 中に文字列として ⟨⟨ や ⟩⟩ が現れる場合（このシステム自体を解説する記事等）に、
 // extractCode が生成するプレースホルダと衝突しないよう一旦別文字に escape する。
@@ -43,11 +42,6 @@ function unescapeBareMarkers(s: string): string {
   return s.split(ESCAPED_OPEN).join('⟨⟨').split(ESCAPED_CLOSE).join('⟩⟩');
 }
 
-export interface PlaceholderRef {
-  kind: 'BLOCK' | 'INLINE';
-  idx: number;
-}
-
 export interface ExtractedCode {
   /**
    * プレースホルダで code を置換した markdown。LLM にはこれを渡す。
@@ -61,16 +55,6 @@ export interface ExtractedCode {
    * 直接使わないこと
    */
   codeBlocks: string[];
-  /**
-   * インラインコードのテキスト（バッククォート含む）を順序通りに保持。
-   * codeBlocks と同様に escape 処理済みのテキストである点に注意
-   */
-  inlineCodes: string[];
-  /**
-   * BLOCK と INLINE の出現順序（ドキュメント順、左→右）。
-   * restoreCode の検証で「LLM が BLOCK と INLINE のクロス順序を入れ替えた」を検出するために使う
-   */
-  placeholderSequence: PlaceholderRef[];
 }
 
 // 注意: blockquote 内の code/inlineCode は markdown.slice() が "> " プレフィックス混在の文字列を返すため、
@@ -84,9 +68,6 @@ export function extractCode(markdown: string): ExtractedCode {
   const tree = remarkProcessor.parse(escapedMarkdown);
   const replacements: { start: number; end: number; replacement: string }[] = [];
   const codeBlocks: string[] = [];
-  const inlineCodes: string[] = [];
-  // ドキュメント順（visit 順 = 左→右出現順）の placeholder 列。クロス型の順序検証に使う
-  const placeholderSequence: PlaceholderRef[] = [];
 
   visitParents(tree, (node: Node, ancestors: Parent[]) => {
     const pos = node.position;
@@ -101,9 +82,9 @@ export function extractCode(markdown: string): ExtractedCode {
       // codeBlocks には escape された状態で保持。restoreCode の最後で全体を unescape する
       codeBlocks.push(escapedMarkdown.slice(start, end));
       replacements.push({ start, end, replacement: BLOCK_PLACEHOLDER(idx) });
-      placeholderSequence.push({ kind: 'BLOCK', idx });
     }
-    // inlineCode は抽出しない（top-level のコメント参照）
+    // inlineCode は抽出しない: ja → en では inline code (`Signal` 等) は元から英語/識別子で
+    // 翻訳対象でない。template に backtick ごとそのまま残し LLM に直接見せる
   });
 
   // 右から左へ置換することでオフセットがズレないようにする
@@ -112,7 +93,7 @@ export function extractCode(markdown: string): ExtractedCode {
   for (const r of replacements) {
     template = template.slice(0, r.start) + r.replacement + template.slice(r.end);
   }
-  return { template, codeBlocks, inlineCodes, placeholderSequence };
+  return { template, codeBlocks };
 }
 
 function countOccurrences(haystack: string, needle: string): number {
@@ -120,50 +101,7 @@ function countOccurrences(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1;
 }
 
-// テンプレート内のプレースホルダ列が expected（extractCode の visit 順、ドキュメント順）と
-// 完全一致することを検証する。BLOCK 同士・INLINE 同士の番号順だけでなく、
-// BLOCK と INLINE のクロス順序入れ替えも検出する。
-// 順序入れ替えは記事の意味的構造を壊すため拒否する
-function validatePlaceholderOrder(
-  template: string,
-  expected: readonly PlaceholderRef[],
-): { ok: boolean; reason?: string } {
-  const re = new RegExp(PLACEHOLDER_PATTERN_SOURCE, 'g');
-  let i = 0;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(template)) !== null) {
-    if (i >= expected.length) {
-      return {
-        ok: false,
-        reason: `placeholder order mismatch: extra placeholder ⟨⟨${m[1]}_${m[2]}⟩⟩ at position ${i} (expected ${expected.length} placeholders total)`,
-      };
-    }
-    const kind = m[1] as 'BLOCK' | 'INLINE';
-    const idx = parseInt(m[2], 10);
-    const want = expected[i];
-    if (kind !== want.kind || idx !== want.idx) {
-      return {
-        ok: false,
-        reason: `placeholder order mismatch at position ${i}: expected ⟨⟨${want.kind}_${want.idx}⟩⟩ but found ⟨⟨${kind}_${idx}⟩⟩ (LLM may have swapped placeholder order)`,
-      };
-    }
-    i++;
-  }
-  if (i < expected.length) {
-    return {
-      ok: false,
-      reason: `placeholder order mismatch: missing ${expected.length - i} placeholders at the end (expected total ${expected.length}, got ${i})`,
-    };
-  }
-  return { ok: true };
-}
-
-export function restoreCode(
-  template: string,
-  codeBlocks: string[],
-  inlineCodes: string[],
-  expectedSequence?: readonly PlaceholderRef[],
-): string {
+export function restoreCode(template: string, codeBlocks: string[]): string {
   // テンプレート側で各プレースホルダが exactly 1 回現れることを検証する。
   // - 0 回 = LLM が drop した
   // - 2 回以上 = LLM が重複させた（同じ code が複数箇所に挿入されてしまう）
@@ -179,77 +117,35 @@ export function restoreCode(
       throw new Error(`Restore failed: placeholder ${ph} appears ${n} times in template (LLM duplicated it?)`);
     }
   }
-  for (let i = 0; i < inlineCodes.length; i++) {
-    const ph = INLINE_PLACEHOLDER(i);
-    const n = countOccurrences(template, ph);
-    if (n === 0) {
-      throw new Error(`Restore failed: placeholder ${ph} missing from template (LLM dropped it?)`);
-    }
-    if (n > 1) {
-      throw new Error(`Restore failed: placeholder ${ph} appears ${n} times in template (LLM duplicated it?)`);
-    }
-  }
 
-  // 順序検証: expectedSequence が渡されればドキュメント順との完全一致を検証（クロス型入れ替えも検出）。
-  // 渡されない場合は BLOCK 同士・INLINE 同士の番号昇順のみ検証（後方互換）
-  if (expectedSequence !== undefined) {
-    const order = validatePlaceholderOrder(template, expectedSequence);
-    if (!order.ok) {
-      throw new Error(`Restore failed: ${order.reason ?? 'placeholder order invalid'}`);
+  // BLOCK の番号昇順検証: ja の出現順 = en の出現順を要求する。
+  // block code は段落的構造を持つため、code block 自体の順序が ja と en で異なるのは
+  // 記事の論理構造の破壊を意味する（inline と違い、文中での自由な reorder は起きない）
+  const re = new RegExp(PLACEHOLDER_PATTERN_SOURCE, 'g');
+  let blockExpected = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(template)) !== null) {
+    const idx = parseInt(m[1], 10);
+    if (idx !== blockExpected) {
+      throw new Error(
+        `Restore failed: placeholder order mismatch: expected ⟨⟨BLOCK_${blockExpected}⟩⟩ but found ⟨⟨BLOCK_${idx}⟩⟩`,
+      );
     }
-  } else {
-    // legacy: BLOCK と INLINE をそれぞれ独立に番号昇順チェック
-    const re = new RegExp(PLACEHOLDER_PATTERN_SOURCE, 'g');
-    let blockExpected = 0;
-    let inlineExpected = 0;
-    let m: RegExpExecArray | null;
-    while ((m = re.exec(template)) !== null) {
-      const kind = m[1];
-      const idx = parseInt(m[2], 10);
-      if (kind === 'BLOCK') {
-        if (idx !== blockExpected) {
-          throw new Error(
-            `Restore failed: placeholder order mismatch: expected ⟨⟨BLOCK_${blockExpected}⟩⟩ but found ⟨⟨BLOCK_${idx}⟩⟩`,
-          );
-        }
-        blockExpected++;
-      } else {
-        if (idx !== inlineExpected) {
-          throw new Error(
-            `Restore failed: placeholder order mismatch: expected ⟨⟨INLINE_${inlineExpected}⟩⟩ but found ⟨⟨INLINE_${idx}⟩⟩`,
-          );
-        }
-        inlineExpected++;
-      }
-    }
+    blockExpected++;
   }
 
   // テンプレート内のプレースホルダを順序通りに置換。
   // String#replace のコールバック形式を使い、$ を含む code が special replacement として誤解釈されないようにする
-  const restored = template.replace(
-    new RegExp(PLACEHOLDER_PATTERN_SOURCE, 'g'),
-    (_match, kind: string, idxStr: string) => {
-      const idx = parseInt(idxStr, 10);
-      if (!Number.isInteger(idx) || idx < 0) {
-        throw new Error(`Restore failed: invalid placeholder index "${idxStr}"`);
-      }
-      if (kind === 'BLOCK') {
-        if (idx >= codeBlocks.length) {
-          throw new Error(
-            `Restore failed: placeholder ⟨⟨BLOCK_${idx}⟩⟩ has no corresponding code block (hallucinated?)`,
-          );
-        }
-        return codeBlocks[idx];
-      }
-      // INLINE
-      if (idx >= inlineCodes.length) {
-        throw new Error(
-          `Restore failed: placeholder ⟨⟨INLINE_${idx}⟩⟩ has no corresponding inline code (hallucinated?)`,
-        );
-      }
-      return inlineCodes[idx];
-    },
-  );
+  const restored = template.replace(new RegExp(PLACEHOLDER_PATTERN_SOURCE, 'g'), (_match, idxStr: string) => {
+    const idx = parseInt(idxStr, 10);
+    if (!Number.isInteger(idx) || idx < 0) {
+      throw new Error(`Restore failed: invalid placeholder index "${idxStr}"`);
+    }
+    if (idx >= codeBlocks.length) {
+      throw new Error(`Restore failed: placeholder ⟨⟨BLOCK_${idx}⟩⟩ has no corresponding code block (hallucinated?)`);
+    }
+    return codeBlocks[idx];
+  });
 
   // extractCode で escape した ⟪⟪ ⟫⟫ を元の ⟨⟨ ⟩⟩ に戻す（prose 中・code 内容両方に適用）
   return unescapeBareMarkers(restored);

--- a/tools/auto-translate/main.ts
+++ b/tools/auto-translate/main.ts
@@ -24,17 +24,20 @@ Title rules:
 - Do NOT expand short Japanese titles into long descriptive English titles. If the source is "Xを対象として見る", prefer "Viewing X as an Object" over "Viewing X as the Object of Your Work".
 - Avoid adding clarifying phrases that are not in the source.
 
-Code placeholders (CRITICAL — read carefully):
-The body you receive has had its code blocks and inline code replaced with opaque placeholders:
+Code blocks (CRITICAL — read carefully):
+The body you receive has had its FENCED code blocks (multi-line \`\`\`...\`\`\` or ~~~...~~~) replaced with opaque placeholders:
 - ⟨⟨BLOCK_0⟩⟩, ⟨⟨BLOCK_1⟩⟩, ... — represent fenced code blocks
-- ⟨⟨INLINE_0⟩⟩, ⟨⟨INLINE_1⟩⟩, ... — represent inline code (was wrapped in backticks in the source)
 
-Rules for placeholders:
-- Each placeholder MUST appear exactly once in your output, in a position that corresponds to where the original code appeared in the source.
+Rules for ⟨⟨BLOCK_N⟩⟩ placeholders:
+- Each placeholder MUST appear exactly once in your output, in a position that corresponds to where the original block appeared in the source.
 - Do NOT translate, modify, or remove placeholders. Copy them verbatim.
 - Do NOT invent new placeholders.
 - Do NOT wrap placeholders in additional backticks, brackets, or formatting.
-- When you reference a placeholder in prose (e.g., describing what the code does), refer to it by its placeholder token directly.
+
+Inline code (single backticks, e.g. \`Signal\`, \`Resource\`):
+- Inline code is NOT replaced by placeholders. It appears verbatim in the body.
+- These are programming identifiers/keywords. They are already in English/code form — do NOT translate them, do NOT change spelling, do NOT add or remove backticks.
+- You MAY reorder inline code within a sentence to fit natural English word order (Japanese SOV → English SVO frequently requires this). Order in the English output need NOT match the source order.
 
 Escape markers (⟪⟪ and ⟫⟫):
 - The source you receive may contain the literal sequences ⟪⟪ and ⟫⟫ (mathematical double angle brackets, U+27EA / U+27EB).
@@ -51,7 +54,6 @@ Other structural rules:
 English correctness rules (CRITICAL — these prevent common LLM defects):
 - Indefinite articles a/an follow PHONETIC sound, not spelling, of the next word: "an HTTP" (vowel sound), "a URL" (consonant /j/), "a one-time" (consonant /w/), "an hour" (silent h). For backtick-wrapped identifiers, use the identifier's first phonetic sound: "a \`loading\`" (consonant /l/), NOT "an \`loading\`".
 - Programming-language literals (booleans, null/None, undefined) MUST keep their source-code casing in prose. Do NOT capitalize "true" to "True" because the word starts a sentence or follows a verb. JS/TS use lowercase \`true\`/\`false\`/\`null\`/\`undefined\`. Python uses capitalized \`True\`/\`False\`/\`None\`. Match what the article's surrounding code blocks use.
-- Adjacent placeholders ⟨⟨INLINE_N⟩⟩⟨⟨INLINE_N+1⟩⟩ MUST appear in the SAME ORDER as the source. If the natural English word order would reverse them, restructure the sentence rather than swap the placeholders.
 
 Output only the translated title and body (with placeholders preserved) in the requested JSON schema. Do not include the YAML frontmatter.`;
 

--- a/tools/auto-translate/proofreader.ts
+++ b/tools/auto-translate/proofreader.ts
@@ -49,7 +49,7 @@ export function formatProofIssues(issues: ProofIssue[]): string {
   // 翻訳者 LLM はコードブロックを直接見ず ⟨⟨BLOCK_N⟩⟩ プレースホルダのみを受け取るため、
   // 「code blocks unchanged」ではなくプレースホルダを明示した指示にする
   lines.push(
-    'Please retranslate addressing these issues. Keep all placeholders ⟨⟨BLOCK_N⟩⟩ and ⟨⟨INLINE_N⟩⟩ verbatim.',
+    'Please retranslate addressing these issues. Keep all ⟨⟨BLOCK_N⟩⟩ placeholders verbatim and preserve backtick inline code identifiers as-is.',
   );
   return lines.join('\n');
 }

--- a/tools/auto-translate/structure-validator.ts
+++ b/tools/auto-translate/structure-validator.ts
@@ -143,8 +143,9 @@ export function validateStructure(source: string, target: string): ValidationRes
 
   // コードブロック（blockquote 外）・インラインコードの内容比較は実施しない:
   // - コードブロック: code-translator でコメントのみ翻訳されるため byte 内容は意図的に異なる
-  // - インラインコード: extractCode → restoreCode で ja のものを byte 一致で復元するため常に一致
-  // カウント一致は codeBlocks / inlineCodes で担保済み
+  // - インラインコード: LLM に直接渡るため内容保証はなく、カウント検証のみ実施。識別子の改変
+  //   (例: \`Signal\` → \`Observable\`) は proofreader rule 1 (translation-induced identifier
+  //   mismatch) が semantic に検出する
 
   // blockquote 内コードはプレースホルダ化されず LLM プロンプトに直接渡るため、byte 一致を検証する。
   // 順序を含めた完全一致を要求（contents 配列の長さ・各要素の byte 一致）。

--- a/tools/auto-translate/translator.spec.ts
+++ b/tools/auto-translate/translator.spec.ts
@@ -390,42 +390,6 @@ describe('translateOne', () => {
       assert.ok(calls[1].feedback);
       assert.match(calls[1].feedback, /placeholder/i);
     });
-
-    test('placeholder order swap → 2 回目の feedback に restoreCode の具体的なエラー（位置・期待・実際）と order 強調が含まれる', async () => {
-      // 本番 angular-debounced-resource.md で再現した症状: LLM が連続する INLINE 系 placeholder を
-      // 並び替えてしまう（英語として自然な語順に変えるバイアス）。汎用 feedback では改善しないため、
-      // restoreCode の具体的なエラーメッセージ（"position N: expected X but found Y"）と
-      // 「順序を保て」という明示的な指示を 2 回目の feedback に含める必要がある
-      const ja = buildJaContent({
-        body: '`a` と `b` の話。\n\n```ts\nconst x = 1;\n```\n\nhttps://example.com\n',
-      });
-      const calls: { feedback?: string }[] = [];
-      let count = 0;
-      const client: GeminiClient = mock.fn((input) => {
-        calls.push({ feedback: input.feedback });
-        count++;
-        if (count === 1) {
-          // INLINE_0 と INLINE_1 を入れ替えた出力（restoreCode の order check で throw）
-          return Promise.resolve({
-            title_en: 'Title',
-            body_en: 'About ⟨⟨INLINE_1⟩⟩ and ⟨⟨INLINE_0⟩⟩.\n\n⟨⟨BLOCK_0⟩⟩\n\nhttps://example.com\n',
-          });
-        }
-        return Promise.resolve({
-          title_en: 'Title',
-          body_en: 'About ⟨⟨INLINE_0⟩⟩ and ⟨⟨INLINE_1⟩⟩.\n\n⟨⟨BLOCK_0⟩⟩\n\nhttps://example.com\n',
-        });
-      });
-      const result = await translateOne(makeArgs({ jaContent: ja, geminiClient: client }));
-      assert.equal(result.kind, 'translated');
-      assert.ok(calls[1].feedback);
-      // 具体的なエラー本文が含まれる（restoreCode の "position N: expected ⟨⟨INLINE_X⟩⟩ but found ⟨⟨INLINE_Y⟩⟩"
-      // がそのまま埋め込まれているか確認）。/position/i 単体だと他の feedback パスと区別できないため
-      // expected/found プレースホルダ表記まで含めて検証する
-      assert.match(calls[1].feedback, /position \d+: expected ⟨⟨INLINE_\d+⟩⟩ but found ⟨⟨INLINE_\d+⟩⟩/);
-      // 順序保持の明示（SAME ORDER キーワード）
-      assert.match(calls[1].feedback, /SAME ORDER/);
-    });
   });
 
   describe('proofread リトライ', () => {

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -9,7 +9,7 @@ import { validateStructure, type ValidationResult } from './structure-validator.
 
 // PROMPT_VERSION: プロンプト/モデル/構造検証ロジックが変わったらインクリメントしてキャッシュを invalidate する。
 // バージョン履歴は git log で追える（変更時はコミットメッセージに「PROMPT_VERSION N → N+1」と記載）
-export const PROMPT_VERSION = 5;
+export const PROMPT_VERSION = 6;
 // Gemini 3 Flash の preview モデル。本番運用中（2026-04 時点で stable な 3 系 flash モデルは未提供）。
 // 将来 stable 移行・廃止時は GEMINI_MODEL env で適切な ID（例: gemini-3-flash 等の後継 GA 名）に切替可能。
 // 参考: https://ai.google.dev/gemini-api/docs/models
@@ -82,12 +82,10 @@ export function joinFrontmatter(frontmatter: Frontmatter, body: string): string 
 // そのまま埋め込まれることはない。したがって LLM 経由でのプロンプト書き換えは不可能
 function buildPlaceholderFeedback(error: string): string {
   return [
-    `Your previous response did not preserve code placeholders correctly: ${error}`,
+    `Your previous response did not preserve code block placeholders correctly: ${error}`,
     '',
-    'CRITICAL placeholder rules:',
-    '- Each ⟨⟨BLOCK_N⟩⟩ and ⟨⟨INLINE_N⟩⟩ from the source MUST appear exactly once in your output, verbatim.',
-    '- Placeholders MUST appear in the SAME ORDER as in the source. Do NOT reorder them even if it feels more natural in English.',
-    '- If two adjacent ⟨⟨INLINE_N⟩⟩ placeholders appear in source order N then N+1, they MUST appear in the same order in your translation. Restructure the sentence if needed to preserve order.',
+    'CRITICAL ⟨⟨BLOCK_N⟩⟩ placeholder rules:',
+    '- Each ⟨⟨BLOCK_N⟩⟩ from the source MUST appear exactly once in your output, verbatim.',
     '- Do not invent new placeholders. Do not omit any. Do not modify or duplicate them.',
   ].join('\n');
 }
@@ -128,7 +126,7 @@ function buildFeedback(validation: ValidationResult): string {
   }
   lines.push('');
   lines.push(
-    'Please retranslate ensuring all links, images, and bare URL paragraphs from the source are preserved exactly. Do not omit, merge, or wrap any URL into prose. Each placeholder ⟨⟨BLOCK_N⟩⟩ and ⟨⟨INLINE_N⟩⟩ must appear exactly once in your output, verbatim — do not modify, drop, or duplicate them.',
+    'Please retranslate ensuring all links, images, and bare URL paragraphs from the source are preserved exactly. Do not omit, merge, or wrap any URL into prose. Each ⟨⟨BLOCK_N⟩⟩ placeholder must appear exactly once in your output, verbatim — do not modify, drop, or duplicate them.',
   );
   if (hasBlockquoteCodeIssue) {
     lines.push(

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { errorMessage } from './ast-utils.ts';
-import { extractCode, restoreCode, type PlaceholderRef } from './code-extractor.ts';
+import { extractCode, restoreCode } from './code-extractor.ts';
 import { translateCodeBlock, type CodeTranslatorClient } from './code-translator.ts';
 import { buildEnFrontmatter, getAutoTranslatedFrom, isAutoTranslated, type Frontmatter } from './frontmatter.ts';
 import { proofread, formatProofIssues, type ProofreaderClient } from './proofreader.ts';
@@ -165,8 +165,6 @@ interface CallWithRetriesArgs {
     body: string;
     jaTemplate: string;
     codeBlocks: string[];
-    inlineCodes: string[];
-    placeholderSequence: readonly PlaceholderRef[];
   };
   slug: string;
 }
@@ -179,7 +177,7 @@ async function callWithRetries(
   | { ok: false; attempts: number; thrownAt: number; cause: unknown }
 > {
   const { geminiClient: client, proofreaderClient, codeTranslatorClient, model, input, slug } = args;
-  const { jaTemplate, codeBlocks, inlineCodes, placeholderSequence } = input;
+  const { jaTemplate, codeBlocks } = input;
 
   // 各コードブロックを個別翻訳（コメントのみ）。インラインコードは識別子なので翻訳しない。
   // ブロック間は独立しているため Promise.all で並列化する
@@ -211,7 +209,7 @@ async function callWithRetries(
     // 翻訳結果（プレースホルダ入り）を、コメント翻訳済みのコードブロック + インラインコードで復元する
     let restoredBody: string;
     try {
-      restoredBody = restoreCode(output.body_en, translatedCodeBlocks, inlineCodes, placeholderSequence);
+      restoredBody = restoreCode(output.body_en, translatedCodeBlocks);
     } catch (e) {
       // LLM がプレースホルダを drop / 幻覚した場合に到達。retry で改善する可能性
       lastFailure = { kind: 'placeholder' };
@@ -359,8 +357,6 @@ export async function translateOne(args: TranslateOneArgs): Promise<TranslateRes
         body: ja.body,
         jaTemplate: extracted.template,
         codeBlocks: extracted.codeBlocks,
-        inlineCodes: extracted.inlineCodes,
-        placeholderSequence: extracted.placeholderSequence,
       },
       slug,
     });


### PR DESCRIPTION
## 真因

run 24987177820 で \`angular-debounced-resource.md\` が 4/4 attempts swap fail。これまで対症療法 (retry feedback / SYSTEM_INSTRUCTION の order rule / MAX_RETRIES bump) を重ねたが、**真因は設計の前提誤り**。

検証で確認した事実:
- ja: 「ソースとなる \`Signal\` の変更が...一定の待機時間を備えた \`Resource\` オブジェクトを返す」
- LLM 出力 (en): "returns a \`Resource\` object with a specific wait time when the source \`Signal\` changes frequently"

LLM は **正しく英訳** している。ja の SOV (Signal → Resource) と en の SVO (Resource → Signal) の語順差を反映しているだけ。我々の strict order check が「placeholder の出現順序が ja と en で一致」という不可能な前提に立っていたため reject していた。

## 設計の根本的誤り

inline code (\`Signal\` \`Resource\` 等) を placeholder 化していた根拠:
> LLM に code byte-fidelity を要求するのは無理筋
> (`code-extractor.ts:1-3` 原典コメント)

しかし **翻訳方向は常に ja → en**。inline code は元から英語/識別子で、ja → en で翻訳圧力はゼロ。LLM が \`Signal\` を変更する動機がない。phantom threat に対する防御として placeholder 化していた。

その placeholder 化が ja-en 語順差で必ず swap 誤検出を起こす副作用を生んでいた。

## 変更

- \`extractCode\`: inline code を抽出しない、template に backtick ごとそのまま残す
- LLM は backtick 識別子を見て自然な英訳 (順序自由)、改変は proofreader rule 1 で検出
- \`SYSTEM_INSTRUCTION\` 更新: ⟨⟨INLINE_N⟩⟩ 関連削除、「inline code は backtick 含めて preserve、語順は自由」と明示
- \`buildPlaceholderFeedback\` / \`buildFeedback\`: ⟨⟨BLOCK_N⟩⟩ のみ言及
- \`PROMPT_VERSION\` 5 → 6: 全 327 件再翻訳

block code (multi-line / indent / syntax) は placeholder 維持。byte-fidelity 要件が真に存在する。

## Test plan

- [x] \`pnpm test:tools\` (244 pass)
- [x] \`pnpm lint\`, \`pnpm format\`
- [ ] CI code-review pass
- [ ] マージ後の sync で \`angular-debounced-resource.md\` が swap fail せず翻訳成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)