### PR TITLE
fix(embed): stream response body and stop at </head> or 512KB cap

### DIFF
--- a/src/libs/embed/fetchPageMetadata.spec.ts
+++ b/src/libs/embed/fetchPageMetadata.spec.ts
@@ -180,9 +180,27 @@ describe('fetchPageMetadata', () => {
       title: 'https://example.com/file.pdf',
       description: '',
       imageUrl: null,
-      cacheControl: null,
+      // Cache-Control 未設定なので catch fallback と同じデフォルトに揃える
+      cacheControl: 'max-age=60, must-revalidate',
     });
     expect(cancel).toHaveBeenCalled();
+  });
+
+  it('content-type が HTML 以外 + Cache-Control ヘッダあり → サーバー指定値を尊重する', async () => {
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: new Headers({
+        'content-type': 'application/pdf',
+        'cache-control': 'public, max-age=86400',
+      }),
+      body: { cancel } as unknown as ReadableStream<Uint8Array>,
+    });
+
+    const result = await fetchPageMetadata('https://example.com/file.pdf');
+
+    expect(result.cacheControl).toBe('public, max-age=86400');
   });
 
   it('streaming で </head> を見つけた時点で body 読み込みを打ち切る (巨大HTML対策)', async () => {

--- a/src/libs/embed/fetchPageMetadata.spec.ts
+++ b/src/libs/embed/fetchPageMetadata.spec.ts
@@ -164,4 +164,100 @@ describe('fetchPageMetadata', () => {
     expect(result.title).toBe('invalid-url');
     expect(result.cacheControl).toBe('max-age=60, must-revalidate');
   });
+
+  it('content-type が HTML 以外なら body を読まずに fallback する (PDF などの巨大バイナリ対策)', async () => {
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/pdf' }),
+      body: { cancel } as unknown as ReadableStream<Uint8Array>,
+    });
+
+    const result = await fetchPageMetadata('https://example.com/file.pdf');
+
+    expect(result).toEqual({
+      title: 'https://example.com/file.pdf',
+      description: '',
+      imageUrl: null,
+      cacheControl: null,
+    });
+    expect(cancel).toHaveBeenCalled();
+  });
+
+  it('streaming で </head> を見つけた時点で body 読み込みを打ち切る (巨大HTML対策)', async () => {
+    const head =
+      '<html><head><title>Streamed</title><meta property="og:image" content="https://example.com/og.png"></head>';
+    const giantBody = '<body>' + 'x'.repeat(10_000_000) + '</body></html>';
+    const fullHtml = head + giantBody;
+
+    // 64KB 単位で chunk 化。reader.read() がどこまで呼ばれるかを観測する
+    const encoder = new TextEncoder();
+    const chunkSize = 64 * 1024;
+    const chunks: Uint8Array[] = [];
+    for (let i = 0; i < fullHtml.length; i += chunkSize) {
+      chunks.push(encoder.encode(fullHtml.slice(i, i + chunkSize)));
+    }
+    let readIndex = 0;
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    const reader = {
+      read: vi.fn(() => {
+        if (readIndex >= chunks.length) return Promise.resolve({ done: true, value: undefined });
+        return Promise.resolve({ done: false, value: chunks[readIndex++] });
+      }),
+      cancel,
+    };
+    const body = { getReader: () => reader } as unknown as ReadableStream<Uint8Array>;
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'text/html' }),
+      body,
+    });
+
+    const result = await fetchPageMetadata('https://example.com');
+
+    expect(result.title).toBe('Streamed');
+    expect(result.imageUrl).toBe('https://example.com/og.png');
+    // body 全体 (10MB) を読み切らず、最初の chunk で </head> 検出して break していること
+    expect(reader.read).toHaveBeenCalledTimes(1);
+    expect(cancel).toHaveBeenCalled();
+  });
+
+  it('</head> が見つからないまま上限 byte に達したらそこで打ち切る (壊れたHTML対策)', async () => {
+    // head 終端が現れない壊れた HTML
+    const malformed = '<html><head><title>Broken</title>' + 'x'.repeat(2_000_000);
+    const encoder = new TextEncoder();
+    const chunkSize = 128 * 1024;
+    const chunks: Uint8Array[] = [];
+    for (let i = 0; i < malformed.length; i += chunkSize) {
+      chunks.push(encoder.encode(malformed.slice(i, i + chunkSize)));
+    }
+    let readIndex = 0;
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    const reader = {
+      read: vi.fn(() => {
+        if (readIndex >= chunks.length) return Promise.resolve({ done: true, value: undefined });
+        return Promise.resolve({ done: false, value: chunks[readIndex++] });
+      }),
+      cancel,
+    };
+    const body = { getReader: () => reader } as unknown as ReadableStream<Uint8Array>;
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),
+      body,
+    });
+
+    const result = await fetchPageMetadata('https://example.com/broken');
+
+    // title だけは抽出できる
+    expect(result.title).toBe('Broken');
+    // 上限 512KB に達するまでしか読まない (128KB chunk * 4 = 512KB)
+    expect(reader.read).toHaveBeenCalledTimes(4);
+    expect(cancel).toHaveBeenCalled();
+  });
 });

--- a/src/libs/embed/fetchPageMetadata.ts
+++ b/src/libs/embed/fetchPageMetadata.ts
@@ -8,6 +8,13 @@ const CHROME_USER_AGENT =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
 const DEFAULT_USER_AGENT = 'blog.lacolaco.net';
 
+// OGP/meta は <head> 内で完結するため body 全部は読まない。
+// 巨大な SPA / Google Slides 等 (20MB+) を丸ごと cheerio.load すると Cloud Run の
+// メモリと request timeout を食い潰して 503 になる。streaming で </head> を見つけたら
+// 即 abort し、見つからなくても上限 byte で打ち切る (head 終端不明な壊れた HTML の保険)
+const MAX_HTML_BYTES = 512 * 1024; // 512 KB
+const HEAD_END_PATTERN = /<\/head\s*>/i;
+
 // 型定義
 export interface PageMetadata {
   title: string;
@@ -66,6 +73,45 @@ function extractImageUrl($: CheerioAPI, baseUrl: string): string | null {
   }
 }
 
+// response body を <head> 終端 or 上限 byte まで streaming で読む。
+// body プロパティが存在しない場合 (テストの簡易 mock 等) は従来通り text() に fallback。
+async function readHtmlHead(res: Response): Promise<string> {
+  if (!res.body) {
+    return await res.text();
+  }
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder('utf-8');
+  let total = 0;
+  let acc = '';
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      acc += decoder.decode(value, { stream: true });
+      const idx = acc.search(HEAD_END_PATTERN);
+      if (idx !== -1) {
+        // </head> までを切り出して残りは読み捨て
+        const endIdx = acc.indexOf('>', idx) + 1;
+        acc = acc.slice(0, endIdx);
+        break;
+      }
+      if (total >= MAX_HTML_BYTES) {
+        // head 終端を見つけられないまま上限に達した。ここまでで切り上げる
+        break;
+      }
+    }
+    acc += decoder.decode();
+  } finally {
+    try {
+      await reader.cancel();
+    } catch {
+      // cancel が rejected でも本処理には影響しない
+    }
+  }
+  return acc;
+}
+
 export const DEFAULT_CACHE_MAX_AGE = 60 * 60; // 1 hour
 
 export async function fetchPageMetadata(url: string): Promise<PageMetadata> {
@@ -117,7 +163,23 @@ export async function fetchPageMetadata(url: string): Promise<PageMetadata> {
       },
     );
 
-    const html = await response.text();
+    // content-type が HTML 系でなければ metadata 抽出は無意味なので fallback
+    const contentType = response.headers.get('content-type') ?? '';
+    if (contentType && !/text\/html|application\/xhtml/i.test(contentType)) {
+      try {
+        await response.body?.cancel();
+      } catch {
+        // cancel 失敗は無害
+      }
+      return {
+        title: url,
+        description: '',
+        imageUrl: null,
+        cacheControl: response.headers.get('cache-control'),
+      };
+    }
+
+    const html = await readHtmlHead(response);
     const $ = load(html);
 
     return {

--- a/src/libs/embed/fetchPageMetadata.ts
+++ b/src/libs/embed/fetchPageMetadata.ts
@@ -175,7 +175,9 @@ export async function fetchPageMetadata(url: string): Promise<PageMetadata> {
         title: url,
         description: '',
         imageUrl: null,
-        cacheControl: response.headers.get('cache-control'),
+        // Cache-Control 未設定 (PDF 等で一般的) なら catch ブロックの fallback と
+        // 揃えて短期間 must-revalidate にする。毎リクエスト再 fetch を避ける
+        cacheControl: response.headers.get('cache-control') ?? 'max-age=60, must-revalidate',
       };
     }
 


### PR DESCRIPTION
## Summary
- bit.ly 短縮 URL (例: `https://bit.ly/tskaigi2026-lacolaco`) のリダイレクト先が **約 20MB の Google Slides /pub HTML** だと、SSR の `/embed` エンドポイントが 503 を返して埋め込みが壊れていた ( https://blog.lacolaco.net/posts/tskaigi-2026-deck で発覚)
- 原因: `fetchPageMetadata` が `response.text()` で全文を文字列化したうえ `cheerio.load()` でパースしており、Cloud Run のメモリ・request timeout を食い潰していた
- 修正: response body を **streaming で `</head>` まで読んだ時点で abort**、見つからない場合は 512KB の byte cap で打ち切る。OGP/Twitter Card/<meta> は <head> 内で完結するため body 後半は無くて支障なし

## 業界の先例

metascraper・open-graph-scraper・Twitter Card crawler・Slack unfurl 等のいずれも「head 終端 abort + byte limit」が標準。20MB をメモリに乗せる方が異常で、本修正は標準的な堅牢化に揃えるもの。

## 追加対策

- `content-type` ヘッダが `text/html` / `application/xhtml+xml` 系でなければ body を読まずに fallback (PDF 等のバイナリ URL 対策)
- `response.body` が無い (テストの簡易 mock 等) ケースは従来通り `response.text()` に fallback して互換維持

## Test plan
- [x] 単体テスト 10 件 pass (既存 7 件 + 新規 3 件: streaming で </head> 検出 break / 上限 byte 到達 break / 非 HTML content-type で fallback)
- [x] `IMAGE_CDN_BASE_URL=... pnpm build` pass
- [ ] CI / production deploy 後、 https://blog.lacolaco.net/embed?url=https://bit.ly/tskaigi2026-lacolaco が 200 を返し、 https://blog.lacolaco.net/posts/tskaigi-2026-deck で埋め込みカードが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)