### PR TITLE
feat(notion-sync): zenn cross-post時のcanonical_urlを自動設定

### DIFF
--- a/tools/notion-sync/canonical-url.spec.ts
+++ b/tools/notion-sync/canonical-url.spec.ts
@@ -1,0 +1,40 @@
+import { strict as assert } from 'node:assert';
+import { test, describe } from 'node:test';
+import { resolveCanonicalUrl } from './canonical-url.ts';
+
+describe('resolveCanonicalUrl', () => {
+  test('Notion canonical_url に値がある → distribution によらず採用', () => {
+    assert.equal(
+      resolveCanonicalUrl('https://example.com/explicit', ['zenn'], 'my-slug'),
+      'https://example.com/explicit',
+    );
+    assert.equal(
+      resolveCanonicalUrl('https://example.com/explicit', undefined, 'my-slug'),
+      'https://example.com/explicit',
+    );
+  });
+
+  test('Notion 空 + distribution に "zenn" → Zenn URL を生成', () => {
+    assert.equal(resolveCanonicalUrl(undefined, ['zenn'], 'my-slug'), 'https://zenn.dev/lacolaco/articles/my-slug');
+    assert.equal(
+      resolveCanonicalUrl(undefined, ['blog.lacolaco.net', 'zenn'], 'angular-signal-inputs'),
+      'https://zenn.dev/lacolaco/articles/angular-signal-inputs',
+    );
+  });
+
+  test('Notion 空 + distribution に "zenn" なし → null', () => {
+    assert.equal(resolveCanonicalUrl(undefined, ['blog.lacolaco.net'], 'my-slug'), null);
+    assert.equal(resolveCanonicalUrl(undefined, ['dev'], 'my-slug'), null);
+    assert.equal(resolveCanonicalUrl(undefined, [], 'my-slug'), null);
+  });
+
+  test('Notion 空 + distribution undefined → null', () => {
+    assert.equal(resolveCanonicalUrl(undefined, undefined, 'my-slug'), null);
+  });
+
+  test('Notion 空白文字のみ → 「値なし」として扱う', () => {
+    assert.equal(resolveCanonicalUrl('   ', ['zenn'], 'my-slug'), 'https://zenn.dev/lacolaco/articles/my-slug');
+    assert.equal(resolveCanonicalUrl('', ['zenn'], 'my-slug'), 'https://zenn.dev/lacolaco/articles/my-slug');
+    assert.equal(resolveCanonicalUrl('   ', undefined, 'my-slug'), null);
+  });
+});

--- a/tools/notion-sync/canonical-url.ts
+++ b/tools/notion-sync/canonical-url.ts
@@ -1,0 +1,28 @@
+// Notion DB の canonical_url + distribution プロパティから、frontmatter に出力する
+// canonical_url を決定する純関数。
+
+const ZENN_USERNAME = 'lacolaco';
+const ZENN_DISTRIBUTION = 'zenn';
+
+/**
+ * canonical URL を決定する。優先順位:
+ *   1. Notion canonical_url に値があれば採用 (distribution によらず)
+ *   2. distribution に "zenn" が含まれる場合は Zenn URL を生成 (slug 同一前提)
+ *   3. それ以外は null
+ *
+ * Notion 側が空白のみ・空文字列のときは「値なし」として扱い、フォールバックロジックに進む。
+ */
+export function resolveCanonicalUrl(
+  notionCanonical: string | undefined,
+  distribution: string[] | undefined,
+  slug: string,
+): string | null {
+  const explicit = notionCanonical?.trim();
+  if (explicit) {
+    return explicit;
+  }
+  if (distribution?.includes(ZENN_DISTRIBUTION)) {
+    return `https://zenn.dev/${ZENN_USERNAME}/articles/${slug}`;
+  }
+  return null;
+}

--- a/tools/notion-sync/canonical-url.ts
+++ b/tools/notion-sync/canonical-url.ts
@@ -1,17 +1,7 @@
-// Notion DB の canonical_url + distribution プロパティから、frontmatter に出力する
-// canonical_url を決定する純関数。
-
 const ZENN_USERNAME = 'lacolaco';
 const ZENN_DISTRIBUTION = 'zenn';
 
-/**
- * canonical URL を決定する。優先順位:
- *   1. Notion canonical_url に値があれば採用 (distribution によらず)
- *   2. distribution に "zenn" が含まれる場合は Zenn URL を生成 (slug 同一前提)
- *   3. それ以外は null
- *
- * Notion 側が空白のみ・空文字列のときは「値なし」として扱い、フォールバックロジックに進む。
- */
+// 優先順位: Notion canonical_url > zenn distribution 自動生成 > null
 export function resolveCanonicalUrl(
   notionCanonical: string | undefined,
   distribution: string[] | undefined,

--- a/tools/notion-sync/main.ts
+++ b/tools/notion-sync/main.ts
@@ -6,6 +6,7 @@ import { createHash } from 'node:crypto';
 import * as path from 'node:path';
 import { parseArgs } from 'node:util';
 import { extractAutoTranslate, frontmatterAutoTranslate } from './auto-translate-flag.ts';
+import { resolveCanonicalUrl } from './canonical-url.ts';
 
 // Notion DBプロパティのスキーマ。get(name)の戻り値型をここで定義する
 type BlogPostDatasource = {
@@ -16,6 +17,7 @@ type BlogPostDatasource = {
   locale: string | undefined;
   tags: string[] | undefined;
   canonical_url: string | undefined;
+  distribution: string[] | undefined;
   updated_at: string | undefined;
   created_at_override: string | undefined;
   auto_translate: boolean | undefined;
@@ -184,6 +186,7 @@ const result = await syncNotionDatasource<BlogPostMetadata, BlogPostDatasource>(
     const locale = get('locale');
     const tags = get('tags');
     const canonicalUrl = get('canonical_url');
+    const distribution = get('distribution');
     const updatedAt = get('updated_at');
     const createdAtOverride = get('created_at_override');
     const autoTranslate = get('auto_translate');
@@ -215,7 +218,7 @@ const result = await syncNotionDatasource<BlogPostMetadata, BlogPostDatasource>(
       locale: locale ?? 'ja',
       source_url: page.url,
       tags: tags ?? [],
-      canonical_url: canonicalUrl ?? null,
+      canonical_url: resolveCanonicalUrl(canonicalUrl, distribution, slug),
       created_time: date.toISOString(),
       last_edited_time: lastEditedTime.toISOString(),
       auto_translate: extractAutoTranslate(autoTranslate),


### PR DESCRIPTION
## Summary
- distribution multi_select に "zenn" が含まれる記事で canonical_url が未設定なら、`https://zenn.dev/lacolaco/articles/{slug}` を自動生成
- Notion 側に明示値があればそちら優先 (現状維持)
- Notion への書き戻しなし

## 決定論理 (resolveCanonicalUrl)
1. Notion canonical_url に値あり → 採用
2. (1)空 かつ distribution に "zenn" → Zenn URL を生成
3. それ以外 → null

## 影響範囲
Notion検証で対象記事 5 件を確認済み (canonical_url 空 + distribution=zenn):
- angular-debounced-resource
- angular-v22-onpush-by-default
- angular-builtin-summarizer-resource
- testing-angular-applications-with-vitest
- angular-signal-equal-option

次回 notion-sync 実行時に上記の frontmatter `canonical_url` が自動補完される。既存 canonical_url 設定済み記事の挙動は変わらない。

## Test plan
- [x] resolveCanonicalUrl の単体テスト 5 ケース (node:test) pass
- [x] format / lint pass
- [x] notion-sync --dry-run で全 341 件処理エラーなし
- [ ] CI green