### PR TITLE
fix(ci): bump anthropics/claude-code-action to v1.0.148 to fix structured_output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,7 @@ jobs:
 
       - name: Review content with Claude
         id: review
-        uses: anthropics/claude-code-action@11ba60486e4aec9ddfeafcf4bb3f00b028ac2c16 # v1.0.142
+        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1.0.148
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: 'lacolaco-actions-worker[bot]'
@@ -353,7 +353,7 @@ jobs:
 
       - name: Review code with Claude
         id: review
-        uses: anthropics/claude-code-action@11ba60486e4aec9ddfeafcf4bb3f00b028ac2c16 # v1.0.142
+        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1.0.148
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: 'lacolaco-actions-worker[bot]'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@11ba60486e4aec9ddfeafcf4bb3f00b028ac2c16 # v1.0.142
+        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1.0.148
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
## Summary

`anthropics/claude-code-action` を v1.0.142 → **v1.0.148** に bump。3 箇所すべて (ci.yml の renovate-review と code-review、claude.yml) を一括更新。

## なぜ必要か

v1.0.142 の Bun `--tsconfig-override` 渡し方バグにより、code-review job 内で:

```
Internal error: directory mismatch for directory ".../tsconfig.json", fd 4
→ structured_output is empty → Gate fail
```

upstream PR [anthropics/claude-code-action#1315](https://github.com/anthropics/claude-code-action/pull/1315) ("Drop --tsconfig-override from Bun invocations to avoid runtime crash") が **v1.0.143** で fix 済み。本 PR では最新の v1.0.148 へ pin。

関連 upstream issue:
- [#1234](https://github.com/anthropics/claude-code-action/issues/1234) (parent)
- [#1295](https://github.com/anthropics/claude-code-action/issues/1295) (duplicate)

直近の通常 PR の code-review が全て壊れていた (Notion PR は code-review が classify で skipped されるため気付かれなかった)。

## Test plan

- [ ] CI 全 pass
- [ ] code-review が v1.0.148 で structured_output を返して動くこと (ただし本 PR 自身は workflow 変更 PR のため OIDC app token exchange 制約で code-review fail = `ok` fail。これは設計どおり、ci.yml line 32-34 に「ワークフロー変更時は人間が手動マージ」と明記)
- [ ] マージ後の通常 PR で code-review が正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)