### PR TITLE
chore: drop @lacolaco scope registry config (GitHub Packages no longer needed)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,11 +106,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: 'pnpm'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@lacolaco'
       - run: pnpm install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm run build
 
   lint:
@@ -122,11 +118,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: 'pnpm'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@lacolaco'
       - run: pnpm install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm astro sync
       - run: pnpm lint
 
@@ -139,11 +131,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: 'pnpm'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@lacolaco'
       - run: pnpm install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm format:check
 
   test:
@@ -155,11 +143,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: 'pnpm'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@lacolaco'
       - run: pnpm install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm test:tools
 
   terraform:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -78,13 +78,9 @@ jobs:
         with:
           node-version-file: .node-version
           cache: 'pnpm'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@lacolaco'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -36,13 +36,9 @@ jobs:
         with:
           node-version-file: .node-version
           cache: 'pnpm'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@lacolaco'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         run: pnpm run build

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 shamefully-hoist=true
-@lacolaco:registry=https://npm.pkg.github.com


### PR DESCRIPTION
lacolaco/blog-contents PR #382 で merge した plan 009 (Phase 3A Step 4, Option B) の最終 cleanup PR。PR #1720 で @lacolaco/notion-sync 削除済 (本 PR は #1720 base)。

## 変更

- .npmrc: @lacolaco:registry 行削除
- .github/workflows/ci.yml: build/lint/format/test 4 job の setup-node から registry-url/scope/NODE_AUTH_TOKEN 除去
- .github/workflows/deploy-production.yml: 同上
- .github/workflows/deploy-preview.yml: 同上

## 前提条件

本 PR の base branch は chore/remove-notion-sync-tooling (PR #1720)。#1720 が main に merge された後、本 PR の base を main に変更してから merge する。逆順だと CI の pnpm install が 401 する。