### PR TITLE
chore: SessionStart hookでstale branch検知 + §2d merge分離

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,13 +7,7 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/tools/protect-notion-content.sh"
-          }
-        ]
-      }
-    ],
-    "SessionStart": [
-      {
-        "hooks": [
+          },
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/tools/check-branch-state.sh"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,16 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/tools/check-branch-state.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,16 +34,16 @@ NEVER delete files/directories without user saying "yes, delete".
 - 「working tree にあるから」を理由に異種関心を 1 commit に同居させるな
 - conventional commit の type と branch prefix が不整合 (例: `feat/*` branch に `chore:` commit) なら STOP
 
-### 2d. Commit→Push→PR→CI watch は不可分。Merge は別単位
+### 2d. Merge は user 明示指示必須。Push までは不可分
 
-`git commit` 単発で完了報告を出すな。以下を 1 単位として実行せよ:
+`gh pr merge` (main への取り込み) は user の明示指示なしに実行禁止。skill / agent の自走範囲に merge は含まれない。retrospective skill の "commit and push" は文字通り push まで。
+
+merge を除いた以下は 1 単位として実行 (途中で止めるな):
 1. commit
 2. push
 3. PR が未作成なら作成
 4. `gh pr checks --watch` をバックグラウンドで起動
-5. CI 完了 + code-review 確認まで見届けて完了報告 → **ここで停止**
-
-`gh pr merge` (main への取り込み) は必ず user の明示指示が必要。skill / agent の自走範囲に merge は含まれない。retrospective skill の "commit and push" は文字通り push までを意味し、merge は含まない。
+5. CI 完了 + code-review 確認 → 完了報告
 
 ### 2b. Notion-Sourced Content (.md / .en.md) は編集しない
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,16 +34,16 @@ NEVER delete files/directories without user saying "yes, delete".
 - 「working tree にあるから」を理由に異種関心を 1 commit に同居させるな
 - conventional commit の type と branch prefix が不整合 (例: `feat/*` branch に `chore:` commit) なら STOP
 
-### 2d. Commit→Push→PR→CI watch は不可分
+### 2d. Commit→Push→PR→CI watch は不可分。Merge は別単位
 
 `git commit` 単発で完了報告を出すな。以下を 1 単位として実行せよ:
 1. commit
 2. push
 3. PR が未作成なら作成
 4. `gh pr checks --watch` をバックグラウンドで起動
-5. CI 完了 + code-review 確認まで見届けて初めて完了報告
+5. CI 完了 + code-review 確認まで見届けて完了報告 → **ここで停止**
 
-途中で止めて user の入力を待つな。Auto mode 下では特に「commit 完了しました」だけの報告は禁止。
+`gh pr merge` (main への取り込み) は必ず user の明示指示が必要。skill / agent の自走範囲に merge は含まれない。retrospective skill の "commit and push" は文字通り push までを意味し、merge は含まない。
 
 ### 2b. Notion-Sourced Content (.md / .en.md) は編集しない
 

--- a/tools/check-branch-state.sh
+++ b/tools/check-branch-state.sh
@@ -12,17 +12,10 @@ if [[ -z "$BRANCH" || "$BRANCH" == "main" || "$BRANCH" == "HEAD" ]]; then
 fi
 
 REMOTE_BRANCH=$(timeout 5 git ls-remote --heads origin "$BRANCH" 2>/dev/null | awk '{print $2}')
-PR_JSON=$(timeout 5 gh pr view "$BRANCH" --json number,state,mergedAt 2>/dev/null || echo "")
 
-if [[ -n "$PR_JSON" ]]; then
-  PR_STATE=$(echo "$PR_JSON" | jq -r '.state // empty' 2>/dev/null || echo "")
-  PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number // empty' 2>/dev/null || echo "")
-  PR_MERGED_AT=$(echo "$PR_JSON" | jq -r '.mergedAt // empty' 2>/dev/null || echo "")
-else
-  PR_STATE=""
-  PR_NUMBER=""
-  PR_MERGED_AT=""
-fi
+PR_STATE=$(timeout 5 gh pr view "$BRANCH" --json state --jq '.state // empty' 2>/dev/null || echo "")
+PR_NUMBER=$(timeout 5 gh pr view "$BRANCH" --json number --jq '.number // empty' 2>/dev/null || echo "")
+PR_MERGED_AT=$(timeout 5 gh pr view "$BRANCH" --json mergedAt --jq '.mergedAt // empty' 2>/dev/null || echo "")
 
 echo "## Branch state check"
 echo ""
@@ -34,7 +27,7 @@ else
   echo "- Remote branch: exists"
 fi
 
-if [[ -z "$PR_JSON" ]]; then
+if [[ -z "$PR_NUMBER" ]]; then
   echo "- Associated PR: none"
 else
   echo "- Associated PR: #$PR_NUMBER, state=$PR_STATE, mergedAt=$PR_MERGED_AT"

--- a/tools/check-branch-state.sh
+++ b/tools/check-branch-state.sh
@@ -3,9 +3,7 @@
 # Output is shown to Claude as additional context so stale branches are caught
 # before any mutating operation.
 
-set -e
-
-cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}" 2>/dev/null || cd "$(pwd)"
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 
@@ -17,9 +15,9 @@ REMOTE_BRANCH=$(git ls-remote --heads origin "$BRANCH" 2>/dev/null | awk '{print
 PR_JSON=$(gh pr view "$BRANCH" --json number,state,mergedAt 2>/dev/null || echo "")
 
 if [[ -n "$PR_JSON" ]]; then
-  PR_STATE=$(echo "$PR_JSON" | jq -r .state 2>/dev/null || echo "")
-  PR_NUMBER=$(echo "$PR_JSON" | jq -r .number 2>/dev/null || echo "")
-  PR_MERGED_AT=$(echo "$PR_JSON" | jq -r .mergedAt 2>/dev/null || echo "")
+  PR_STATE=$(echo "$PR_JSON" | jq -r '.state // empty' 2>/dev/null || echo "")
+  PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number // empty' 2>/dev/null || echo "")
+  PR_MERGED_AT=$(echo "$PR_JSON" | jq -r '.mergedAt // empty' 2>/dev/null || echo "")
 else
   PR_STATE=""
   PR_NUMBER=""

--- a/tools/check-branch-state.sh
+++ b/tools/check-branch-state.sh
@@ -12,6 +12,18 @@ if [[ -z "$BRANCH" || "$BRANCH" == "main" || "$BRANCH" == "HEAD" ]]; then
   exit 0
 fi
 
+# 60s TTL cache: skip network calls when branch was recently confirmed live.
+# Cache is per-branch and stored in /tmp; mtime serves as the timestamp.
+CACHE_DIR="${TMPDIR:-/tmp}"
+CACHE_FILE="$CACHE_DIR/check-branch-state-$(echo "$BRANCH" | tr '/' '_').cache"
+NOW=$(date +%s)
+if [[ -f "$CACHE_FILE" ]]; then
+  CACHE_MTIME=$(stat -f %m "$CACHE_FILE" 2>/dev/null || stat -c %Y "$CACHE_FILE" 2>/dev/null || echo 0)
+  if (( NOW - CACHE_MTIME < 60 )); then
+    exit 0
+  fi
+fi
+
 # Primary signal: remote branch existence. GitHub auto-deletes branches on merge,
 # so a missing remote is the most reliable "stale" indicator and avoids gh auth latency.
 # Capture timeout exit code (124) separately from "branch not found" (empty output, exit 0)
@@ -24,6 +36,7 @@ fi
 REMOTE_BRANCH=$(echo "$LS_OUT" | awk '{print $2}')
 
 if [[ -n "$REMOTE_BRANCH" ]]; then
+  touch "$CACHE_FILE" 2>/dev/null
   exit 0
 fi
 

--- a/tools/check-branch-state.sh
+++ b/tools/check-branch-state.sh
@@ -15,7 +15,8 @@ fi
 # 60s TTL cache: skip network calls when branch was recently confirmed live.
 # Cache is per-branch and stored in /tmp; mtime serves as the timestamp.
 CACHE_DIR="${TMPDIR:-/tmp}"
-CACHE_FILE="$CACHE_DIR/check-branch-state-$(echo "$BRANCH" | tr '/' '_').cache"
+BRANCH_HASH=$(printf '%s' "$BRANCH" | shasum -a 256 2>/dev/null | cut -c1-16)
+CACHE_FILE="$CACHE_DIR/check-branch-state-${BRANCH_HASH:-default}.cache"
 NOW=$(date +%s)
 if [[ -f "$CACHE_FILE" ]]; then
   CACHE_MTIME=$(stat -f %m "$CACHE_FILE" 2>/dev/null || stat -c %Y "$CACHE_FILE" 2>/dev/null || echo 0)

--- a/tools/check-branch-state.sh
+++ b/tools/check-branch-state.sh
@@ -14,15 +14,25 @@ fi
 
 # Primary signal: remote branch existence. GitHub auto-deletes branches on merge,
 # so a missing remote is the most reliable "stale" indicator and avoids gh auth latency.
-REMOTE_BRANCH=$(timeout 3 git ls-remote --heads origin "$BRANCH" 2>/dev/null | awk '{print $2}')
+# Capture timeout exit code (124) separately from "branch not found" (empty output, exit 0)
+# so a network outage doesn't cascade into a second 5s gh call on every Edit.
+LS_OUT=$(timeout 3 git ls-remote --heads origin "$BRANCH" 2>/dev/null)
+LS_EXIT=$?
+if [[ $LS_EXIT -eq 124 ]]; then
+  exit 0  # network timeout — assume live, do not block
+fi
+REMOTE_BRANCH=$(echo "$LS_OUT" | awk '{print $2}')
 
 if [[ -n "$REMOTE_BRANCH" ]]; then
-  # Remote exists — branch is live. No further check needed.
   exit 0
 fi
 
 # Remote missing. Confirm via PR state to distinguish "never pushed" from "merged & deleted".
-PR_INFO=$(timeout 5 gh pr view "$BRANCH" --json state,number --template '{{.state}}|{{.number}}' 2>/dev/null || echo "")
+PR_INFO=$(timeout 5 gh pr view "$BRANCH" --json state,number --template '{{.state}}|{{.number}}' 2>/dev/null)
+GH_EXIT=$?
+if [[ $GH_EXIT -eq 124 ]]; then
+  exit 0  # gh timeout — cannot determine state, do not block
+fi
 PR_STATE="${PR_INFO%%|*}"
 PR_NUMBER="${PR_INFO#*|}"
 

--- a/tools/check-branch-state.sh
+++ b/tools/check-branch-state.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# SessionStart hook: surface current branch state for non-main branches.
+# Output is shown to Claude as additional context so stale branches are caught
+# before any mutating operation.
+
+set -e
+
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+if [[ -z "$BRANCH" || "$BRANCH" == "main" || "$BRANCH" == "HEAD" ]]; then
+  exit 0
+fi
+
+REMOTE_BRANCH=$(git ls-remote --heads origin "$BRANCH" 2>/dev/null | awk '{print $2}')
+PR_JSON=$(gh pr view "$BRANCH" --json number,state,mergedAt 2>/dev/null || echo "")
+
+echo "## Branch state check"
+echo ""
+echo "- Current branch: \`$BRANCH\`"
+
+if [[ -z "$REMOTE_BRANCH" ]]; then
+  echo "- Remote branch: **NOT FOUND** (origin/$BRANCH does not exist)"
+else
+  echo "- Remote branch: exists"
+fi
+
+if [[ -z "$PR_JSON" ]]; then
+  echo "- Associated PR: none"
+else
+  STATE=$(echo "$PR_JSON" | jq -r .state)
+  NUMBER=$(echo "$PR_JSON" | jq -r .number)
+  MERGED_AT=$(echo "$PR_JSON" | jq -r .mergedAt)
+  echo "- Associated PR: #$NUMBER, state=$STATE, mergedAt=$MERGED_AT"
+fi
+
+PR_STATE=$(echo "$PR_JSON" | jq -r .state 2>/dev/null || echo "")
+if [[ "$PR_STATE" == "MERGED" || "$PR_STATE" == "CLOSED" ]]; then
+  echo ""
+  echo "**WARNING**: associated PR is $PR_STATE. This branch is stale - do not commit/push to it. Switch to main and start fresh."
+fi

--- a/tools/check-branch-state.sh
+++ b/tools/check-branch-state.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# SessionStart hook: surface current branch state for non-main branches.
-# Output is shown to Claude as additional context so stale branches are caught
-# before any mutating operation.
+# PreToolUse hook for Edit/Write/MultiEdit/NotebookEdit:
+# Block file modifications when current branch is stale (merged/closed PR).
+# This catches the case where Claude continues working on a branch after its PR
+# was merged elsewhere — the SessionStart-only approach misses mid-session staleness.
 
 cd "${CLAUDE_PROJECT_DIR:-$(pwd)}" 2>/dev/null || cd "$(pwd)"
 
@@ -11,33 +12,28 @@ if [[ -z "$BRANCH" || "$BRANCH" == "main" || "$BRANCH" == "HEAD" ]]; then
   exit 0
 fi
 
-REMOTE_BRANCH=$(timeout 5 git ls-remote --heads origin "$BRANCH" 2>/dev/null | awk '{print $2}')
+# Primary signal: remote branch existence. GitHub auto-deletes branches on merge,
+# so a missing remote is the most reliable "stale" indicator and avoids gh auth latency.
+REMOTE_BRANCH=$(timeout 3 git ls-remote --heads origin "$BRANCH" 2>/dev/null | awk '{print $2}')
 
-# Single gh call; parse via Go template to avoid jq dependency and 3x latency
-PR_INFO=$(timeout 5 gh pr view "$BRANCH" --json state,number,mergedAt --template '{{.state}}|{{.number}}|{{.mergedAt}}' 2>/dev/null || echo "")
+if [[ -n "$REMOTE_BRANCH" ]]; then
+  # Remote exists — branch is live. No further check needed.
+  exit 0
+fi
+
+# Remote missing. Confirm via PR state to distinguish "never pushed" from "merged & deleted".
+PR_INFO=$(timeout 5 gh pr view "$BRANCH" --json state,number --template '{{.state}}|{{.number}}' 2>/dev/null || echo "")
 PR_STATE="${PR_INFO%%|*}"
-PR_REST="${PR_INFO#*|}"
-PR_NUMBER="${PR_REST%%|*}"
-PR_MERGED_AT="${PR_REST#*|}"
-[[ "$PR_MERGED_AT" == "<no value>" || "$PR_MERGED_AT" == "<nil>" ]] && PR_MERGED_AT=""
-
-echo "## Branch state check"
-echo ""
-echo "- Current branch: \`$BRANCH\`"
-
-if [[ -z "$REMOTE_BRANCH" ]]; then
-  echo "- Remote branch: **NOT FOUND** (origin/$BRANCH does not exist)"
-else
-  echo "- Remote branch: exists"
-fi
-
-if [[ -z "$PR_NUMBER" ]]; then
-  echo "- Associated PR: none"
-else
-  echo "- Associated PR: #$PR_NUMBER, state=$PR_STATE, mergedAt=$PR_MERGED_AT"
-fi
+PR_NUMBER="${PR_INFO#*|}"
 
 if [[ "$PR_STATE" == "MERGED" || "$PR_STATE" == "CLOSED" ]]; then
-  echo ""
-  echo "**WARNING**: associated PR is $PR_STATE. This branch is stale - do not commit/push to it. Switch to main and start fresh."
+  cat >&2 <<EOF
+Blocked: branch '$BRANCH' is stale.
+Associated PR #$PR_NUMBER is $PR_STATE and the remote branch was deleted.
+Do not commit/edit on this branch. Switch to main and start a fresh branch:
+  git checkout main && git pull && git checkout -b <new-branch>
+EOF
+  exit 2
 fi
+
+exit 0

--- a/tools/check-branch-state.sh
+++ b/tools/check-branch-state.sh
@@ -13,9 +13,13 @@ fi
 
 REMOTE_BRANCH=$(timeout 5 git ls-remote --heads origin "$BRANCH" 2>/dev/null | awk '{print $2}')
 
-PR_STATE=$(timeout 5 gh pr view "$BRANCH" --json state --jq '.state // empty' 2>/dev/null || echo "")
-PR_NUMBER=$(timeout 5 gh pr view "$BRANCH" --json number --jq '.number // empty' 2>/dev/null || echo "")
-PR_MERGED_AT=$(timeout 5 gh pr view "$BRANCH" --json mergedAt --jq '.mergedAt // empty' 2>/dev/null || echo "")
+# Single gh call; parse via Go template to avoid jq dependency and 3x latency
+PR_INFO=$(timeout 5 gh pr view "$BRANCH" --json state,number,mergedAt --template '{{.state}}|{{.number}}|{{.mergedAt}}' 2>/dev/null || echo "")
+PR_STATE="${PR_INFO%%|*}"
+PR_REST="${PR_INFO#*|}"
+PR_NUMBER="${PR_REST%%|*}"
+PR_MERGED_AT="${PR_REST#*|}"
+[[ "$PR_MERGED_AT" == "<no value>" || "$PR_MERGED_AT" == "<nil>" ]] && PR_MERGED_AT=""
 
 echo "## Branch state check"
 echo ""

--- a/tools/check-branch-state.sh
+++ b/tools/check-branch-state.sh
@@ -1,70 +1,19 @@
 #!/usr/bin/env bash
-# PreToolUse hook for Edit/Write/MultiEdit/NotebookEdit:
-# Block file modifications when current branch is stale (merged/closed PR).
-# This catches the case where Claude continues working on a branch after its PR
-# was merged elsewhere — the SessionStart-only approach misses mid-session staleness.
+# PreToolUse hook: block file edits when current branch's PR is MERGED/CLOSED.
+# Fail-open: any error (no gh auth, network down, no PR, etc) → allow.
 
-cd "${CLAUDE_PROJECT_DIR:-$(pwd)}" 2>/dev/null || cd "$(pwd)"
+cd "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null || exit 0
 
-BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+[[ -z "$BRANCH" || "$BRANCH" == "main" || "$BRANCH" == "HEAD" ]] && exit 0
 
-if [[ -z "$BRANCH" || "$BRANCH" == "main" || "$BRANCH" == "HEAD" ]]; then
-  exit 0
-fi
+STATE=$(timeout 5 gh pr view "$BRANCH" --json state --template '{{.state}}' 2>/dev/null) || exit 0
 
-# 60s TTL cache: skip network calls when branch was recently confirmed live.
-# Cache is per-branch and stored in /tmp; mtime serves as the timestamp.
-CACHE_DIR="${TMPDIR:-/tmp}"
-BRANCH_HASH=$(
-  printf '%s' "$BRANCH" | sha256sum 2>/dev/null | cut -c1-16 \
-  || printf '%s' "$BRANCH" | shasum -a 256 2>/dev/null | cut -c1-16
-)
-# Final fallback: sanitized branch name (no hash tools available)
-if [[ -z "$BRANCH_HASH" ]]; then
-  BRANCH_HASH=$(printf '%s' "$BRANCH" | tr '/' '-' | tr -cd '[:alnum:]._-' | cut -c1-64)
-fi
-CACHE_FILE="$CACHE_DIR/check-branch-state-${BRANCH_HASH:-default}.cache"
-NOW=$(date +%s)
-if [[ -f "$CACHE_FILE" ]]; then
-  CACHE_MTIME=$(stat -f %m "$CACHE_FILE" 2>/dev/null || stat -c %Y "$CACHE_FILE" 2>/dev/null || echo 0)
-  if (( NOW - CACHE_MTIME < 60 )); then
-    exit 0
-  fi
-fi
-
-# Primary signal: remote branch existence. GitHub auto-deletes branches on merge,
-# so a missing remote is the most reliable "stale" indicator and avoids gh auth latency.
-# Capture timeout exit code (124) separately from "branch not found" (empty output, exit 0)
-# so a network outage doesn't cascade into a second 5s gh call on every Edit.
-LS_OUT=$(timeout 3 git ls-remote --heads origin "$BRANCH" 2>/dev/null)
-LS_EXIT=$?
-if [[ $LS_EXIT -eq 124 ]]; then
-  exit 0  # network timeout — assume live, do not block
-fi
-REMOTE_BRANCH=$(echo "$LS_OUT" | awk '{print $2}')
-
-if [[ -n "$REMOTE_BRANCH" ]]; then
-  touch "$CACHE_FILE" 2>/dev/null
-  exit 0
-fi
-
-# Remote missing. Confirm via PR state to distinguish "never pushed" from "merged & deleted".
-PR_INFO=$(timeout 5 gh pr view "$BRANCH" --json state,number --template '{{.state}}|{{.number}}' 2>/dev/null)
-GH_EXIT=$?
-if [[ $GH_EXIT -eq 124 ]]; then
-  exit 0  # gh timeout — cannot determine state, do not block
-fi
-PR_STATE="${PR_INFO%%|*}"
-PR_NUMBER="${PR_INFO#*|}"
-
-if [[ "$PR_STATE" == "MERGED" || "$PR_STATE" == "CLOSED" ]]; then
-  cat >&2 <<EOF
-Blocked: branch '$BRANCH' is stale.
-Associated PR #$PR_NUMBER is $PR_STATE and the remote branch was deleted.
-Do not commit/edit on this branch. Switch to main and start a fresh branch:
-  git checkout main && git pull && git checkout -b <new-branch>
-EOF
-  exit 2
-fi
-
+case "$STATE" in
+  MERGED|CLOSED)
+    echo "Blocked: branch '$BRANCH' has a $STATE PR. Switch to main and start a fresh branch:" >&2
+    echo "  git checkout main && git pull && git checkout -b <new-branch>" >&2
+    exit 2
+    ;;
+esac
 exit 0

--- a/tools/check-branch-state.sh
+++ b/tools/check-branch-state.sh
@@ -11,8 +11,8 @@ if [[ -z "$BRANCH" || "$BRANCH" == "main" || "$BRANCH" == "HEAD" ]]; then
   exit 0
 fi
 
-REMOTE_BRANCH=$(git ls-remote --heads origin "$BRANCH" 2>/dev/null | awk '{print $2}')
-PR_JSON=$(gh pr view "$BRANCH" --json number,state,mergedAt 2>/dev/null || echo "")
+REMOTE_BRANCH=$(timeout 5 git ls-remote --heads origin "$BRANCH" 2>/dev/null | awk '{print $2}')
+PR_JSON=$(timeout 5 gh pr view "$BRANCH" --json number,state,mergedAt 2>/dev/null || echo "")
 
 if [[ -n "$PR_JSON" ]]; then
   PR_STATE=$(echo "$PR_JSON" | jq -r '.state // empty' 2>/dev/null || echo "")

--- a/tools/check-branch-state.sh
+++ b/tools/check-branch-state.sh
@@ -15,7 +15,14 @@ fi
 # 60s TTL cache: skip network calls when branch was recently confirmed live.
 # Cache is per-branch and stored in /tmp; mtime serves as the timestamp.
 CACHE_DIR="${TMPDIR:-/tmp}"
-BRANCH_HASH=$(printf '%s' "$BRANCH" | shasum -a 256 2>/dev/null | cut -c1-16)
+BRANCH_HASH=$(
+  printf '%s' "$BRANCH" | sha256sum 2>/dev/null | cut -c1-16 \
+  || printf '%s' "$BRANCH" | shasum -a 256 2>/dev/null | cut -c1-16
+)
+# Final fallback: sanitized branch name (no hash tools available)
+if [[ -z "$BRANCH_HASH" ]]; then
+  BRANCH_HASH=$(printf '%s' "$BRANCH" | tr '/' '-' | tr -cd '[:alnum:]._-' | cut -c1-64)
+fi
 CACHE_FILE="$CACHE_DIR/check-branch-state-${BRANCH_HASH:-default}.cache"
 NOW=$(date +%s)
 if [[ -f "$CACHE_FILE" ]]; then

--- a/tools/check-branch-state.sh
+++ b/tools/check-branch-state.sh
@@ -16,6 +16,16 @@ fi
 REMOTE_BRANCH=$(git ls-remote --heads origin "$BRANCH" 2>/dev/null | awk '{print $2}')
 PR_JSON=$(gh pr view "$BRANCH" --json number,state,mergedAt 2>/dev/null || echo "")
 
+if [[ -n "$PR_JSON" ]]; then
+  PR_STATE=$(echo "$PR_JSON" | jq -r .state 2>/dev/null || echo "")
+  PR_NUMBER=$(echo "$PR_JSON" | jq -r .number 2>/dev/null || echo "")
+  PR_MERGED_AT=$(echo "$PR_JSON" | jq -r .mergedAt 2>/dev/null || echo "")
+else
+  PR_STATE=""
+  PR_NUMBER=""
+  PR_MERGED_AT=""
+fi
+
 echo "## Branch state check"
 echo ""
 echo "- Current branch: \`$BRANCH\`"
@@ -29,13 +39,9 @@ fi
 if [[ -z "$PR_JSON" ]]; then
   echo "- Associated PR: none"
 else
-  STATE=$(echo "$PR_JSON" | jq -r .state)
-  NUMBER=$(echo "$PR_JSON" | jq -r .number)
-  MERGED_AT=$(echo "$PR_JSON" | jq -r .mergedAt)
-  echo "- Associated PR: #$NUMBER, state=$STATE, mergedAt=$MERGED_AT"
+  echo "- Associated PR: #$PR_NUMBER, state=$PR_STATE, mergedAt=$PR_MERGED_AT"
 fi
 
-PR_STATE=$(echo "$PR_JSON" | jq -r .state 2>/dev/null || echo "")
 if [[ "$PR_STATE" == "MERGED" || "$PR_STATE" == "CLOSED" ]]; then
   echo ""
   echo "**WARNING**: associated PR is $PR_STATE. This branch is stale - do not commit/push to it. Switch to main and start fresh."


### PR DESCRIPTION
## Summary
- retrospective結果を反映: stale な merged-PR branch 上で作業して状況把握ミスを起こした事故への再発防止
- `tools/check-branch-state.sh`: SessionStart hook。current branch の関連 PR が MERGED/CLOSED なら警告
- `.claude/settings.json`: 上記 hook を SessionStart に登録
- `CLAUDE.md §2d`: 「commit→push→PR→CI watch 完了報告」と「main へ merge」を分離。merge は user 明示指示必須

## Test plan
- [x] format / lint pass
- [x] hook script 単体動作確認
- [ ] CI green