### PR TITLE
chore: redirect .sync comment trigger to blog-contents

### DIFF
--- a/.github/workflows/trigger-sync-from-pr-comment.yml
+++ b/.github/workflows/trigger-sync-from-pr-comment.yml
@@ -11,7 +11,6 @@ jobs:
       pull-requests: write
       issues: write
       checks: read
-      actions: write
     steps:
       - uses: github/command@3442f3fa1efe01bdb024b157083c337902d17372 # v2.0.3
         id: command
@@ -22,17 +21,26 @@ jobs:
           skip_ci: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowlist: lacolaco
-      - name: Trigger Workflow
+
+      # blog-contents への repository_dispatch には GITHUB_TOKEN だと権限不足のため App token を発行
+      - name: Generate App token (for blog-contents dispatch)
+        id: app-token
+        if: ${{ steps.command.outputs.continue == 'true' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.WORKER_APP_ID }}
+          private-key: ${{ secrets.WORKER_APP_PRIVATE_KEY }}
+          owner: lacolaco
+          repositories: blog-contents
+
+      - name: Dispatch sync workflow in blog-contents
         if: ${{ steps.command.outputs.continue == 'true' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
-            github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'sync-with-notion.yml',
-              ref: 'main',
-              inputs: {
-                forceUpdate: 'false'
-              }
-            })
+            await github.rest.repos.createDispatchEvent({
+              owner: 'lacolaco',
+              repo: 'blog-contents',
+              event_type: 'notion-sync-blog-lacolaco',
+            });


### PR DESCRIPTION
## Summary

[lacolaco/blog-contents PR #388](https://github.com/lacolaco/blog-contents/pull/388) の **PR-D 段階**。

PR #1731 で `sync-with-notion.yml` を削除済のため、`.sync` PR コメント trigger の dispatch 先を **blog-contents の `sync-blog-lacolaco.yml`** に切替える (`repository_dispatch`, event_type: `notion-sync-blog-lacolaco`)。

## 変更内容

- `.github/workflows/trigger-sync-from-pr-comment.yml`:
  - `actions: write` 権限を除去 (workflow_dispatch しないため不要)
  - App token (`WORKER_APP`, `repositories: blog-contents`) を発行
  - `github.rest.actions.createWorkflowDispatch` → `github.rest.repos.createDispatchEvent` に書換

## 前提条件

PR #1730 / #1731 / #1732 merged 済 (本 PR は独立に進められるが、PR #1731 merge 後の状態を前提)。

## Test plan

- [ ] CI: format / lint / build / test 通過
- [ ] (merge 後) consumer の PR で `.sync` コメント → blog-contents 側で `notion-sync-blog-lacolaco` の `repository_dispatch` が受信され、`sync-blog-lacolaco.yml` workflow が起動することを確認