### PR TITLE
feat(ci): add auto-translate job + redirect .sync to blog-contents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,63 @@ jobs:
         env:
           NOTION_AUTH_TOKEN: ${{ secrets.NOTION_AUTH_TOKEN }}
 
+  auto-translate:
+    # blog-contents から push される sync PR にのみ翻訳を実行 (人手 PR は翻訳しない)
+    if: github.event.pull_request.head.ref == 'notion-sync-from-blog-contents'
+    runs-on: ubuntu-latest
+    # GITHUB_TOKEN は使わない (App token で checkout + push を完結)
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.WORKER_APP_ID }}
+          private-key: ${{ secrets.WORKER_APP_PRIVATE_KEY }}
+          owner: lacolaco
+          repositories: blog.lacolaco.net
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # PR head に直接 commit back するため head SHA を checkout
+          ref: ${{ github.event.pull_request.head.sha }}
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 1
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .node-version
+          cache: 'pnpm'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@lacolaco'
+      - run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # `pnpm run auto-translate` は `tsx --env-file .env tools/auto-translate/main.ts`。
+      # tsx の --env-file は対象ファイル不存在で起動失敗するため空 .env を生成して通す
+      # (GEMINI_API_KEY は下で env: 注入、.env はダミー)
+      - run: touch .env
+
+      - name: Auto-translate ja → en for flagged articles
+        run: pnpm run auto-translate
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+
+      - name: Commit translated files back to PR branch
+        # context 値はシェルに直接埋め込まず env 経由で参照する (GitHub Actions security guide)
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          git config user.name "lacolaco-actions-worker[bot]"
+          git config user.email "lacolaco-actions-worker[bot]@users.noreply.github.com"
+          if [[ -n "$(git status --porcelain src/content/post/notion)" ]]; then
+            git add src/content/post/notion
+            git commit -m "chore: auto-translate ja → en"
+            git push origin "HEAD:$HEAD_REF"
+          else
+            echo "No translation changes"
+          fi
+
   terraform:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/trigger-sync-from-pr-comment.yml
+++ b/.github/workflows/trigger-sync-from-pr-comment.yml
@@ -11,7 +11,6 @@ jobs:
       pull-requests: write
       issues: write
       checks: read
-      actions: write
     steps:
       - uses: github/command@3442f3fa1efe01bdb024b157083c337902d17372 # v2.0.3
         id: command
@@ -22,17 +21,26 @@ jobs:
           skip_ci: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowlist: lacolaco
-      - name: Trigger Workflow
+
+      # blog-contents への repository_dispatch には GITHUB_TOKEN だと権限不足のため App token を発行
+      - name: Generate App token (for blog-contents dispatch)
+        id: app-token
+        if: ${{ steps.command.outputs.continue == 'true' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.WORKER_APP_ID }}
+          private-key: ${{ secrets.WORKER_APP_PRIVATE_KEY }}
+          owner: lacolaco
+          repositories: blog-contents
+
+      - name: Dispatch sync workflow in blog-contents
         if: ${{ steps.command.outputs.continue == 'true' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
-            github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'sync-with-notion.yml',
-              ref: 'main',
-              inputs: {
-                forceUpdate: 'false'
-              }
-            })
+            await github.rest.repos.createDispatchEvent({
+              owner: 'lacolaco',
+              repo: 'blog-contents',
+              event_type: 'notion-sync-blog-lacolaco',
+            });


### PR DESCRIPTION
## Summary

[lacolaco/blog-contents PR #382](https://github.com/lacolaco/blog-contents/pull/382) で merge した plan 009 (Phase 3A Step 4, Option B) の **事前準備分**。旧 sync (`sync-with-notion.yml` / `tools/notion-sync` / `tools/r2-sync` / `@lacolaco` scope deps) は本 PR では **温存** し、新経路だけを並列に張る。

### 1. `ci.yml` に `auto-translate` job を新規追加

- blog-contents から push される sync PR (branch: `notion-sync-from-blog-contents`) のみで実行 (`if: head.ref == ...`)
- App token (`WORKER_APP`) で head SHA を checkout → `pnpm auto-translate` 実行 → 同 PR branch に `.en.md` を commit back
- 冪等性: `tools/auto-translate/translator.ts` の `auto_translated_from: <hash>` キャッシュで再 trigger 時は API 未呼出 + `git status` 空チェックで空 commit を push しない (無限ループ防止)
- `ok` gate の `needs` には **入れない** (人手 PR で skip され ok を fail させるため。content-review が後追い review を cover)
- `permissions: contents: read` のみ (App token 側で push を完結、GITHUB_TOKEN は使わない)

### 2. `trigger-sync-from-pr-comment.yml` の rewrite

- 旧: `.sync` PR コメント → consumer 自身の `sync-with-notion.yml` を `workflow_dispatch`
- 新: `.sync` PR コメント → blog-contents への `repository_dispatch` (event_type: `notion-sync-blog-lacolaco`)
- App token (`WORKER_APP`, `repositories: blog-contents`) で発行
- GITHUB_TOKEN ベースの `actions: write` 権限は不要になったため除去

## 後続 PR

1. (この PR) — auto-translate job + trigger rewrite
2. (今後) — 旧 sync (`sync-with-notion.yml` / `tools/notion-sync` / `tools/r2-sync` / 関連 deps) の削除 + `ci.yml` の `notion-sync-dry-run` job 削除
3. (今後) — `@lacolaco` scope registry config の cleanup (`.npmrc` / `setup-node` の `registry-url` / `scope` / `NODE_AUTH_TOKEN`)

## 挙動 (merge 後)

- consumer cron (`sync-with-notion.yml` の `0 */2 * * *`) は **温存**、引き続き sync 実行
- `.sync` コメントは blog-contents 経由で sync 実行 (consumer 側の `workflow_dispatch` は停止)
- blog-contents 由来 PR が CI で `auto-translate` job を走らせる (該当 PR が来た場合のみ)
- 人手 PR では `auto-translate` job は `if` で skip される

## Test plan

- [ ] CI: format / lint / build / test 通過
- [ ] (merge 後) blog-contents 側 `sync-blog-lacolaco.yml` を手動 dispatch → 生成された PR で `auto-translate` job が if 通過、`.en.md` が PR branch に commit back されること
- [ ] (merge 後) 該当 PR で `.sync` コメント → blog-contents 側で `notion-sync-blog-lacolaco` の repository_dispatch が受信されること