### PR TITLE
fix(auto-translate): drop inlineCodes count from structure-validator (post inline placeholder removal)

### DIFF
--- a/tools/auto-translate/structure-validator.spec.ts
+++ b/tools/auto-translate/structure-validator.spec.ts
@@ -230,21 +230,22 @@ describe('validateStructure', () => {
     assert.ok(result.mismatches.some((m) => m.kind === 'blockquoteInlineCodeContent'));
   });
 
-  test('blockquote 内インラインコードが削除された → ng (inlineCodes count)', () => {
-    // count 差異は inlineCodes 全体カウントで検出される（個別の blockquoteInlineCode count check は実装しない）
+  test('blockquote 内インラインコードが削除された → ng (blockquoteInlineCodeContent count)', () => {
+    // 全体 inlineCodes カウントは check しない (LLM の有用な追加/補正を許容するため)。
+    // ただし blockquote 内 inline は byte fidelity 保護が必要なので個別に count + content check する
     const source = '> 引用 `foo`\n';
     const target = '> no code\n';
     const result = validateStructure(source, target);
     assert.equal(result.ok, false);
-    assert.ok(result.mismatches.some((m) => m.kind === 'inlineCodes'));
+    assert.ok(result.mismatches.some((m) => m.kind === 'blockquoteInlineCodeContent'));
   });
 
-  test('blockquote 内インラインコードが追加された → ng (inlineCodes count)', () => {
+  test('blockquote 内インラインコードが追加された → ng (blockquoteInlineCodeContent count)', () => {
     const source = '> 引用文\n';
     const target = '> Added `code` here\n';
     const result = validateStructure(source, target);
     assert.equal(result.ok, false);
-    assert.ok(result.mismatches.some((m) => m.kind === 'inlineCodes'));
+    assert.ok(result.mismatches.some((m) => m.kind === 'blockquoteInlineCodeContent'));
   });
 
   test('blockquote 内コードの言語タグが変えられた → ng (blockquoteCodeContent, content)', () => {
@@ -280,19 +281,22 @@ describe('validateStructure', () => {
     assert.equal(m.differKind, 'count');
   });
 
-  test('翻訳結果に source にないインラインコードが追加されている → ng (inlineCodes count)', () => {
-    const source = 'plain text\n';
-    const target = 'translated `extra` text\n';
-    const result = validateStructure(source, target);
-    assert.equal(result.ok, false);
-    assert.ok(result.mismatches.some((m) => m.kind === 'inlineCodes'));
-  });
+  test('翻訳結果のインラインコードが source と異なってもエラーにしない (LLM の有用な補正を許容)', () => {
+    // LLM は backtick 識別子を追加 (例: \`true\` で wrap) または削除 (例: source の informal
+    // \`active\` を正規 \`waiting\` に補正) することがある。これらは品質改善方向の挙動で
+    // corruption ではないため inlineCodes count は flag しない設計。
+    // 識別子の semantic な改変は proofreader rule 1 が検出する責務範囲
 
-  test('翻訳結果のインラインコードが少ない → ng (inlineCodes count)', () => {
-    const source = 'use `foo` and `bar`\n';
-    const target = 'use foo and `bar`\n';
-    const result = validateStructure(source, target);
-    assert.equal(result.ok, false);
-    assert.ok(result.mismatches.some((m) => m.kind === 'inlineCodes'));
+    // ケース 1: en で inline code 追加
+    const source1 = 'plain text\n';
+    const target1 = 'translated `extra` text\n';
+    const result1 = validateStructure(source1, target1);
+    assert.ok(!result1.mismatches.some((m) => m.kind === 'inlineCodes'));
+
+    // ケース 2: en で inline code 削除
+    const source2 = 'use `foo` and `bar`\n';
+    const target2 = 'use foo and `bar`\n';
+    const result2 = validateStructure(source2, target2);
+    assert.ok(!result2.mismatches.some((m) => m.kind === 'inlineCodes'));
   });
 });

--- a/tools/auto-translate/structure-validator.ts
+++ b/tools/auto-translate/structure-validator.ts
@@ -134,18 +134,19 @@ export function validateStructure(source: string, target: string): ValidationRes
   const tgt = snapshotStructureInternal(target);
   const mismatches: StructureMismatch[] = [];
 
-  const kinds: (keyof StructureCounts)[] = ['codeBlocks', 'inlineCodes', 'images', 'links', 'bareUrlParagraphs'];
+  // inlineCodes は count check しない: LLM は backtick 識別子を追加/補正することがあり
+  // (例: ja source の informal \`active\` → en で正規変数名 \`waiting\` に補正、TS boolean を
+  // \`true\` で wrap 等)、これらは品質改善方向の有用な変化であって corruption ではない。
+  // 識別子の semantic な改変 (例: \`Signal\` → \`Observable\`) は proofreader rule 1 が検出する
+  const kinds: (keyof StructureCounts)[] = ['codeBlocks', 'images', 'links', 'bareUrlParagraphs'];
   for (const kind of kinds) {
     if (src.counts[kind] !== tgt.counts[kind]) {
       mismatches.push({ kind, source: src.counts[kind], target: tgt.counts[kind] });
     }
   }
 
-  // コードブロック（blockquote 外）・インラインコードの内容比較は実施しない:
-  // - コードブロック: code-translator でコメントのみ翻訳されるため byte 内容は意図的に異なる
-  // - インラインコード: LLM に直接渡るため内容保証はなく、カウント検証のみ実施。識別子の改変
-  //   (例: \`Signal\` → \`Observable\`) は proofreader rule 1 (translation-induced identifier
-  //   mismatch) が semantic に検出する
+  // コードブロック（blockquote 外）の内容比較は実施しない:
+  // code-translator でコメントのみ翻訳されるため byte 内容は意図的に異なる
 
   // blockquote 内コードはプレースホルダ化されず LLM プロンプトに直接渡るため、byte 一致を検証する。
   // 順序を含めた完全一致を要求（contents 配列の長さ・各要素の byte 一致）。


### PR DESCRIPTION
## 課題

PR #1583 で inline placeholder 化を廃止した結果、以前と異なる失敗モードが発生:

sync run 24994809852 で \`angular-debounced-resource.md\` が 4/4 attempts で structure validation reject:
- attempt 1: \`inlineCodes ja=40 en=56\` (+16)
- attempt 2: \`inlineCodes ja=40 en=41\` (+1)
- attempt 3: \`inlineCodes ja=40 en=26\` (-14、他構造も corrupt)
- attempt 4: 同様

attempt 1, 2 は LLM の有用な補正:
- source の informal 参照 \`active\` を正規変数名 \`waiting\` に修正
- TS boolean を \`true\` で backtick wrap
これらを「count mismatch = corruption」と判定する strict check が前提を破っている。

## 修正

\`structure-validator\` の strict count check 対象から \`inlineCodes\` を除外。

維持される check:
- \`codeBlocks\` count (block 構造保護)
- \`images\` / \`links\` / \`bareUrlParagraphs\` count
- \`blockquoteInlineCodeContent\` (blockquote 内 inline は byte fidelity 必要)

識別子の semantic 改変 (例: \`Signal\` → \`Observable\`) は proofreader rule 1 が担当。

PROMPT_VERSION 据え置き (validation 緩和のみ、cache 全件 invalidate のコストは不要)。

## Test plan

- [x] \`pnpm test:tools\` (240 pass)
- [x] \`pnpm lint\`, \`pnpm format\`
- [ ] CI code-review pass
- [ ] マージ後の sync で \`angular-debounced-resource.md\` 翻訳成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)