### PR TITLE
chore: drop @lacolaco scope registry config (GitHub Packages no longer needed)

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -21,12 +21,10 @@ on:
 jobs:
   translate:
     runs-on: ubuntu-latest
-    # checkout / push / PR 作成は全て App token で完結。GITHUB_TOKEN は
-    # `NODE_AUTH_TOKEN` 経由で GitHub Packages から `@lacolaco/*` を install するためだけに使う。
-    # `permissions:` を明示すると他は全て none なので `packages: read` を明示付与
+    # checkout / push / PR 作成は全て App token で完結。GITHUB_TOKEN は不使用。
+    # `permissions:` を明示すると他は全て none になる
     permissions:
       contents: read
-      packages: read
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
@@ -45,11 +43,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: 'pnpm'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@lacolaco'
       - run: pnpm install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # tsx --env-file は対象ファイル不存在で起動失敗するため空 .env で workaround
       - run: touch .env
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,11 +106,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: 'pnpm'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@lacolaco'
       - run: pnpm install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm run build
 
   lint:
@@ -122,11 +118,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: 'pnpm'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@lacolaco'
       - run: pnpm install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm astro sync
       - run: pnpm lint
 
@@ -139,11 +131,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: 'pnpm'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@lacolaco'
       - run: pnpm install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm format:check
 
   test:
@@ -155,11 +143,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: 'pnpm'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@lacolaco'
       - run: pnpm install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm test:tools
 
   terraform:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -78,13 +78,9 @@ jobs:
         with:
           node-version-file: .node-version
           cache: 'pnpm'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@lacolaco'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -36,13 +36,9 @@ jobs:
         with:
           node-version-file: .node-version
           cache: 'pnpm'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@lacolaco'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         run: pnpm run build

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 shamefully-hoist=true
-@lacolaco:registry=https://npm.pkg.github.com


### PR DESCRIPTION
## Summary

[lacolaco/blog-contents PR #388](https://github.com/lacolaco/blog-contents/pull/388) の **PR-E (最終) 段階**。

PR #1731 で `@lacolaco/notion-sync` 削除済 + PR #1732 で `r2-sync` 関連削除済 + PR #1733 で trigger workflow 切替済。**consumer から `@lacolaco` scope を使う package が全廃された**ため、関連の registry / 認証設定を全 cleanup する。

これにより consumer は GitHub Packages 認証無しで `pnpm install` が完了でき、**CCW (Claude Code for Web) で blog.lacolaco.net を開いた時に install が 0 exit する状態になる** (plan 009 の最終目的達成)。

## 変更内容

- `.npmrc`: `@lacolaco:registry=https://npm.pkg.github.com` 行削除
- `.github/workflows/ci.yml`: build / lint / format / test 4 job の setup-node から `registry-url` / `scope` / `NODE_AUTH_TOKEN` 除去
- `.github/workflows/deploy-production.yml`: 同上
- `.github/workflows/deploy-preview.yml`: 同上
- `.github/workflows/auto-translate.yml`: 同上 + `permissions.packages: read` も除去 (GitHub Packages 不使用なので不要)

## 全 PR 進行状況

1. ✅ PR #1730 (auto-translate.yml 新設)
2. ✅ PR #1731 (notion-sync 削除)
3. ✅ PR #1732 (r2-sync 削除)
4. ✅ PR #1733 (.sync trigger を blog-contents へ redirect)
5. **PR #1734 (本 PR) — @lacolaco scope cleanup**

## Test plan

- [ ] CI: format / lint / build / test 通過 (registry config なしで `pnpm install --frozen-lockfile` が通る)
- [ ] (merge 後) CCW で `lacolaco/blog.lacolaco.net` を開いて `pnpm install` が 0 exit で完了 ← **plan 009 最終ゴール達成**
- [ ] (merge 後) production / preview deploy workflow が registry config なしで build 成功