### PR TITLE
chore: remove unused rehype dependency (Phase 3A residue)

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "image-size": "^2.0.2",
     "jsdom": "^29.0.2",
     "prettier": "3.8.3",
-    "rehype": "^13.0.2",
     "rehype-github-alert": "^1.0.0",
     "rehype-github-emoji": "^1.0.0",
     "rehype-katex": "^7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,9 +132,6 @@ importers:
       prettier:
         specifier: 3.8.3
         version: 3.8.3
-      rehype:
-        specifier: ^13.0.2
-        version: 13.0.2
       rehype-github-alert:
         specifier: ^1.0.0
         version: 1.0.0


### PR DESCRIPTION
## Summary

- `rehype` (umbrella package v13.0.2) は PR #1280 で Cloudflare R2 image CDN integration の一環として追加されたが、r2-sync 削除 (#1732 / Phase 3A Step 4) 時に取りこぼされた orphan dep
- `git grep` で確認: `src/` および `tools/` に `import 'rehype'` (bare) は存在しない
- 実際に使われている sub-packages (`rehype-stringify`, `rehype-parse`, `rehype-github-alert`, `rehype-github-emoji`, `rehype-katex`, `rehype-mermaid`) は個別に declare されており、本変更の影響なし

## Inspection scope

`dependencies` / `devDependencies` の全エントリを `git grep` で source / config への import 経路を確認:

- **Phase 3A 関連で取りこぼされた orphan**: `rehype` のみ → 本 PR で削除
- **Phase 3A 範囲外の長期 orphan (今回は deferred)**:
  - `zod` (^3.22.4) — 2024 年から orphan、`astro/zod` 経由で `zod/v4` が利用されており top-level v3 は未参照
  - `@astrojs/prism` — astro 初期導入以来 src 内に `<Prism>` 利用なし (transitive 経由でも astro が引く)
  - `katex` (runtime) / `@types/katex` — `rehype-katex` の transitive と CSS CDN のみ。明示宣言は redundant だが Phase 3A 範囲外
- **Keep (verified used)**: その他 deps はすべて src / tools / astro.config.ts / tailwind.config.js / package.json scripts のいずれかで参照確認

## Test plan

- [x] `pnpm lint` pass
- [x] `pnpm build` 成功 (360+ pages 生成)
- [x] `git diff` で package.json -1 行 / pnpm-lock.yaml -3 行 のみ確認
- [ ] CI green
- 既存の test failure (`promoted-tags.spec.ts` の filesystem fixture, `og-image/image.test.tsx` の Resvg mock) は本変更と無関係 (rehype を import していない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)