### PR TITLE
fix(ci): add postinstall astro sync to unblock auto-translate pre-commit lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,6 @@ jobs:
           node-version-file: .node-version
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
-      - run: pnpm astro sync
       - run: pnpm lint
 
   format:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:libs": "vitest run",
     "test": "pnpm test:tools && pnpm test:libs",
     "lint": "eslint .",
-    "prepare": "husky"
+    "prepare": "husky",
+    "postinstall": "astro sync"
   },
   "packageManager": "pnpm@10.34.2",
   "dependencies": {


### PR DESCRIPTION
## Summary

- `package.json` の `scripts` に `postinstall: astro sync` を追加し、すべての `pnpm install` 直後に `.astro/types.d.ts` を生成
- `.github/workflows/ci.yml` line 122 の `pnpm astro sync` を削除 — `postinstall` との二重実行を解消

## なぜ必要か

`auto-translate.yml` workflow run #27528333903 (PR #1811 のマージ後 main 同期) が pre-commit hook 内で失敗していた。

原因:
- `.husky/pre-commit` が `prettier --check && pnpm lint` を実行
- ESLint config (`eslint.config.js`) は `recommendedTypeChecked` を `src/**/*.ts` に適用
- `src/libs/**/*.ts` が `import type { CollectionEntry } from 'astro:content'` を参照
- `auto-translate.yml` は `astro sync` を実行していないため `.astro/types.d.ts` が無く、`astro:content` の型が `any` に解決
- 結果として `no-unsafe-member-access` 等が **248 件** ヒットして lint が落ち、`git commit` が失敗 → 翻訳 PR が一切作成されない状態

これまで auto-translate 成功 run (#1810, #1805) はすべて「翻訳変更なしで早期 exit」していたため気付かなかった。実際に翻訳 commit を試みた #1811 が初めて踏んだ。

## 修正方針

すべての `pnpm install` 後に `astro sync` を保証する根本対応 (postinstall) を選択。`ci.yml` 側は二重実行を解消するため削除 (1 PR で完結する同一関心事として束ねる)。

過去 PR #1448 が同等修正を提案 (2026-04-07) しているが約 2 ヶ月放置のため、本 PR で対応する。マージ後 #1448 はクローズ可能。

## 検証

ローカルで `rm -rf .astro && pnpm install --frozen-lockfile && pnpm lint` を実行:
- postinstall 適用前: 248 errors
- postinstall 適用後: 0 errors

## 注意: workflow 変更を含むため code-review は OIDC 制約で skip 相当

`ci.yml` を変更しているため、claude-code-action の OIDC app token exchange が「PR の workflow file は main と一致しないと token を発行しない」セキュリティ制約により 401 を返し、code-review job が `structured_output is empty` で fail する。これは `ci.yml` line 32-34 に明記された設計どおり (「ワークフロー変更時は人間がレビューして手動マージ」)。PR #1814 (claude-code-action v1.0.148 bump) と同じ運用。

## Follow-up

マージ後、`auto-translate.yml` を workflow_dispatch (sha=7f5f61b1) で再実行し #1811 分の en 翻訳 PR を生成する必要あり。

## Test plan

- [ ] CI (lint / format / test / build) all pass
- [ ] code-review fail は workflow 変更 PR の意図的挙動として許容
- [ ] マージ後 auto-translate を sha=7f5f61b1 で workflow_dispatch して翻訳 PR が作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)