### PR TITLE
ci: drop legacy src/content/** from ci.yml path filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
         with:
           filters: |
             content:
-              - 'src/content/**'
               - 'content/**'
               - 'public/images/**'
               - 'manifest.json'
@@ -65,7 +64,6 @@ jobs:
           filters: |
             code:
               - '**'
-              - '!src/content/**'
               - '!content/**'
               - '!public/images/**'
               - '!manifest.json'
@@ -272,7 +270,7 @@ jobs:
           allowed_bots: 'lacolaco-actions-worker[bot]'
           prompt: |
             このPRに含まれるブログ記事コンテンツの変更をレビューしてください。
-            `gh pr diff ${{ github.event.pull_request.number }}` でdiffを取得し、コンテンツファイル（src/content/**, content/**, public/images/**）の変更のみを対象に文面チェックを行ってください。
+            `gh pr diff ${{ github.event.pull_request.number }}` でdiffを取得し、コンテンツファイル（content/**, public/images/**）の変更のみを対象に文面チェックを行ってください。
             コード変更が含まれる場合がありますが、レビュー対象外です。
 
             チェック項目:
@@ -362,7 +360,7 @@ jobs:
           prompt: |
             このPRのコード変更をレビューしてください。
             `gh pr diff ${{ github.event.pull_request.number }}` でdiffを取得し、コードファイルの変更のみを対象にレビューを行ってください。
-            コンテンツ変更（src/content/**, content/**, public/images/**, manifest.json）が含まれる場合がありますが、レビュー対象外です。
+            コンテンツ変更（content/**, public/images/**, manifest.json）が含まれる場合がありますが、レビュー対象外です。
 
             レビュー観点:
             - コード品質とベストプラクティス


### PR DESCRIPTION
## Summary

3 段ロケットの仕上げ: `.github/workflows/ci.yml` の path filter から旧 `src/content/**` 行を除去。

## 段取り (3 PRs)

1. **#1758** (merged): `src/content/**` を残したまま `content/**` を path filter に追加 (非破壊的追加)
2. **#1757** (merged): Notion 由来配置を `src/content/post/notion/` → `content/notion/` に移動 (content 移動)
3. **本 PR**: dead config になった `src/content/**` 行を ci.yml から除去 (cleanup)

## What

- `content-paths` filter から `'src/content/**'` 行を削除
- `code-paths` 除外から `'!src/content/**'` 行を削除
- code-review / content-review プロンプトの説明から `src/content/**` を削除

## Why this is safe

- `src/content/post/notion/` ツリーは #1757 で完全に削除済み
- 残る `src/content/{tags,categories,kitchen-sink.md}` は build 未参照の orphan (片付けは CLAUDE.md §2 で別承認必要)
- 既存の `content/**` filter で新パスは引き続き正しく分類される

## CI fail について

本 PR は workflow file (.github/workflows/ci.yml) を変更するため、`anthropics/claude-code-action` の Workflow validation auth ガード (`The workflow file must exist and have identical content to the version on the repository's default branch.` で 401) で code-review / content-review jobs の auto review が実行できず、`ok` ゲートは fail します。

これは ci.yml L32-34 に明記された設計通り:
```
# claude-code-action失敗時（ワークフロー変更PR等）:
#   - Gateステップ(if: always())がapproved=falseでfail
#   - ok fail → 人間がレビューして手動マージ
```

= **手動 merge が正規ルート** (#1758 と同じパターン)。
