### PR TITLE
revert: PR #1586 (list page deduplicatePosts) — design doc 不在で実装した

### DIFF
--- a/src/pages/channels/[channel].astro
+++ b/src/pages/channels/[channel].astro
@@ -1,13 +1,12 @@
 ---
-import { queryAvailablePosts, queryChannels, deduplicatePosts } from '@lib/query';
+import { queryAvailablePosts, queryChannels } from '@lib/query';
 import type { CollectionEntry } from 'astro:content';
 import ChannelNav from 'src/components/ChannelNav.astro';
 import List from '../../layouts/List.astro';
 import { urlize } from '../../libs/strings';
 
 export async function getStaticPaths() {
-  // 同一 slug の ja/en は重複表示しないため deduplicatePosts で ja を優先採用
-  const posts = deduplicatePosts(await queryAvailablePosts());
+  const posts = await queryAvailablePosts();
   const channels = queryChannels();
 
   return channels.map((channel) => {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,10 +1,9 @@
 ---
-import { queryAvailablePosts, deduplicatePosts } from '@lib/query';
+import { queryAvailablePosts } from '@lib/query';
 import ChannelNav from 'src/components/ChannelNav.astro';
 import List from '../layouts/List.astro';
 
-// 同一 slug の ja/en は重複表示しないため deduplicatePosts で ja を優先採用
-const posts = deduplicatePosts(await queryAvailablePosts());
+const posts = await queryAvailablePosts();
 ---
 
 <List posts={posts} feedUrl="/index.xml" showChannels>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,12 +1,11 @@
 ---
-import { queryAvailablePosts, queryTags, deduplicatePosts } from '@lib/query';
+import { queryAvailablePosts, queryTags } from '@lib/query';
 import List from '../../layouts/List.astro';
 import { urlize } from '../../libs/strings';
 import type { CollectionEntry } from 'astro:content';
 
 export async function getStaticPaths() {
-  // 同一 slug の ja/en は重複表示しないため deduplicatePosts で ja を優先採用
-  const posts = deduplicatePosts(await queryAvailablePosts());
+  const posts = await queryAvailablePosts();
   const tags = await queryTags();
 
   return tags.map((tag) => {

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,9 +1,8 @@
 ---
-import { queryAvailablePosts, queryTags, deduplicatePosts } from '@lib/query';
+import { queryAvailablePosts, queryTags } from '@lib/query';
 import Tags from '../../layouts/Tags.astro';
 
-// 同一 slug の ja/en は重複カウントしない (タグ一覧の usedCount が [tag].astro の表示件数と一致するように)
-const posts = deduplicatePosts(await queryAvailablePosts());
+const posts = await queryAvailablePosts();
 const tags = await queryTags();
 
 const tagWithCount = tags


### PR DESCRIPTION
## 経緯

PR #1586 で list page の ja/en 重複表示を \`deduplicatePosts\` 適用で解消した。
しかし bilingual list 表示の spec はユーザの判断領域であり、design doc も書かずに独断で「重複時 ja 優先」という挙動を decide して実装した。

## 対応

PR #1586 を revert する。

## 次のステップ

bilingual 表示の design doc を \`docs/design/\` に起こし、ユーザ承認後に実装する。検討すべき option:

- A: ja/en 両方 list に表示 (現状)
- B: 重複時 ja 優先、en は list 非表示 (PR #1586 で実装したもの)
- C: locale 別に list 分離 (\`/\` は ja 専用、\`/en/\` は en 専用)
- D: それ以外

これらを spec として整理して design doc にしてから実装する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)