### PR TITLE
feat(rss): channel情報をtagsの先頭にcategoriesとして含める

### DIFF
--- a/src/libs/post/index.ts
+++ b/src/libs/post/index.ts
@@ -1,2 +1,3 @@
 export * from './schema';
 export * from './properties';
+export * from './rss-categories';

--- a/src/libs/post/rss-categories.spec.ts
+++ b/src/libs/post/rss-categories.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { buildRssCategories } from './rss-categories';
+
+describe('buildRssCategories', () => {
+  it('channelsをtagsの先頭に含める', () => {
+    const result = buildRssCategories({
+      channels: ['Angular'],
+      tags: ['TypeScript', 'Web'],
+    });
+    expect(result).toEqual(['Angular', 'TypeScript', 'Web']);
+  });
+
+  it('複数channelsをtagsの先頭に含める', () => {
+    const result = buildRssCategories({
+      channels: ['Angular', 'Frontend'],
+      tags: ['TypeScript'],
+    });
+    expect(result).toEqual(['Angular', 'Frontend', 'TypeScript']);
+  });
+
+  it('channelsがundefinedでもtagsを返す', () => {
+    const result = buildRssCategories({
+      channels: undefined,
+      tags: ['TypeScript', 'Web'],
+    });
+    expect(result).toEqual(['TypeScript', 'Web']);
+  });
+
+  it('channelsが空配列でもtagsを返す', () => {
+    const result = buildRssCategories({
+      channels: [],
+      tags: ['TypeScript'],
+    });
+    expect(result).toEqual(['TypeScript']);
+  });
+
+  it('tagsが空でもchannelsを返す', () => {
+    const result = buildRssCategories({
+      channels: ['Angular'],
+      tags: [],
+    });
+    expect(result).toEqual(['Angular']);
+  });
+});

--- a/src/libs/post/rss-categories.ts
+++ b/src/libs/post/rss-categories.ts
@@ -1,0 +1,8 @@
+type RssCategoriesInput = {
+  channels: string[] | undefined;
+  tags: string[];
+};
+
+export function buildRssCategories({ channels, tags }: RssCategoriesInput): string[] {
+  return [...(channels ?? []), ...tags];
+}

--- a/src/pages/channels/[channel].en.full.xml.ts
+++ b/src/pages/channels/[channel].en.full.xml.ts
@@ -1,5 +1,6 @@
 import type { CollectionEntry } from 'astro:content';
 import rss from '@astrojs/rss';
+import { buildRssCategories } from '@lib/post';
 import { queryAvailablePosts, queryChannels } from '@lib/query';
 import type { APIContext } from 'astro';
 import { RSS_FULL_ITEMS_LIMIT, SITE_DESCRIPTION, SITE_TITLE } from '../../consts';
@@ -37,7 +38,7 @@ export async function GET(context: APIContext<Props>) {
         title: post.data.title,
         pubDate: post.data.created_time,
         link: `/posts/${post.data.slug}.en`,
-        categories: post.data.tags,
+        categories: buildRssCategories(post.data),
         content: post.rendered?.html,
       };
     }),

--- a/src/pages/channels/[channel].en.xml.ts
+++ b/src/pages/channels/[channel].en.xml.ts
@@ -1,5 +1,6 @@
 import type { CollectionEntry } from 'astro:content';
 import rss from '@astrojs/rss';
+import { buildRssCategories } from '@lib/post';
 import { queryAvailablePosts, queryChannels } from '@lib/query';
 import type { APIContext } from 'astro';
 import { RSS_ITEMS_LIMIT, SITE_DESCRIPTION, SITE_TITLE } from '../../consts';
@@ -37,7 +38,7 @@ export async function GET(context: APIContext<Props>) {
         title: post.data.title,
         pubDate: post.data.created_time,
         link: `/posts/${post.data.slug}.en`,
-        categories: post.data.tags,
+        categories: buildRssCategories(post.data),
       };
     }),
   });

--- a/src/pages/channels/[channel].full.xml.ts
+++ b/src/pages/channels/[channel].full.xml.ts
@@ -1,5 +1,6 @@
 import type { CollectionEntry } from 'astro:content';
 import rss from '@astrojs/rss';
+import { buildRssCategories } from '@lib/post';
 import { queryAvailablePosts, queryChannels, deduplicatePosts } from '@lib/query';
 import type { APIContext } from 'astro';
 import { RSS_FULL_ITEMS_LIMIT, SITE_DESCRIPTION, SITE_TITLE } from '../../consts';
@@ -37,7 +38,7 @@ export async function GET(context: APIContext<Props>) {
         title: post.data.title,
         pubDate: post.data.created_time,
         link: `/posts/${post.data.slug}`,
-        categories: post.data.tags,
+        categories: buildRssCategories(post.data),
         content: post.rendered?.html,
       };
     }),

--- a/src/pages/channels/[channel].xml.ts
+++ b/src/pages/channels/[channel].xml.ts
@@ -1,5 +1,6 @@
 import type { CollectionEntry } from 'astro:content';
 import rss from '@astrojs/rss';
+import { buildRssCategories } from '@lib/post';
 import { queryAvailablePosts, queryChannels, deduplicatePosts } from '@lib/query';
 import type { APIContext } from 'astro';
 import { RSS_ITEMS_LIMIT, SITE_DESCRIPTION, SITE_TITLE } from '../../consts';
@@ -37,7 +38,7 @@ export async function GET(context: APIContext<Props>) {
         title: post.data.title,
         pubDate: post.data.created_time,
         link: `/posts/${post.data.slug}`,
-        categories: post.data.tags,
+        categories: buildRssCategories(post.data),
       };
     }),
   });

--- a/src/pages/index.en.full.xml.ts
+++ b/src/pages/index.en.full.xml.ts
@@ -1,4 +1,5 @@
 import rss from '@astrojs/rss';
+import { buildRssCategories } from '@lib/post';
 import { queryAvailablePosts } from '@lib/query';
 import type { APIContext } from 'astro';
 import { RSS_FULL_ITEMS_LIMIT, SITE_DESCRIPTION, SITE_TITLE } from '../consts';
@@ -16,7 +17,7 @@ export async function GET(context: APIContext) {
         title: post.data.title,
         pubDate: post.data.created_time,
         link: `/posts/${post.data.slug}.en`,
-        categories: post.data.tags,
+        categories: buildRssCategories(post.data),
         content: post.rendered?.html,
       };
     }),

--- a/src/pages/index.en.xml.ts
+++ b/src/pages/index.en.xml.ts
@@ -1,4 +1,5 @@
 import rss from '@astrojs/rss';
+import { buildRssCategories } from '@lib/post';
 import { queryAvailablePosts } from '@lib/query';
 import type { APIContext } from 'astro';
 import { RSS_ITEMS_LIMIT, SITE_DESCRIPTION, SITE_TITLE } from '../consts';
@@ -16,7 +17,7 @@ export async function GET(context: APIContext) {
         title: post.data.title,
         pubDate: post.data.created_time,
         link: `/posts/${post.data.slug}.en`,
-        categories: post.data.tags,
+        categories: buildRssCategories(post.data),
       };
     }),
   });

--- a/src/pages/index.full.xml.ts
+++ b/src/pages/index.full.xml.ts
@@ -1,4 +1,5 @@
 import rss from '@astrojs/rss';
+import { buildRssCategories } from '@lib/post';
 import { queryAvailablePosts, deduplicatePosts } from '@lib/query';
 import type { APIContext } from 'astro';
 import { RSS_FULL_ITEMS_LIMIT, SITE_DESCRIPTION, SITE_TITLE } from '../consts';
@@ -16,7 +17,7 @@ export async function GET(context: APIContext) {
         title: post.data.title,
         pubDate: post.data.created_time,
         link: `/posts/${post.data.slug}`,
-        categories: post.data.tags,
+        categories: buildRssCategories(post.data),
         content: post.rendered?.html,
       };
     }),

--- a/src/pages/index.xml.ts
+++ b/src/pages/index.xml.ts
@@ -1,4 +1,5 @@
 import rss from '@astrojs/rss';
+import { buildRssCategories } from '@lib/post';
 import { queryAvailablePosts, deduplicatePosts } from '@lib/query';
 import type { APIContext } from 'astro';
 import { RSS_ITEMS_LIMIT, SITE_DESCRIPTION, SITE_TITLE } from '../consts';
@@ -16,7 +17,7 @@ export async function GET(context: APIContext) {
         title: post.data.title,
         pubDate: post.data.created_time,
         link: `/posts/${post.data.slug}`,
-        categories: post.data.tags,
+        categories: buildRssCategories(post.data),
       };
     }),
   });

--- a/src/pages/tags/[tag].en.full.xml.ts
+++ b/src/pages/tags/[tag].en.full.xml.ts
@@ -1,4 +1,5 @@
 import rss from '@astrojs/rss';
+import { buildRssCategories } from '@lib/post';
 import { queryAvailablePosts, queryTags } from '@lib/query';
 import type { APIContext } from 'astro';
 import { RSS_FULL_ITEMS_LIMIT, SITE_DESCRIPTION, SITE_TITLE } from '../../consts';
@@ -39,7 +40,7 @@ export async function GET(context: APIContext<Props>) {
         title: post.data.title,
         pubDate: post.data.created_time,
         link: `/posts/${post.data.slug}.en`,
-        categories: post.data.tags,
+        categories: buildRssCategories(post.data),
         content: post.rendered?.html,
       };
     }),

--- a/src/pages/tags/[tag].en.xml.ts
+++ b/src/pages/tags/[tag].en.xml.ts
@@ -1,4 +1,5 @@
 import rss from '@astrojs/rss';
+import { buildRssCategories } from '@lib/post';
 import { queryAvailablePosts, queryTags } from '@lib/query';
 import type { APIContext } from 'astro';
 import { RSS_ITEMS_LIMIT, SITE_DESCRIPTION, SITE_TITLE } from '../../consts';
@@ -39,7 +40,7 @@ export async function GET(context: APIContext<Props>) {
         title: post.data.title,
         pubDate: post.data.created_time,
         link: `/posts/${post.data.slug}.en`,
-        categories: post.data.tags,
+        categories: buildRssCategories(post.data),
       };
     }),
   });

--- a/src/pages/tags/[tag].full.xml.ts
+++ b/src/pages/tags/[tag].full.xml.ts
@@ -1,4 +1,5 @@
 import rss from '@astrojs/rss';
+import { buildRssCategories } from '@lib/post';
 import { queryAvailablePosts, queryTags, deduplicatePosts } from '@lib/query';
 import type { APIContext } from 'astro';
 import { RSS_FULL_ITEMS_LIMIT, SITE_DESCRIPTION, SITE_TITLE } from '../../consts';
@@ -39,7 +40,7 @@ export async function GET(context: APIContext<Props>) {
         title: post.data.title,
         pubDate: post.data.created_time,
         link: `/posts/${post.data.slug}`,
-        categories: post.data.tags,
+        categories: buildRssCategories(post.data),
         content: post.rendered?.html,
       };
     }),

--- a/src/pages/tags/[tag].xml.ts
+++ b/src/pages/tags/[tag].xml.ts
@@ -1,4 +1,5 @@
 import rss from '@astrojs/rss';
+import { buildRssCategories } from '@lib/post';
 import { queryAvailablePosts, queryTags, deduplicatePosts } from '@lib/query';
 import type { APIContext } from 'astro';
 import { RSS_ITEMS_LIMIT, SITE_DESCRIPTION, SITE_TITLE } from '../../consts';
@@ -39,7 +40,7 @@ export async function GET(context: APIContext<Props>) {
         title: post.data.title,
         pubDate: post.data.created_time,
         link: `/posts/${post.data.slug}`,
-        categories: post.data.tags,
+        categories: buildRssCategories(post.data),
       };
     }),
   });


### PR DESCRIPTION
## Summary
- RSSフィードの `<category>` に channel を tags の先頭で含めるよう変更（index / tags / channels の通常版・full版・en版 計12ファイル）
- `buildRssCategories({channels, tags})` ヘルパーを `src/libs/post/rss-categories.ts` に新設し、12箇所の重複を集約
- 純粋関数として5ケースのテスト追加（channels先頭・複数channels・undefined・空配列・tags空）

## Test plan
- [x] `pnpm test:libs src/libs/post/rss-categories.spec.ts` 全pass
- [x] `pnpm lint` / `pnpm format` pass
- [x] `pnpm build` 成功
- [x] 生成された `dist/client/index.xml` を実視確認: 投稿のchannel（"Code", "Angular"等）が tags より先に `<category>` として出力されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)