### PR TITLE
feat(ci): add auto-translate workflow (post-merge ja → en, separate PR)

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -1,0 +1,86 @@
+name: auto-translate
+
+# main に新規 ja content がマージされた後、en 翻訳を生成して別 PR で提案する。
+# consumer 自身が PR 作成者となり、blog-contents 作成 PR には触らない。
+# ci.yml (validation) とは責務 (content 生成) が異なるため別 workflow file で分離。
+# 詳細設計: lacolaco/blog-contents docs/plans/009-extract-public-consumer-syncs.md (Phase 3A Step 4, Option N)
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/content/post/notion/**/*.md'
+      - '!src/content/post/notion/**/*.en.md' # en 自身の変更では起動しない (無限ループ防止)
+  workflow_dispatch:
+    # 任意 SHA に対する手動再実行 (en PR 作成途中の失敗復旧等)
+    inputs:
+      sha:
+        description: 'main の commit SHA (省略時は現在の main HEAD)'
+        required: false
+        type: string
+
+jobs:
+  translate:
+    runs-on: ubuntu-latest
+    # GITHUB_TOKEN は使わない (App token で checkout + push + PR 作成を完結)
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.WORKER_APP_ID }}
+          private-key: ${{ secrets.WORKER_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # workflow_dispatch で sha が指定されていればそれを使い、なければ trigger commit
+          ref: ${{ github.event.inputs.sha || github.sha }}
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 1
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .node-version
+          cache: 'pnpm'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@lacolaco'
+      - run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # tsx --env-file は対象ファイル不存在で起動失敗するため空 .env で workaround
+      - run: touch .env
+
+      - name: Auto-translate ja → en
+        run: pnpm run auto-translate
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+
+      - name: Create PR for translated files
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          COMMIT_SHA: ${{ github.event.inputs.sha || github.sha }}
+        run: |
+          if [[ -z "$(git status --porcelain src/content/post/notion)" ]]; then
+            echo "No translation changes"
+            exit 0
+          fi
+          BRANCH="auto-translate/${COMMIT_SHA}"
+          # 再実行時の冪等性ガード: branch 存在 → PR 状態 (open/closed/merged) の 2 段判定
+          if git ls-remote --exit-code --heads origin "refs/heads/$BRANCH" >/dev/null 2>&1; then
+            PR_COUNT=$(gh pr list --head "$BRANCH" --state all --json number --jq 'length')
+            if [ "$PR_COUNT" -gt 0 ]; then
+              echo "Branch $BRANCH と PR が既存 (open/closed/merged のいずれか)、skipping"
+              exit 0
+            fi
+            echo "Branch $BRANCH exists but no PR record, creating PR only"
+          else
+            git config user.name "lacolaco-actions-worker[bot]"
+            git config user.email "lacolaco-actions-worker[bot]@users.noreply.github.com"
+            git checkout -b "$BRANCH"
+            git add src/content/post/notion
+            git commit -m "chore: auto-translate ja → en for ${COMMIT_SHA}"
+            git push origin "$BRANCH"
+          fi
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore: auto-translate ja → en (${COMMIT_SHA:0:7})" \
+            --body "Automated translation for content merged in ${COMMIT_SHA}."

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -21,9 +21,12 @@ on:
 jobs:
   translate:
     runs-on: ubuntu-latest
-    # GITHUB_TOKEN は使わない (App token で checkout + push + PR 作成を完結)
+    # checkout / push / PR 作成は全て App token で完結。GITHUB_TOKEN は
+    # `NODE_AUTH_TOKEN` 経由で GitHub Packages から `@lacolaco/*` を install するためだけに使う。
+    # `permissions:` を明示すると他は全て none なので `packages: read` を明示付与
     permissions:
       contents: read
+      packages: read
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token


### PR DESCRIPTION
## Summary

[lacolaco/blog-contents PR #388 merged](https://github.com/lacolaco/blog-contents/pull/388) (plan 009 v4 / Option N) の **PR-A 段階**。

ja PR (blog-contents 由来) が main に merge された後、その main push を契機に `.en.md` を生成し **別 PR** で提案する独立 workflow を追加。**本 PR は追加のみ**、旧 sync-with-notion.yml や notion-sync 関連の削除は後続 PR で分割実施。

## 設計の根拠

| 制約 | 充足 |
|---|---|
| 他人 PR に commit 足さない | blog-contents 作成 PR には触らない (consumer 自身が en 専用 PR を別途作成) |
| main 直接 push しない | en も PR 経由 |
| auto-translate は CI じゃない | 独立 workflow file (`auto-translate.yml`)、`ci.yml` とは別 |
| 翻訳責務は consumer | workflow + execution + GEMINI_API_KEY 全て consumer 内 |
| 自動化 | push trigger による完全自動 |
| 責務単一 | translation only (r2-sync は blog-contents で完結済) |

## 冪等性 / 復旧

- `paths:` の `!` 否定パターンで `*.en.md` を trigger 除外 (en PR merge による無限ループ防止)
- branch 存在チェック → PR state all (open/closed/merged) チェックの 2 段ガードで同 SHA 再実行を skip
- `workflow_dispatch:` 入力 `sha` で任意 commit への手動 retry 可能

## 後続 PR

1. (この PR) `auto-translate.yml` 新設
2. (次) `sync-with-notion.yml` 削除 + `tools/notion-sync/` 削除 + 関連 deps + lockfile + `ci.yml` の `notion-sync-dry-run` job 削除
3. (次) `tools/r2-sync/` 削除 + 関連 deps + lockfile
4. (次) `trigger-sync-from-pr-comment.yml` を blog-contents への `repository_dispatch` に書換
5. (次) `.npmrc` + `ci.yml`/`deploy-*.yml` setup-node から `@lacolaco` scope 関連除去

## Test plan

- [ ] CI: format / build / test / lint 通過 (新 workflow file 追加のみ、既存挙動への影響なし)
- [ ] (merge 後) 次の ja merge 時 (PR-B 以降 merge 後) に `auto-translate.yml` workflow が起動、en 専用 PR が別途作成されることを確認