### PR TITLE
fix(blog): apply deduplicatePosts to list pages (no more ja/en duplicate)

### DIFF
--- a/src/pages/channels/[channel].astro
+++ b/src/pages/channels/[channel].astro
@@ -1,12 +1,13 @@
 ---
-import { queryAvailablePosts, queryChannels } from '@lib/query';
+import { queryAvailablePosts, queryChannels, deduplicatePosts } from '@lib/query';
 import type { CollectionEntry } from 'astro:content';
 import ChannelNav from 'src/components/ChannelNav.astro';
 import List from '../../layouts/List.astro';
 import { urlize } from '../../libs/strings';
 
 export async function getStaticPaths() {
-  const posts = await queryAvailablePosts();
+  // 同一 slug の ja/en は重複表示しないため deduplicatePosts で ja を優先採用
+  const posts = deduplicatePosts(await queryAvailablePosts());
   const channels = queryChannels();
 
   return channels.map((channel) => {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,9 +1,10 @@
 ---
-import { queryAvailablePosts } from '@lib/query';
+import { queryAvailablePosts, deduplicatePosts } from '@lib/query';
 import ChannelNav from 'src/components/ChannelNav.astro';
 import List from '../layouts/List.astro';
 
-const posts = await queryAvailablePosts();
+// 同一 slug の ja/en は重複表示しないため deduplicatePosts で ja を優先採用
+const posts = deduplicatePosts(await queryAvailablePosts());
 ---
 
 <List posts={posts} feedUrl="/index.xml" showChannels>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,11 +1,12 @@
 ---
-import { queryAvailablePosts, queryTags } from '@lib/query';
+import { queryAvailablePosts, queryTags, deduplicatePosts } from '@lib/query';
 import List from '../../layouts/List.astro';
 import { urlize } from '../../libs/strings';
 import type { CollectionEntry } from 'astro:content';
 
 export async function getStaticPaths() {
-  const posts = await queryAvailablePosts();
+  // 同一 slug の ja/en は重複表示しないため deduplicatePosts で ja を優先採用
+  const posts = deduplicatePosts(await queryAvailablePosts());
   const tags = await queryTags();
 
   return tags.map((tag) => {

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,8 +1,9 @@
 ---
-import { queryAvailablePosts, queryTags } from '@lib/query';
+import { queryAvailablePosts, queryTags, deduplicatePosts } from '@lib/query';
 import Tags from '../../layouts/Tags.astro';
 
-const posts = await queryAvailablePosts();
+// 同一 slug の ja/en は重複カウントしない (タグ一覧の usedCount が [tag].astro の表示件数と一致するように)
+const posts = deduplicatePosts(await queryAvailablePosts());
 const tags = await queryTags();
 
 const tagWithCount = tags


### PR DESCRIPTION
## 課題

ユーザ報告: リストページで同一記事の ja 版と en 版が並んで表示されていた。

例 (channels/Code):
- 「Angular v22: debounced Resource の解説」 (ja)
- 「Angular v22: Explaining debounced Resource」 (en)

両方が同列に表示されており、同じ記事が 2 回読まれているように見える。

## 原因

\`deduplicatePosts\` 関数は \`src/libs/query/posts.ts\` に存在し、同一 slug の場合 ja を優先する設計が既にあったが、HTML list page では未使用だった。RSS feed (\`index.xml.ts\`) では使われていた。

## 修正

以下の 3 ページで \`deduplicatePosts(await queryAvailablePosts())\` に変更:
- \`src/pages/index.astro\`
- \`src/pages/channels/[channel].astro\`
- \`src/pages/tags/[tag].astro\`

en の RSS feed (\`index.en.xml.ts\`) は locale フィルタで処理しているため変更なし。

## Test plan

- [x] \`pnpm test:libs\` 既存 \`deduplicatePosts\` test 全 pass (og-image の SVG test 1 件 fail は main でも fail する pre-existing 問題、本 PR と無関係)
- [x] \`pnpm lint\` / \`pnpm format\` pass
- [ ] CI code-review pass
- [ ] preview deploy で実際に重複が解消されているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)