### PR TITLE
ci(trigger): add main push trigger to refresh outdated sync PRs

### DIFF
--- a/.github/workflows/trigger-sync-from-pr-comment.yml
+++ b/.github/workflows/trigger-sync-from-pr-comment.yml
@@ -1,4 +1,4 @@
-name: trigger-sync-from-pr-comment
+name: trigger-blog-contents-sync
 
 on:
   issue_comment:

--- a/.github/workflows/trigger-sync-from-pr-comment.yml
+++ b/.github/workflows/trigger-sync-from-pr-comment.yml
@@ -7,11 +7,14 @@ on:
     branches: [main]
 
 # 連打 / 複数 main push を debounce、blog-contents 側 sync workflow の concurrency と協調
-# event_name を group に含めることで comment-trigger と push-trigger が互いを cancel しないようにする
-# (共有 group だと `.sync` コメント実行中に main push が来ると eyes reaction だけ残して
-#  dispatch が無音ドロップされる UX バグになる)
+# group キーは以下の 2 軸で scope:
+#   - event_name: comment-trigger と push-trigger が互いを cancel しないように分離
+#   - issue.number (comment 時) / 'push' (push 時): PR ごと / push 全体で独立した group に
+# こうすることで silent-drop UX バグを以下のいずれの軸でも回避できる:
+#   - `.sync` コメント実行中に main push が来ても comment-trigger は cancel されない
+#   - PR #1 の `.sync` 実行中に PR #2 の `.sync` が来ても PR #1 は cancel されない
 concurrency:
-  group: dispatch-blog-contents-sync-${{ github.event_name }}
+  group: dispatch-blog-contents-sync-${{ github.event_name }}-${{ github.event.issue.number || 'push' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/trigger-sync-from-pr-comment.yml
+++ b/.github/workflows/trigger-sync-from-pr-comment.yml
@@ -7,8 +7,11 @@ on:
     branches: [main]
 
 # 連打 / 複数 main push を debounce、blog-contents 側 sync workflow の concurrency と協調
+# event_name を group に含めることで comment-trigger と push-trigger が互いを cancel しないようにする
+# (共有 group だと `.sync` コメント実行中に main push が来ると eyes reaction だけ残して
+#  dispatch が無音ドロップされる UX バグになる)
 concurrency:
-  group: dispatch-blog-contents-sync
+  group: dispatch-blog-contents-sync-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/trigger-sync-from-pr-comment.yml
+++ b/.github/workflows/trigger-sync-from-pr-comment.yml
@@ -3,9 +3,17 @@ name: trigger-sync-from-pr-comment
 on:
   issue_comment:
     types: [created]
+  push:
+    branches: [main]
+
+# 連打 / 複数 main push を debounce、blog-contents 側 sync workflow の concurrency と協調
+concurrency:
+  group: dispatch-blog-contents-sync
+  cancel-in-progress: true
 
 jobs:
-  trigger-sync:
+  comment-trigger:
+    if: github.event_name == 'issue_comment'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -35,6 +43,34 @@ jobs:
 
       - name: Dispatch sync workflow in blog-contents
         if: ${{ steps.command.outputs.continue == 'true' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'lacolaco',
+              repo: 'blog-contents',
+              event_type: 'notion-sync-blog-lacolaco',
+            });
+
+  # main push 時にも dispatch を投げ、blog-contents 側の既存 sync PR を最新 main base で refresh する
+  # (renovate / 人手 PR / sync PR merge → main 更新 → 既存 sync PR が base behind になる問題への対処)
+  push-trigger:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Generate App token (for blog-contents dispatch)
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.WORKER_APP_ID }}
+          private-key: ${{ secrets.WORKER_APP_PRIVATE_KEY }}
+          owner: lacolaco
+          repositories: blog-contents
+
+      - name: Dispatch sync workflow in blog-contents
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- `.github/workflows/trigger-sync-from-pr-comment.yml` を拡張し、`push: branches: [main]` trigger を追加。consumer main 更新時に blog-contents の sync workflow を `repository_dispatch` で再走させ、既存 sync PR を最新 main base で refresh する
- 既存 `.sync` コメント経路は `comment-trigger` job として保持。新規 main push 経路は `push-trigger` job として分離 (`if: github.event_name == ...`)
- workflow-level `concurrency` を以下の 2 軸で scope:
  - `github.event_name`: comment-trigger と push-trigger が互いを cancel しないように分離
  - `github.event.issue.number || 'push'`: PR ごと / push 全体で独立した group に
  - これにより 3 種の silent-drop UX バグをすべて回避: (a) push 連打の debounce 維持 (b) PR #1 の `.sync` が PR #2 の `.sync` に cancel されない (c) `.sync` 実行中の main push で comment-trigger が cancel されない
- workflow `name:` を `trigger-blog-contents-sync` にリネーム (push + comment 両 trigger を包含する命名)。ファイル名は UI run history 連続性維持のため据え置き

## Background

plan 009 Phase 4 検証で発覚した Gap 1: consumer main が更新されると (renovate PR merge / 人手 PR merge / sync PR merge) blog-contents 側の既存 sync PR (`notion-sync-from-blog-contents` branch) が base behind になり outdated 状態で滞留する。

dispatch を投げると blog-contents 側 sync workflow が再走、peter-evans が latest main base で branch を force-push、PR が rebased state に戻る。

Pairs with blog-contents PR #391 (`sync-blog-lacolaco.yml` の同等 push trigger 追加)。両者で Gap 1 を closed。

## Commits

1. `ci(trigger)`: push trigger + job 分割 + workflow concurrency 初版
2. `fix(trigger)`: concurrency group を event_name で scope (code-review 1st 指摘対応)
3. `fix(trigger)`: concurrency group に issue.number も含める (code-review 2nd 指摘対応 — comment⇔comment 間 silent-drop 回避)
4. `ci(trigger)`: workflow name を `trigger-blog-contents-sync` にリネーム (code-review 3rd 指摘対応 — 名称と実態の一致)

## Test plan

- [ ] PR merge 後、main への push をトリガーに blog-contents 側 `notion-sync-blog-lacolaco` workflow が起動することを確認
- [ ] `.sync` コメント経路が引き続き機能することを確認 (回帰なし)
- [ ] 同一 PR 連続 push 時に concurrency group が古い run をキャンセルすることを確認
- [ ] `.sync` 実行中の main push が comment-trigger を cancel しないことを確認
- [ ] PR #1 の `.sync` 実行中に PR #2 の `.sync` が来ても PR #1 が cancel されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)