### PR TITLE
ci: add content/** to path filter (non-destructive)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
           filters: |
             content:
               - 'src/content/**'
+              - 'content/**'
               - 'public/images/**'
               - 'manifest.json'
 
@@ -65,6 +66,7 @@ jobs:
             code:
               - '**'
               - '!src/content/**'
+              - '!content/**'
               - '!public/images/**'
               - '!manifest.json'
 
@@ -270,7 +272,7 @@ jobs:
           allowed_bots: 'lacolaco-actions-worker[bot]'
           prompt: |
             このPRに含まれるブログ記事コンテンツの変更をレビューしてください。
-            `gh pr diff ${{ github.event.pull_request.number }}` でdiffを取得し、コンテンツファイル（src/content/**, public/images/**）の変更のみを対象に文面チェックを行ってください。
+            `gh pr diff ${{ github.event.pull_request.number }}` でdiffを取得し、コンテンツファイル（src/content/**, content/**, public/images/**）の変更のみを対象に文面チェックを行ってください。
             コード変更が含まれる場合がありますが、レビュー対象外です。
 
             チェック項目:
@@ -360,7 +362,7 @@ jobs:
           prompt: |
             このPRのコード変更をレビューしてください。
             `gh pr diff ${{ github.event.pull_request.number }}` でdiffを取得し、コードファイルの変更のみを対象にレビューを行ってください。
-            コンテンツ変更（src/content/**, public/images/**, manifest.json）が含まれる場合がありますが、レビュー対象外です。
+            コンテンツ変更（src/content/**, content/**, public/images/**, manifest.json）が含まれる場合がありますが、レビュー対象外です。
 
             レビュー観点:
             - コード品質とベストプラクティス


### PR DESCRIPTION
## Summary

CI の path classifier (`.github/workflows/ci.yml`) に `content/**` を **非破壊的に追加**する。後続 PR #1757 (Notion 由来生成物を `src/content/post/notion/` から `content/notion/` へ移動) が CI の content/code 分類を正しく通せるようにするための先行 PR。

## 段取り (3 PRs)

1. **本 PR**: `src/content/**` を残したまま `content/**` を path filter に追加 (非破壊)
2. #1757 (content 移動): ci.yml に手を入れずに済むので claude-code-action の Workflow validation auth ガードに引っかからず code-review が pass できる
3. 後続 PR: `src/content/**` 行を ci.yml から外す (片付け)

## Why this PR exists

#1757 で ci.yml の path filter も同時に更新しようとしたところ、claude-code-action の auth ガード (`Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch.`) で code-review が 401 を返し、ok ゲート fail で merge できない状態に陥った。

filter の更新を本 PR に分離することで、#1757 では ci.yml に触らずに済み、auto review が正しく走る。

## What

- `content-paths` filter: `'content/**'` を追加 (`src/content/**` はそのまま残置)
- `code-paths` 除外: `'!content/**'` を追加 (同様に既存除外も残置)
- code-review / content-review プロンプトの説明にも `content/**` を併記

## Test Plan

- [x] diff は ci.yml の 6 行追加のみ (path filter 2 行 + 除外 2 行 + プロンプト 2 行)
- [x] 既存の `src/content/**` 配下に対する挙動は無変更 (filter は or 条件)
- [ ] CI: `ok` は **fail 予定** (workflow file 変更 PR の documented failure mode = ci.yml L32-34)。手動 merge 必要

## Out of Scope

- 旧 `src/content/**` 行の削除 → 3 番目の PR で対応 (#1757 merge 後)
- `src/content/post/notion/` から `content/notion/` への実際の移動 → #1757
