### PR TITLE
feat(blog): translated list display (Option D — per-entry locale-aware swap)

### DIFF
--- a/src/layouts/List.astro
+++ b/src/layouts/List.astro
@@ -83,7 +83,7 @@ const postsByYear = Array.from(
                         {post.data.locale === 'en' && (
                           <span class="inline-block text-[10px] font-bold text-white bg-blue-500 py-px px-1.5 rounded-[3px] ml-1.5 align-middle">EN</span>
                         )}
-                        {translations.en && post.data.locale !== 'en' && (
+                        {translations.en && (
                           <span
                             class="inline-block text-[10px] font-bold text-white bg-blue-500 py-px px-1.5 rounded-[3px] ml-1.5 align-middle"
                             data-translation-en-badge
@@ -107,6 +107,12 @@ const postsByYear = Array.from(
       // 翻訳がある entry の title / href を user の locale 設定に応じて en に swap する。
       // 詳細は docs/design/bilingual-list-display.md (Option D) を参照
       // 判定: navigator.languages を順に走査し、en が ja より先に出現したら en preference
+      //
+      // FOUC について: en preference のユーザは ja title が一瞬見えてから en に swap される
+      // (script は type="module" の defer 実行)。タイトルを初期非表示 (opacity:0) にすれば
+      // FOUC は隠せるが、JS 不在環境 / script 失敗時に永久に title が見えなくなる劣化が
+      // 大きいため敢えて行わない。EN badge は逆に「未スワップ時は無いべきもの」なので
+      // \`display: none\` で初期非表示にしている (バッジとタイトルで扱いが異なるのは設計意図)
       const langs = navigator.languages ?? [navigator.language];
       let prefersEn = false;
       for (const lang of langs) {

--- a/src/layouts/List.astro
+++ b/src/layouts/List.astro
@@ -83,6 +83,13 @@ const postsByYear = Array.from(
                         {post.data.locale === 'en' && (
                           <span class="inline-block text-[10px] font-bold text-white bg-blue-500 py-px px-1.5 rounded-[3px] ml-1.5 align-middle">EN</span>
                         )}
+                        {translations.en && post.data.locale !== 'en' && (
+                          <span
+                            class="inline-block text-[10px] font-bold text-white bg-blue-500 py-px px-1.5 rounded-[3px] ml-1.5 align-middle"
+                            data-translation-en-badge
+                            style="display: none;"
+                          >EN</span>
+                        )}
                       </a>
                     </div>
                   </li>
@@ -121,6 +128,10 @@ const postsByYear = Array.from(
           const titleEl = link.querySelector<HTMLElement>('[data-translation-target]');
           if (titleEl) titleEl.textContent = enTitle;
           link.setAttribute('hreflang', 'en');
+          // 翻訳済みであることを EN badge で示す。ja のままの entry には badge を出さないため
+          // 「今 en 表示の記事」と「ja のまま残った記事」が視覚的に区別できる
+          const badge = link.querySelector<HTMLElement>('[data-translation-en-badge]');
+          if (badge) badge.style.display = '';
         }
       }
     </script>

--- a/src/layouts/List.astro
+++ b/src/layouts/List.astro
@@ -8,10 +8,10 @@ import FormattedDate from '../components/FormattedDate';
 import Header from '../components/Header.astro';
 import MainContainer from '../components/MainContainer.astro';
 import { SITE_TITLE } from '../consts';
-import type { CollectionEntry } from 'astro:content';
+import type { PostWithTranslations } from '../libs/query';
 
 type Props = {
-  posts: Array<CollectionEntry<'posts'>>;
+  posts: PostWithTranslations[];
   /** RSS auto-discoveryリンク用URL（例: "/index.xml", "/tags/angular.xml"） */
   feedUrl?: string;
   showChannels?: boolean;
@@ -20,13 +20,13 @@ type Props = {
 const { posts, feedUrl, showChannels = false } = Astro.props;
 const postsByYear = Array.from(
   posts
-    .reduce((acc, post) => {
-      const year = formatDate(getDate(post), 'yyyy');
-      const posts = acc.get(year) ?? [];
-      posts.push(post);
-      acc.set(year, posts);
+    .reduce((acc, item) => {
+      const year = formatDate(getDate(item.post), 'yyyy');
+      const list = acc.get(year) ?? [];
+      list.push(item);
+      acc.set(year, list);
       return acc;
-    }, new Map<string, Array<CollectionEntry<'posts'>>>())
+    }, new Map<string, PostWithTranslations[]>())
     .entries(),
 ).sort(([a], [b]) => Number(b) - Number(a));
 ---
@@ -55,7 +55,7 @@ const postsByYear = Array.from(
               </div>
             )}
             <ul class="list-none">
-              {posts.map((post) => {
+              {posts.map(({ post, translations }) => {
                 const postChannels = showChannels ? getChannels(post) : [];
                 return (
                   <li class="[&+&]:border-t [&+&]:border-[var(--color-border-light)]">
@@ -73,8 +73,13 @@ const postsByYear = Array.from(
                           </div>
                         )}
                       </div>
-                      <a href={getRelativePostUrl(post)} class="text-base lg:text-[18px] font-semibold lg:font-bold leading-[1.5] lg:leading-[1.45] text-default no-underline hover:text-muted lg:hover:text-hover-link lg:hover:no-underline lg:group-hover:text-hover-link transition-colors duration-100 lg:after:absolute lg:after:inset-0 lg:after:content-['']">
-                        {getTitle(post)}
+                      <a
+                        href={getRelativePostUrl(post)}
+                        data-translation-en-href={translations.en?.href}
+                        data-translation-en-title={translations.en?.title}
+                        class="text-base lg:text-[18px] font-semibold lg:font-bold leading-[1.5] lg:leading-[1.45] text-default no-underline hover:text-muted lg:hover:text-hover-link lg:hover:no-underline lg:group-hover:text-hover-link transition-colors duration-100 lg:after:absolute lg:after:inset-0 lg:after:content-['']"
+                      >
+                        <span data-translation-target>{getTitle(post)}</span>
                         {post.data.locale === 'en' && (
                           <span class="inline-block text-[10px] font-bold text-white bg-blue-500 py-px px-1.5 rounded-[3px] ml-1.5 align-middle">EN</span>
                         )}
@@ -90,5 +95,34 @@ const postsByYear = Array.from(
     </MainContainer>
 
     <Footer class="py-4 lg:py-0" />
+
+    <script>
+      // 翻訳がある entry の title / href を user の locale 設定に応じて en に swap する。
+      // 詳細は docs/design/bilingual-list-display.md (Option D) を参照
+      // 判定: navigator.languages を順に走査し、en が ja より先に出現したら en preference
+      const langs = navigator.languages ?? [navigator.language];
+      let prefersEn = false;
+      for (const lang of langs) {
+        if (!lang) continue;
+        const lower = lang.toLowerCase();
+        if (lower === 'ja' || lower.startsWith('ja-')) break;
+        if (lower === 'en' || lower.startsWith('en-')) {
+          prefersEn = true;
+          break;
+        }
+      }
+      if (prefersEn) {
+        const links = document.querySelectorAll<HTMLAnchorElement>('a[data-translation-en-href]');
+        for (const link of links) {
+          const enHref = link.dataset.translationEnHref;
+          const enTitle = link.dataset.translationEnTitle;
+          if (!enHref || !enTitle) continue;
+          link.href = enHref;
+          const titleEl = link.querySelector<HTMLElement>('[data-translation-target]');
+          if (titleEl) titleEl.textContent = enTitle;
+          link.setAttribute('hreflang', 'en');
+        }
+      }
+    </script>
   </body>
 </html>

--- a/src/libs/compat.ts
+++ b/src/libs/compat.ts
@@ -1,20 +1,20 @@
 import type { CollectionEntry } from 'astro:content';
 import { channels as channelDefinitions } from './post/properties';
 
-export function getDate(post: CollectionEntry<'posts'>): Date {
+export function getDate(post: CollectionEntry<'posts' | 'postsEn'>): Date {
   return post.data.created_time;
 }
 
-export function getRelativePostUrl(post: CollectionEntry<'posts'>): string {
+export function getRelativePostUrl(post: CollectionEntry<'posts' | 'postsEn'>): string {
   const localeSuffix = post.data.locale === 'en' ? '.en' : '';
   return `/posts/${post.data.slug}${localeSuffix}`;
 }
 
-export function getTitle(post: CollectionEntry<'posts'>): string {
+export function getTitle(post: CollectionEntry<'posts' | 'postsEn'>): string {
   return post.data.title;
 }
 
-export function getChannels(post: CollectionEntry<'posts'>): string[] {
+export function getChannels(post: CollectionEntry<'posts' | 'postsEn'>): string[] {
   const postChannels = post.data.channels ?? [];
   const order = channelDefinitions.map((c) => c.name);
   return [...postChannels].sort((a, b) => {

--- a/src/libs/query/posts.spec.ts
+++ b/src/libs/query/posts.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { queryAdjacentPosts, deduplicatePosts, attachTranslations } from './posts';
+import { queryAdjacentPosts, deduplicatePosts, attachTranslations, buildListPagePosts } from './posts';
 import type { CollectionEntry } from 'astro:content';
 
 // テスト用のモックデータを作成するヘルパー関数
@@ -290,5 +290,64 @@ describe('attachTranslations', () => {
     expect(result[0].translations).toEqual({});
     expect(result[1].translations.en).toBeDefined();
     expect(result[2].translations).toEqual({});
+  });
+});
+
+describe('buildListPagePosts', () => {
+  it('ja/en 両エントリのスラッグは ja に集約され translations.en が付く', () => {
+    const allPosts: Array<CollectionEntry<'posts' | 'postsEn'>> = [
+      createMockPost('post-1', new Date('2023-01-01'), 'ja'),
+      createMockEnPost('post-1', new Date('2023-01-01')),
+    ];
+
+    const result = buildListPagePosts(allPosts);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].post.data.locale).toBe('ja');
+    expect(result[0].translations.en).toEqual({
+      title: 'Test Post post-1 (EN)',
+      href: '/posts/post-1.en',
+    });
+  });
+
+  it('ja のみのエントリは translations が空', () => {
+    const allPosts: Array<CollectionEntry<'posts' | 'postsEn'>> = [
+      createMockPost('post-1', new Date('2023-01-01'), 'ja'),
+    ];
+
+    const result = buildListPagePosts(allPosts);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].translations).toEqual({});
+  });
+
+  it('en のみのエントリ (ja なし) は en が canonical となり translations は空', () => {
+    const allPosts: Array<CollectionEntry<'posts' | 'postsEn'>> = [createMockEnPost('post-1', new Date('2023-01-01'))];
+
+    const result = buildListPagePosts(allPosts);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].post.data.locale).toBe('en');
+    expect(result[0].translations).toEqual({});
+  });
+
+  it('混在: ja+en 重複 / ja のみ / en のみ をそれぞれ正しく扱う', () => {
+    const allPosts: Array<CollectionEntry<'posts' | 'postsEn'>> = [
+      createMockPost('post-1', new Date('2023-01-01'), 'ja'),
+      createMockEnPost('post-1', new Date('2023-01-01')),
+      createMockPost('post-2', new Date('2023-01-02'), 'ja'),
+      createMockEnPost('post-3', new Date('2023-01-03')),
+    ];
+
+    const result = buildListPagePosts(allPosts);
+
+    expect(result).toHaveLength(3);
+    const bySlug = new Map(result.map((r) => [r.post.data.slug, r]));
+    expect(bySlug.get('post-1')?.post.data.locale).toBe('ja');
+    expect(bySlug.get('post-1')?.translations.en).toBeDefined();
+    expect(bySlug.get('post-2')?.post.data.locale).toBe('ja');
+    expect(bySlug.get('post-2')?.translations).toEqual({});
+    expect(bySlug.get('post-3')?.post.data.locale).toBe('en');
+    expect(bySlug.get('post-3')?.translations).toEqual({});
   });
 });

--- a/src/libs/query/posts.spec.ts
+++ b/src/libs/query/posts.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { queryAdjacentPosts, deduplicatePosts } from './posts';
+import { queryAdjacentPosts, deduplicatePosts, attachTranslations } from './posts';
 import type { CollectionEntry } from 'astro:content';
 
 // テスト用のモックデータを作成するヘルパー関数
@@ -240,5 +240,55 @@ describe('deduplicatePosts', () => {
     expect(result[1].data.slug).toBe('post-2');
     expect(result[2].data.slug).toBe('post-1');
     expect(result.every((p) => p.data.locale === 'ja')).toBe(true);
+  });
+});
+
+describe('attachTranslations', () => {
+  it('ja 記事に対応する en 記事があれば translations.en に title/href を attach', () => {
+    const jaPosts = [createMockPost('post-1', new Date('2023-01-01'), 'ja')];
+    const enPosts = [createMockEnPost('post-1', new Date('2023-01-01'))];
+
+    const result = attachTranslations(jaPosts, enPosts);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].translations.en).toEqual({
+      title: 'Test Post post-1 (EN)',
+      href: '/posts/post-1.en',
+    });
+  });
+
+  it('対応する en 記事がなければ translations は空オブジェクト', () => {
+    const jaPosts = [createMockPost('post-1', new Date('2023-01-01'), 'ja')];
+    const enPosts: Array<CollectionEntry<'postsEn'>> = [];
+
+    const result = attachTranslations(jaPosts, enPosts);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].translations).toEqual({});
+  });
+
+  it('en 記事自体には translations は attach しない (en が canonical の場合は swap 対象外)', () => {
+    const enOnly = [createMockEnPost('post-1', new Date('2023-01-01'))] as Array<CollectionEntry<'posts' | 'postsEn'>>;
+    const enPosts = [createMockEnPost('post-1', new Date('2023-01-01'))];
+
+    const result = attachTranslations(enOnly, enPosts);
+
+    expect(result[0].translations).toEqual({});
+  });
+
+  it('元 posts の順序を維持する', () => {
+    const jaPosts = [
+      createMockPost('post-1', new Date('2023-01-01'), 'ja'),
+      createMockPost('post-2', new Date('2023-01-02'), 'ja'),
+      createMockPost('post-3', new Date('2023-01-03'), 'ja'),
+    ];
+    const enPosts = [createMockEnPost('post-2', new Date('2023-01-02'))];
+
+    const result = attachTranslations(jaPosts, enPosts);
+
+    expect(result.map((r) => r.post.data.slug)).toEqual(['post-1', 'post-2', 'post-3']);
+    expect(result[0].translations).toEqual({});
+    expect(result[1].translations.en).toBeDefined();
+    expect(result[2].translations).toEqual({});
   });
 });

--- a/src/libs/query/posts.ts
+++ b/src/libs/query/posts.ts
@@ -84,14 +84,22 @@ export function attachTranslations(
 }
 
 /**
+ * List page で表示する posts を所与の集合から組み立てる pure 関数。
+ * IO を分離して unit test できるようにする (queryListPagePosts は thin wrapper)
+ */
+export function buildListPagePosts(allPosts: Array<CollectionEntry<'posts' | 'postsEn'>>): PostWithTranslations[] {
+  const enPosts = allPosts.filter((p): p is CollectionEntry<'postsEn'> => p.data.locale === 'en');
+  const deduped = deduplicatePosts(allPosts);
+  return attachTranslations(deduped, enPosts);
+}
+
+/**
  * List page で表示する posts に dedup と翻訳 metadata を attach した形を返す helper。
  * 各 list page (index, channels, tags) で共通利用する
  */
 export async function queryListPagePosts(): Promise<PostWithTranslations[]> {
   const allPosts = await queryAvailablePosts();
-  const enPosts = allPosts.filter((p): p is CollectionEntry<'postsEn'> => p.data.locale === 'en');
-  const deduped = deduplicatePosts(allPosts);
-  return attachTranslations(deduped, enPosts);
+  return buildListPagePosts(allPosts);
 }
 
 /**

--- a/src/libs/query/posts.ts
+++ b/src/libs/query/posts.ts
@@ -46,17 +46,6 @@ export function deduplicatePosts(
 }
 
 /**
- * List page で表示する posts に dedup と翻訳 metadata を attach した形を返す helper。
- * 各 list page (index, channels, tags) で共通利用する
- */
-export async function queryListPagePosts(): Promise<PostWithTranslations[]> {
-  const allPosts = await queryAvailablePosts();
-  const enPosts = allPosts.filter((p): p is CollectionEntry<'postsEn'> => p.data.locale === 'en');
-  const deduped = deduplicatePosts(allPosts);
-  return attachTranslations(deduped, enPosts);
-}
-
-/**
  * Translated List Display 用に各 post に翻訳 metadata を attach する。
  * 詳細は docs/design/bilingual-list-display.md (Option D) を参照。
  *
@@ -77,10 +66,12 @@ export function attachTranslations(
   posts: Array<CollectionEntry<'posts' | 'postsEn'>>,
   enPosts: Array<CollectionEntry<'postsEn'>>,
 ): PostWithTranslations[] {
+  // slug → en post の Map を事前構築して posts.map 内 lookup を O(1) にする
+  const enBySlug = new Map(enPosts.map((p) => [p.data.slug, p]));
   return posts.map((post) => {
     const translations: PostTranslations = {};
     if (post.data.locale !== 'en') {
-      const enPost = enPosts.find((p) => p.data.slug === post.data.slug);
+      const enPost = enBySlug.get(post.data.slug);
       if (enPost) {
         translations.en = {
           title: enPost.data.title,
@@ -90,6 +81,17 @@ export function attachTranslations(
     }
     return { post, translations };
   });
+}
+
+/**
+ * List page で表示する posts に dedup と翻訳 metadata を attach した形を返す helper。
+ * 各 list page (index, channels, tags) で共通利用する
+ */
+export async function queryListPagePosts(): Promise<PostWithTranslations[]> {
+  const allPosts = await queryAvailablePosts();
+  const enPosts = allPosts.filter((p): p is CollectionEntry<'postsEn'> => p.data.locale === 'en');
+  const deduped = deduplicatePosts(allPosts);
+  return attachTranslations(deduped, enPosts);
 }
 
 /**

--- a/src/libs/query/posts.ts
+++ b/src/libs/query/posts.ts
@@ -1,5 +1,6 @@
 import { getCollection, type CollectionEntry } from 'astro:content';
 import { compareDesc, compareAsc, isPast } from 'date-fns';
+import { getRelativePostUrl } from '../compat';
 
 export async function queryAvailablePosts(): Promise<Array<CollectionEntry<'posts' | 'postsEn'>>> {
   const posts = await getCollection('posts');
@@ -42,6 +43,53 @@ export function deduplicatePosts(
   }
 
   return deduplicatedPosts;
+}
+
+/**
+ * List page で表示する posts に dedup と翻訳 metadata を attach した形を返す helper。
+ * 各 list page (index, channels, tags) で共通利用する
+ */
+export async function queryListPagePosts(): Promise<PostWithTranslations[]> {
+  const allPosts = await queryAvailablePosts();
+  const enPosts = allPosts.filter((p): p is CollectionEntry<'postsEn'> => p.data.locale === 'en');
+  const deduped = deduplicatePosts(allPosts);
+  return attachTranslations(deduped, enPosts);
+}
+
+/**
+ * Translated List Display 用に各 post に翻訳 metadata を attach する。
+ * 詳細は docs/design/bilingual-list-display.md (Option D) を参照。
+ *
+ * 入力: dedup 済み posts (ja-preferred) と en posts 全集合
+ * 出力: 各 entry に translations.en を持たせた配列。en 記事自体には translations を入れない
+ *       (canonical entry が en になっているケースは swap 対象外)
+ */
+export interface PostTranslations {
+  en?: { title: string; href: string };
+}
+
+export interface PostWithTranslations {
+  post: CollectionEntry<'posts' | 'postsEn'>;
+  translations: PostTranslations;
+}
+
+export function attachTranslations(
+  posts: Array<CollectionEntry<'posts' | 'postsEn'>>,
+  enPosts: Array<CollectionEntry<'postsEn'>>,
+): PostWithTranslations[] {
+  return posts.map((post) => {
+    const translations: PostTranslations = {};
+    if (post.data.locale !== 'en') {
+      const enPost = enPosts.find((p) => p.data.slug === post.data.slug);
+      if (enPost) {
+        translations.en = {
+          title: enPost.data.title,
+          href: getRelativePostUrl(enPost),
+        };
+      }
+    }
+    return { post, translations };
+  });
 }
 
 /**

--- a/src/pages/channels/[channel].astro
+++ b/src/pages/channels/[channel].astro
@@ -1,16 +1,15 @@
 ---
-import { queryAvailablePosts, queryChannels } from '@lib/query';
-import type { CollectionEntry } from 'astro:content';
+import { queryListPagePosts, queryChannels, type PostWithTranslations } from '@lib/query';
 import ChannelNav from 'src/components/ChannelNav.astro';
 import List from '../../layouts/List.astro';
 import { urlize } from '../../libs/strings';
 
 export async function getStaticPaths() {
-  const posts = await queryAvailablePosts();
+  const posts = await queryListPagePosts();
   const channels = queryChannels();
 
   return channels.map((channel) => {
-    const matchPosts = posts.filter((post) => post.data.channels?.includes(channel.name));
+    const matchPosts = posts.filter((item) => item.post.data.channels?.includes(channel.name));
     const urlizedName = urlize(channel.name);
     return {
       params: { channel: urlizedName },
@@ -21,7 +20,7 @@ export async function getStaticPaths() {
 
 type Props = {
   channel: string;
-  posts: Array<CollectionEntry<'posts' | 'postsEn'>>;
+  posts: PostWithTranslations[];
 };
 
 const { channel, posts } = Astro.props;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,9 +1,9 @@
 ---
-import { queryAvailablePosts } from '@lib/query';
+import { queryListPagePosts } from '@lib/query';
 import ChannelNav from 'src/components/ChannelNav.astro';
 import List from '../layouts/List.astro';
 
-const posts = await queryAvailablePosts();
+const posts = await queryListPagePosts();
 ---
 
 <List posts={posts} feedUrl="/index.xml" showChannels>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,16 +1,15 @@
 ---
-import { queryAvailablePosts, queryTags } from '@lib/query';
+import { queryListPagePosts, queryTags, type PostWithTranslations } from '@lib/query';
 import List from '../../layouts/List.astro';
 import { urlize } from '../../libs/strings';
-import type { CollectionEntry } from 'astro:content';
 
 export async function getStaticPaths() {
-  const posts = await queryAvailablePosts();
+  const posts = await queryListPagePosts();
   const tags = await queryTags();
 
   return tags.map((tag) => {
-    const matchPosts = posts.filter((post) => {
-      return post.data.tags?.includes(tag.name);
+    const matchPosts = posts.filter((item) => {
+      return item.post.data.tags?.includes(tag.name);
     });
     const urlizedName = urlize(tag.name);
     return {
@@ -22,7 +21,7 @@ export async function getStaticPaths() {
 
 type Props = {
   tag: string;
-  posts: Array<CollectionEntry<'posts'>>;
+  posts: PostWithTranslations[];
 };
 
 const { tag, posts } = Astro.props;

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,14 +1,15 @@
 ---
-import { queryAvailablePosts, queryTags } from '@lib/query';
+import { queryListPagePosts, queryTags } from '@lib/query';
 import Tags from '../../layouts/Tags.astro';
 
-const posts = await queryAvailablePosts();
+// dedup 済み posts (1 slug 1 entry) で usedCount を計算 → [tag].astro の表示件数と一致
+const posts = await queryListPagePosts();
 const tags = await queryTags();
 
 const tagWithCount = tags
   .map((tag) => {
-    const usedCount = posts.filter((post) => {
-      return post.data.tags.includes(tag.name);
+    const usedCount = posts.filter((item) => {
+      return item.post.data.tags.includes(tag.name);
     }).length;
     return { name: tag.name, usedCount };
   })


### PR DESCRIPTION
## 概要

\`docs/design/bilingual-list-display.md\` (PR #1588 でマージ済み) の Option D を実装。

list 構造はそのまま (1 slug 1 entry, ja-preferred dedup) で、翻訳がある記事のみ user の locale に応じて title / href を client-side swap する。

## 実装

### \`src/libs/query/posts.ts\`
- 型: \`PostTranslations\` / \`PostWithTranslations\`
- \`attachTranslations()\`: ja entry に \`translations.en = { title, href }\` を attach
- \`queryListPagePosts()\`: dedup + attach 済みの helper を新設

### \`src/layouts/List.astro\`
- props 型を \`PostWithTranslations[]\` に
- 翻訳がある entry の \`<a>\` に \`data-translation-en-href\` / \`data-translation-en-title\` を埋め込む
- 末尾に inline script: \`navigator.languages\` で en preference 判定 → swap

### 4 list page の query 切替

- \`src/pages/index.astro\`
- \`src/pages/channels/[channel].astro\`
- \`src/pages/tags/[tag].astro\`
- \`src/pages/tags/index.astro\`

## 動作

- ja 訪問者: 全 entry が ja で表示 (現状と同じ)
- en 訪問者 (\`navigator.languages\` で en が ja より先): 翻訳がある entry だけ title / href が en に swap、他は ja のまま
- no-JS / search bot: 全 entry が ja (canonical) で表示

## トレードオフ (design doc から)

1. no-JS で en preference な訪問者は ja で表示 (致命的でない、SEO 経由の en URL で補完)
2. ja を canonical (og / RSS / 検索 index と整合)
3. locale 判定は \`navigator.languages\` 単純走査 (明示 toggle UI は将来拡張)

## Test plan

- [x] \`pnpm test:libs\` (143 pass、1 fail は og-image の pre-existing 問題で無関係)
- [x] \`pnpm build\` 成功
- [x] \`pnpm lint\` / \`pnpm format\` pass
- [ ] CI code-review pass
- [ ] preview deploy で実際に挙動確認 (ja browser → ja 表示、en browser → swap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)