### PR TITLE
feat(tools): resolve Notion page mentions to internal blog URLs

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -9,6 +9,7 @@ import rehypeMermaid from 'rehype-mermaid';
 import remarkBreaks from 'remark-breaks';
 import remarkMath from 'remark-math';
 import remarkEmbed from './tools/remark-embed';
+import remarkResolveNotionMentions from './tools/remark-resolve-notion-mentions';
 import rehypeImageCdn from './tools/rehype-image-cdn';
 import rehypeExtractVideoHtml from './tools/rehype-extract-video-html';
 
@@ -44,7 +45,11 @@ export default defineConfig({
 
   markdown: {
     gfm: true,
-    remarkPlugins: [remarkBreaks, remarkMath, remarkEmbed],
+    // remarkResolveNotionMentions は notion-sync が出力する `[plain_text](https://www.notion.so/...)`
+    // 形式の page mention link を、frontmatter `notion_url` で照合して blog 内相対 URL に書き換える。
+    // 未解決の notion.so link は build error にする（publication invariant: 未公開 page への mention を
+    // 残さない）。URL 書き換えのみで構造は触らないため、remark チェーンの末尾に置いて差し支えない
+    remarkPlugins: [remarkBreaks, remarkMath, remarkEmbed, remarkResolveNotionMentions],
     // rehypeExtractVideoHtml は notion-sync が出力する <video> を含む raw ノードのみを
     // element 化する最小スコープのプラグイン。後段の rehype-image-cdn が <video> を
     // visit できるようにするため先頭に置く。<video> を含まない raw HTML には触れない

--- a/tools/remark-resolve-notion-mentions/index.spec.ts
+++ b/tools/remark-resolve-notion-mentions/index.spec.ts
@@ -1,0 +1,245 @@
+import { strict as assert } from 'node:assert';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { after, before, describe, test } from 'node:test';
+import { remark } from 'remark';
+import remarkParse from 'remark-parse';
+import remarkStringify from 'remark-stringify';
+import remarkResolveNotionMentions from './index.ts';
+
+const fixturesDir = join(import.meta.dirname, 'fixtures');
+const notionPostsDir = join(fixturesDir, 'notion-posts');
+const userPostsDir = join(fixturesDir, 'user-posts');
+
+const PAST = '2026-01-01T00:00:00.000Z';
+const FUTURE = '2099-01-01T00:00:00.000Z';
+
+function writePost(dir: string, filename: string, frontmatter: Record<string, string | boolean>): void {
+  const yaml = Object.entries(frontmatter)
+    .map(([k, v]) => (typeof v === 'boolean' ? `${k}: ${v}` : `${k}: '${v}'`))
+    .join('\n');
+  writeFileSync(join(dir, filename), `---\n${yaml}\n---\n\nbody\n`);
+}
+
+before(() => {
+  mkdirSync(notionPostsDir, { recursive: true });
+  mkdirSync(join(userPostsDir, 'subdir'), { recursive: true });
+
+  // notion-posts (sync 出力): published, ja
+  writePost(notionPostsDir, 'alpha.md', {
+    title: 'Alpha',
+    slug: 'alpha',
+    published: true,
+    created_time: PAST,
+    last_edited_time: PAST,
+    notion_url: 'https://www.notion.so/Alpha-ja-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  });
+
+  // notion-posts (sync 出力): published, en (filename .en.md で判定)
+  writePost(notionPostsDir, 'alpha.en.md', {
+    title: 'Alpha (en)',
+    slug: 'alpha',
+    // frontmatter.locale はあえて書かない (collection 側が source-of-truth)
+    published: true,
+    created_time: PAST,
+    last_edited_time: PAST,
+    notion_url: 'https://www.notion.so/Alpha-en-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  });
+
+  // notion-posts (sync 出力): published, dense-hex 形式の notion_url
+  writePost(notionPostsDir, 'beta.md', {
+    title: 'Beta',
+    slug: 'beta',
+    published: true,
+    created_time: PAST,
+    last_edited_time: PAST,
+    notion_url: 'https://www.notion.so/Beta-cccccccccccccccccccccccccccccccc',
+  });
+
+  // notion-posts (sync 出力): dashed UUID 形式の notion_url (Share menu copy link)
+  writePost(notionPostsDir, 'gamma.md', {
+    title: 'Gamma',
+    slug: 'gamma',
+    published: true,
+    created_time: PAST,
+    last_edited_time: PAST,
+    notion_url: 'https://www.notion.so/Gamma-dddddddd-dddd-dddd-dddd-dddddddddddd',
+  });
+
+  // notion-posts: draft (published: false) — map に入らず throw 経路へ
+  writePost(notionPostsDir, 'draft.md', {
+    title: 'Draft',
+    slug: 'draft',
+    published: false,
+    created_time: PAST,
+    last_edited_time: PAST,
+    notion_url: 'https://www.notion.so/Draft-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+  });
+
+  // notion-posts: 未来日記 (created_time が未来) — map に入らず throw 経路へ
+  writePost(notionPostsDir, 'future.md', {
+    title: 'Future',
+    slug: 'future',
+    published: true,
+    created_time: FUTURE,
+    last_edited_time: FUTURE,
+    notion_url: 'https://www.notion.so/Future-ffffffffffffffffffffffffffffffff',
+  });
+
+  // user-posts (直接執筆): published, ja
+  writePost(userPostsDir, 'manual.md', {
+    title: 'Manual',
+    slug: 'manual',
+    published: true,
+    created_time: PAST,
+    last_edited_time: PAST,
+    notion_url: 'https://www.notion.so/Manual-11111111111111111111111111111111',
+  });
+
+  // user-posts/subdir: 直接執筆ツリーは再帰的に走査される (content.config.ts の glob と一致)
+  writePost(join(userPostsDir, 'subdir'), 'nested.md', {
+    title: 'Nested',
+    slug: 'nested',
+    published: true,
+    created_time: PAST,
+    last_edited_time: PAST,
+    notion_url: 'https://www.notion.so/Nested-22222222222222222222222222222222',
+  });
+});
+
+after(() => {
+  rmSync(fixturesDir, { recursive: true, force: true });
+});
+
+async function processMd(markdown: string): Promise<string> {
+  const file = await remark()
+    .use(remarkParse)
+    .use(remarkResolveNotionMentions, { postDirs: [notionPostsDir, userPostsDir] })
+    .use(remarkStringify)
+    .process(markdown);
+  return String(file);
+}
+
+describe('remarkResolveNotionMentions', () => {
+  describe('page mention link の書き換え', () => {
+    test('ja 記事の dense-hex notion_url が /posts/<slug> に書き換わる', async () => {
+      const out = await processMd(
+        'See [Alpha](https://www.notion.so/Alpha-ja-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) for more.',
+      );
+      assert.ok(out.includes('[Alpha](/posts/alpha)'), out);
+      assert.ok(!out.includes('notion.so'), out);
+    });
+
+    test('en 記事 (filename .en.md) は /posts/<slug>.en に書き換わる', async () => {
+      const out = await processMd(
+        'See [Alpha](https://www.notion.so/Alpha-en-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) for more.',
+      );
+      assert.ok(out.includes('[Alpha](/posts/alpha.en)'), out);
+    });
+
+    test('複数の notion.so URL が同じ markdown 内で全て書き換わる', async () => {
+      const out = await processMd(
+        'See [Alpha](https://www.notion.so/Alpha-ja-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) and [Beta](https://www.notion.so/Beta-cccccccccccccccccccccccccccccccc).',
+      );
+      assert.ok(out.includes('[Alpha](/posts/alpha)'), out);
+      assert.ok(out.includes('[Beta](/posts/beta)'), out);
+    });
+
+    test('直接執筆ツリー (content/posts/) の記事も解決対象に含まれる', async () => {
+      const out = await processMd('See [Manual](https://www.notion.so/Manual-11111111111111111111111111111111).');
+      assert.ok(out.includes('[Manual](/posts/manual)'), out);
+    });
+
+    test('直接執筆ツリーのサブディレクトリ内の記事も再帰的に走査される', async () => {
+      const out = await processMd('See [Nested](https://www.notion.so/Nested-22222222222222222222222222222222).');
+      assert.ok(out.includes('[Nested](/posts/nested)'), out);
+    });
+  });
+
+  describe('Notion page id の正規化 (dense / dashed UUID / query / fragment)', () => {
+    test('dashed UUID 形式の page mention link も同じ post に解決する', async () => {
+      const out = await processMd('See [Gamma](https://www.notion.so/Gamma-dddddddd-dddd-dddd-dddd-dddddddddddd).');
+      assert.ok(out.includes('[Gamma](/posts/gamma)'), out);
+    });
+
+    test('frontmatter dense, body dashed の混在でも解決する', async () => {
+      // alpha.md の notion_url は dense-hex で書かれているが、本文側が dashed UUID で書かれていても照合する
+      const out = await processMd('See [Alpha](https://www.notion.so/Alpha-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa).');
+      assert.ok(out.includes('[Alpha](/posts/alpha)'), out);
+    });
+
+    test('frontmatter dashed, body dense の混在でも解決する', async () => {
+      // gamma.md の notion_url は dashed UUID で書かれているが、本文側が dense-hex でも照合する
+      const out = await processMd('See [Gamma](https://www.notion.so/Gamma-dddddddddddddddddddddddddddddddd).');
+      assert.ok(out.includes('[Gamma](/posts/gamma)'), out);
+    });
+
+    test('query string 付きの page mention URL も書き換わる (Notion gallery view 由来)', async () => {
+      const out = await processMd(
+        'See [Alpha](https://www.notion.so/Alpha-ja-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa?v=abc123).',
+      );
+      assert.ok(out.includes('[Alpha](/posts/alpha)'), out);
+    });
+
+    test('fragment (#section) は preserve される (heading anchor 対応)', async () => {
+      const out = await processMd(
+        'See [Alpha](https://www.notion.so/Alpha-ja-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#section).',
+      );
+      assert.ok(out.includes('[Alpha](/posts/alpha#section)'), out);
+    });
+  });
+
+  describe('publication invariant (未公開・未来日記・他配信の検出)', () => {
+    test('frontmatter に存在しない notion.so page URL → throw', async () => {
+      await assert.rejects(
+        () => processMd('See [Unknown](https://www.notion.so/Unknown-99999999999999999999999999999999).'),
+        /Unresolved Notion page URL/,
+      );
+    });
+
+    test('draft (published: false) page への mention → throw', async () => {
+      await assert.rejects(
+        () => processMd('See [Draft](https://www.notion.so/Draft-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee).'),
+        /Unresolved Notion page URL/,
+      );
+    });
+
+    test('未来日記 (created_time が未来) への mention → throw', async () => {
+      await assert.rejects(
+        () => processMd('See [Future](https://www.notion.so/Future-ffffffffffffffffffffffffffffffff).'),
+        /Unresolved Notion page URL/,
+      );
+    });
+
+    test('エラーメッセージに該当 URL が含まれる（操作のヒントになる）', async () => {
+      await assert.rejects(
+        () => processMd('See [Unknown](https://www.notion.so/Unknown-99999999999999999999999999999999).'),
+        /Unknown-99999999999999999999999999999999/,
+      );
+    });
+  });
+
+  describe('対象外のリンクは触らない', () => {
+    test('外部 URL（notion.so 以外）は変更されない', async () => {
+      const out = await processMd('See [Example](https://example.com/page).');
+      assert.ok(out.includes('[Example](https://example.com/page)'), out);
+    });
+
+    test('blog 内相対 URL は変更されない', async () => {
+      const out = await processMd('See [Existing](/posts/something).');
+      assert.ok(out.includes('[Existing](/posts/something)'), out);
+    });
+
+    test('リンクを含まない markdown は no-op', async () => {
+      const out = await processMd('Just plain text.\n');
+      assert.equal(out.trim(), 'Just plain text.');
+    });
+
+    test('notion.so のマーケティング/ヘルプ URL は page mention ではないので触らない', async () => {
+      // https://www.notion.so/ja-jp/web-clipper のように page id 形式を持たない URL は
+      // Notion 製品サイトへの外部 link であって page reference ではない
+      const out = await processMd('See [Web Clipper](https://www.notion.so/ja-jp/web-clipper) for more.');
+      assert.ok(out.includes('[Web Clipper](https://www.notion.so/ja-jp/web-clipper)'), out);
+    });
+  });
+});

--- a/tools/remark-resolve-notion-mentions/index.ts
+++ b/tools/remark-resolve-notion-mentions/index.ts
@@ -1,0 +1,110 @@
+import { isPast } from 'date-fns';
+import type { Link, Root } from 'mdast';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import type { Plugin } from 'unified';
+import { visit } from 'unist-util-visit';
+import { parse as parseYaml } from 'yaml';
+
+interface Options {
+  // 既定では content/notion/posts (sync 出力) と content/posts (直接執筆) の両方を走査する。
+  // src/content.config.ts が両ツリーを 1 collection に束ねており、URL 名前空間は共通。
+  postDirs?: string[];
+}
+
+interface Frontmatter {
+  slug?: string;
+  notion_url?: string;
+  published?: boolean;
+  created_time?: string;
+}
+
+const NOTION_URL_PREFIX = 'https://www.notion.so/';
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---/;
+// Notion の page id は 32 char hex (dense, page.url 形式) または 8-4-4-4-12 dashed UUID
+// (Share menu の copy link 形式) で URL に現れる。両方を受け入れて 32-hex lowercase に
+// 正規化したものを map のキーとする。
+const NOTION_PAGE_ID_RE = /([0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[/?#]|$)/i;
+
+function normalizeNotionPageId(url: string): string | null {
+  const m = NOTION_PAGE_ID_RE.exec(url);
+  if (!m) return null;
+  return m[1].replace(/-/g, '').toLowerCase();
+}
+
+function* walkMarkdown(dir: string): Generator<string> {
+  if (!existsSync(dir)) return;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkMarkdown(fullPath);
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith('.md')) yield fullPath;
+  }
+}
+
+function buildNotionUrlMap(postDirs: readonly string[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const dir of postDirs) {
+    for (const filePath of walkMarkdown(dir)) {
+      const content = readFileSync(filePath, 'utf8');
+      const match = FRONTMATTER_RE.exec(content);
+      if (!match) continue;
+      const fm = parseYaml(match[1]) as Frontmatter;
+      if (typeof fm.notion_url !== 'string' || typeof fm.slug !== 'string') continue;
+      // queryAvailablePosts と同じ predicate (src/libs/query/posts.ts):
+      // 公開済み (published === true) かつ created_time が過去のもののみ URL が生成される。
+      // draft / 未来日記への mention は内部 URL を持たないので map に入れない → throw 経路
+      // に流して publication invariant を作動させる。
+      if (fm.published !== true) continue;
+      if (typeof fm.created_time !== 'string' || !isPast(new Date(fm.created_time))) continue;
+      const id = normalizeNotionPageId(fm.notion_url);
+      if (!id) continue;
+      // locale の唯一の出所は collection / filename (src/content.config.ts の不変)。
+      // frontmatter.locale は schema 上 optional でかつ collection 由来値で上書きされるため
+      // 信用しない。.en.md なら en、それ以外は ja。
+      const isEn = basename(filePath).endsWith('.en.md');
+      map.set(id, `/posts/${fm.slug}${isEn ? '.en' : ''}`);
+    }
+  }
+  return map;
+}
+
+// blog.lacolaco.net の Notion 記事フロントマターには `notion_url`（Notion `page.url`）が
+// 出力される。Notion 内の page mention は `[plain_text](https://www.notion.so/...)` 形式の
+// markdown link として渡ってくるので、ビルド時に frontmatter から照合表を作って blog 内
+// 相対 URL に書き換える。照合表に無い notion.so page URL は build を fail させる
+// （publication invariant: 未公開・他配信・draft page への mention は本サイト上に出さない）。
+const remarkResolveNotionMentions: Plugin<[Options?], Root> = (options = {}) => {
+  const postDirs = options.postDirs ?? [
+    join(process.cwd(), 'content', 'notion', 'posts'),
+    join(process.cwd(), 'content', 'posts'),
+  ];
+  let cachedMap: Map<string, string> | null = null;
+
+  return (tree: Root) => {
+    cachedMap ??= buildNotionUrlMap(postDirs);
+    visit(tree, 'link', (node: Link) => {
+      if (!node.url.startsWith(NOTION_URL_PREFIX)) return;
+      const id = normalizeNotionPageId(node.url);
+      // page id (32-hex or dashed UUID) を持たない notion.so URL はマーケティング・ヘルプ
+      // 等の外部 link とみなして触らない。書き換え対象は page mention 由来の link のみ
+      if (!id) return;
+      const resolved = cachedMap.get(id);
+      if (!resolved) {
+        throw new Error(
+          `[remark-resolve-notion-mentions] Unresolved Notion page URL: ${node.url}\n` +
+            `This URL was not found among published blog posts in [${postDirs.join(', ')}]. ` +
+            `Ensure the referenced page is published (published: true), dated in the past, and distributed to blog.lacolaco.net.`,
+        );
+      }
+      // fragment (#section) は blog 記事内 heading の anchor に対応する可能性があるので preserve。
+      // query (?v=...) は Notion 固有の view 識別子 (gallery view 等) なので捨てる。
+      const hashIdx = node.url.indexOf('#');
+      node.url = hashIdx >= 0 ? resolved + node.url.slice(hashIdx) : resolved;
+    });
+  };
+};
+
+export default remarkResolveNotionMentions;


### PR DESCRIPTION
## Summary

Add a remark plugin `tools/remark-resolve-notion-mentions/` that rewrites Notion page mention links to internal blog URLs at build time.

## Why

Upstream [`@lacolaco/notion-sync` PR #399](https://github.com/lacolaco/blog-contents/pull/399) now emits page mentions as `[plain_text](https://www.notion.so/<page-id>)` markdown links instead of dropping the URL. This consumer-side plugin maps those notion.so URLs to `/posts/<slug>(.en)?` using each post's `notion_url` frontmatter — entirely offline, no extra Notion API queries, no library API expansion.

If a page-id-formed `notion.so` URL is encountered that doesn't resolve to a published blog post, the build fails (publication invariant: never ship an unresolved internal mention).

## Design

- **Scan scope**: both `content/notion/posts/` (sync output) and `content/posts/` (direct authoring), matching `src/content.config.ts`'s collection definition. Recursive walker so nested posts are picked up.
- **Locale source-of-truth**: derived from filename (`.en.md` → en), matching `content.config.ts`'s `transform((data) => ({ ...data, locale }))` invariant. `frontmatter.locale` is ignored to avoid drift.
- **Publication predicate**: `published === true && isPast(created_time)` — same as `queryAvailablePosts` in `src/libs/query/posts.ts`. Drafts and future-dated posts are excluded from the map → throw path.
- **Page id normalization**: Notion emits page IDs in two forms — 32-char dense hex (from `page.url`) and 8-4-4-4-12 dashed UUID (from Share menu copy link). Both forms are normalized to lowercase 32-hex and used as the map key, so any combination of frontmatter / body URL forms resolves correctly.
- **Fragment preservation**: `#section` is preserved (heading anchors transfer); `?query` is dropped (Notion view IDs don't translate).
- **Non-page notion.so URLs** (e.g. marketing pages like `https://www.notion.so/ja-jp/web-clipper`) are not page mentions and are left untouched.

## Plugin registration

`astro.config.ts` adds the plugin at the end of `markdown.remarkPlugins`. URL rewriting only — no structural changes, so order doesn't matter relative to other remark plugins.

## Test plan

- [x] 18 tests in 4 groups (`pnpm test:tools`): page rewrite (5), id normalization (5), publication invariant (4), pass-through (4). All pass.
- [x] code-critic review: `Approved` after addressing 5 blockers from round 001 (locale source-of-truth, publication predicate, content/posts/ tree, dashed UUID + URL normalization, test coverage).
- [x] Full `pnpm build` succeeds. Existing non-page `notion.so` link in `inside-laco-feed.md` (`https://www.notion.so/ja-jp/web-clipper`) survives unchanged in build output.
- [x] `pnpm lint`, `pnpm format` clean.
- [ ] CI green
- [ ] End-to-end (deferred): after upstream library publish + sync rerun, verify that real page mention URLs in production content resolve correctly.

## Sequencing

This PR is independent of the upstream library PR — it works correctly even before the library publishes the new emission (no notion.so page mention links exist in current content yet, so the plugin is a no-op until then). It does NOT cause regressions because non-page notion.so URLs (the only ones currently in content) are explicitly pass-through.