### PR TITLE
ci: re-dispatch auto-translate workflow on main push

### DIFF
--- a/.github/workflows/trigger-sync-from-pr-comment.yml
+++ b/.github/workflows/trigger-sync-from-pr-comment.yml
@@ -78,6 +78,7 @@ jobs:
           repositories: blog-contents
 
       - name: Dispatch sync workflow in blog-contents
+        continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/trigger-sync-from-pr-comment.yml
+++ b/.github/workflows/trigger-sync-from-pr-comment.yml
@@ -59,10 +59,10 @@ jobs:
               event_type: 'notion-sync-blog-lacolaco',
             });
 
-  # main push 契機:
-  #   - blog-contents 側 sync PR への dispatch
-  #   - 自リポ auto-translate PR を main に追従させる (auto-merge は base behind を解決しない)
-  refresh-stale-prs:
+  # main push 契機で下流の sync 系ワークフローを再送する:
+  #   - blog-contents 側 sync workflow (Notion → md)
+  #   - 自リポ auto-translate workflow (ja → en)
+  dispatch-syncs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
@@ -97,25 +97,8 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
 
-      - name: Update stale auto-translate PRs
+      - name: Re-dispatch auto-translate workflow
         env:
           GH_TOKEN: ${{ steps.self-app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
-        run: |
-          PRS=$(gh pr list --state open --limit 100 --json number,headRefName \
-            --jq '.[] | select(.headRefName | startswith("auto-translate/")) | .number')
-          if [[ -z "$PRS" ]]; then
-            echo "No open auto-translate PRs"
-            exit 0
-          fi
-          for PR in $PRS; do
-            echo "::group::PR #$PR"
-            if output=$(gh pr update-branch "$PR" 2>&1); then
-              echo "$output"
-            elif echo "$output" | grep -qi "already up.to.date"; then
-              echo "PR #$PR is already up to date"
-            else
-              echo "::warning::Failed to update PR #$PR: $output"
-            fi
-            echo "::endgroup::"
-          done
+        run: gh workflow run auto-translate.yml --ref main

--- a/.github/workflows/trigger-sync-from-pr-comment.yml
+++ b/.github/workflows/trigger-sync-from-pr-comment.yml
@@ -59,9 +59,10 @@ jobs:
               event_type: 'notion-sync-blog-lacolaco',
             });
 
-  # main push 時にも dispatch を投げ、blog-contents 側の既存 sync PR を最新 main base で refresh する
-  # (renovate / 人手 PR / sync PR merge → main 更新 → 既存 sync PR が base behind になる問題への対処)
-  push-trigger:
+  # main push 時に:
+  #   - blog-contents 側の既存 sync PR を最新 main base で refresh する dispatch を投げる
+  #   - 自リポの open な auto-translate PR を main に追従させる (auto-merge は base behind を自動解決しない)
+  propagate-main-update:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
@@ -87,16 +88,8 @@ jobs:
               event_type: 'notion-sync-blog-lacolaco',
             });
 
-  # main push 時に自リポの open な auto-translate PR を main に追従させる
-  # (auto-merge は base behind を自動解決しない)
-  refresh-auto-translate-prs:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
       - name: Generate App token (for self repo)
-        id: app-token
+        id: self-app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.WORKER_APP_ID }}
@@ -106,7 +99,7 @@ jobs:
 
       - name: Update stale auto-translate PRs
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.self-app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
         run: |
           PRS=$(gh pr list --state open --limit 100 --json number,headRefName \

--- a/.github/workflows/trigger-sync-from-pr-comment.yml
+++ b/.github/workflows/trigger-sync-from-pr-comment.yml
@@ -59,10 +59,8 @@ jobs:
               event_type: 'notion-sync-blog-lacolaco',
             });
 
-  # main push 契機で下流の sync 系ワークフローを再送する:
-  #   - blog-contents 側 sync workflow (Notion → md)
-  #   - 自リポ auto-translate workflow (ja → en)
-  dispatch-syncs:
+  # main push 時に blog-contents 側の sync workflow を再送する
+  dispatch-blog-contents-sync:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
@@ -78,7 +76,6 @@ jobs:
           repositories: blog-contents
 
       - name: Dispatch sync workflow in blog-contents
-        continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.app-token.outputs.token }}
@@ -89,8 +86,15 @@ jobs:
               event_type: 'notion-sync-blog-lacolaco',
             });
 
+  # main push 時に自リポの auto-translate workflow を再送する
+  dispatch-auto-translate:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
       - name: Generate App token (for self repo)
-        id: self-app-token
+        id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.WORKER_APP_ID }}
@@ -100,6 +104,6 @@ jobs:
 
       - name: Re-dispatch auto-translate workflow
         env:
-          GH_TOKEN: ${{ steps.self-app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
         run: gh workflow run auto-translate.yml --ref main

--- a/.github/workflows/trigger-sync-from-pr-comment.yml
+++ b/.github/workflows/trigger-sync-from-pr-comment.yml
@@ -87,9 +87,8 @@ jobs:
               event_type: 'notion-sync-blog-lacolaco',
             });
 
-  # main push 時に自リポの open な auto-translate PR を main に追従させる。
-  # GitHub auto-merge は base behind を自動解決しないため、push-trigger と同じ責務 (main 更新で
-  # behind になる PR を refresh する) の自リポ側実装として並置する。
+  # main push 時に自リポの open な auto-translate PR を main に追従させる
+  # (auto-merge は base behind を自動解決しない)
   refresh-auto-translate-prs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
@@ -110,26 +109,20 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-          # --limit を明示しないと default 30 件で頭打ちになり、auto-translate PR が滞留したときに古いものから漏れる。
           PRS=$(gh pr list --state open --limit 100 --json number,headRefName \
             --jq '.[] | select(.headRefName | startswith("auto-translate/")) | .number')
           if [[ -z "$PRS" ]]; then
             echo "No open auto-translate PRs"
             exit 0
           fi
-          # gh pr update-branch の出力をケース分け:
-          #   - 成功 (新 merge commit 追加): 普通の info
-          #   - 既に最新: info (PR が既に追従済みなだけで異常ではない)
-          #   - それ以外 (conflict / auth / network 等): warning で個別 PR を記録するが job は止めない
-          #     (batch の他 PR を止めず、次の push で再試行できるように warning に留める)
           for PR in $PRS; do
             echo "::group::PR #$PR"
             if output=$(gh pr update-branch "$PR" 2>&1); then
               echo "$output"
-            elif echo "$output" | grep -qi "already up.to.date"; then  # `.` は space と `-` の両方にマッチ
+            elif echo "$output" | grep -qi "already up.to.date"; then
               echo "PR #$PR is already up to date"
             else
-              echo "::warning::Failed to update PR #$PR (possible conflict): $output"
+              echo "::warning::Failed to update PR #$PR: $output"
             fi
             echo "::endgroup::"
           done

--- a/.github/workflows/trigger-sync-from-pr-comment.yml
+++ b/.github/workflows/trigger-sync-from-pr-comment.yml
@@ -59,7 +59,8 @@ jobs:
               event_type: 'notion-sync-blog-lacolaco',
             });
 
-  # main push 時に blog-contents 側の sync workflow を再送する
+  # blog-contents 側 sync PR を最新 main base で refresh するための dispatch
+  # (main 更新で sync PR が base behind になる問題への対処)
   dispatch-blog-contents-sync:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
@@ -86,7 +87,8 @@ jobs:
               event_type: 'notion-sync-blog-lacolaco',
             });
 
-  # main push 時に自リポの auto-translate workflow を再送する
+  # auto-translate.yml は content/notion/posts/ 変更を含む push しか自動起動しない。
+  # コード push でも main は進むので、追従していない翻訳 PR を捕まえるため明示的に再送する。
   dispatch-auto-translate:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest

--- a/.github/workflows/trigger-sync-from-pr-comment.yml
+++ b/.github/workflows/trigger-sync-from-pr-comment.yml
@@ -124,7 +124,7 @@ jobs:
             echo "::group::PR #$PR"
             if output=$(gh pr update-branch "$PR" 2>&1); then
               echo "$output"
-            elif echo "$output" | grep -qi "already up.to.date\|already up to date"; then
+            elif echo "$output" | grep -qi "already up.to.date"; then  # `.` は space と `-` の両方にマッチ
               echo "PR #$PR is already up to date"
             else
               echo "::warning::Failed to update PR #$PR (possible conflict): $output"

--- a/.github/workflows/trigger-sync-from-pr-comment.yml
+++ b/.github/workflows/trigger-sync-from-pr-comment.yml
@@ -86,3 +86,36 @@ jobs:
               repo: 'blog-contents',
               event_type: 'notion-sync-blog-lacolaco',
             });
+
+  # main push 時に自リポの open な auto-translate PR を main に追従させる。
+  # GitHub auto-merge は base behind を自動解決しないため、push-trigger と同じ責務 (main 更新で
+  # behind になる PR を refresh する) の自リポ側実装として並置する。
+  refresh-auto-translate-prs:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Generate App token (for self repo)
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.WORKER_APP_ID }}
+          private-key: ${{ secrets.WORKER_APP_PRIVATE_KEY }}
+
+      - name: Update stale auto-translate PRs
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          # --limit を明示しないと default 30 件で頭打ちになり、auto-translate PR が滞留したときに古いものから漏れる。
+          PRS=$(gh pr list --state open --limit 100 --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("auto-translate/")) | .number')
+          if [[ -z "$PRS" ]]; then
+            echo "No open auto-translate PRs"
+            exit 0
+          fi
+          for PR in $PRS; do
+            echo "Updating PR #$PR"
+            gh pr update-branch "$PR" || echo "::warning::Failed to update PR #$PR (conflict or already up-to-date)"
+          done

--- a/.github/workflows/trigger-sync-from-pr-comment.yml
+++ b/.github/workflows/trigger-sync-from-pr-comment.yml
@@ -102,6 +102,8 @@ jobs:
         with:
           app-id: ${{ secrets.WORKER_APP_ID }}
           private-key: ${{ secrets.WORKER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Update stale auto-translate PRs
         env:

--- a/.github/workflows/trigger-sync-from-pr-comment.yml
+++ b/.github/workflows/trigger-sync-from-pr-comment.yml
@@ -115,7 +115,19 @@ jobs:
             echo "No open auto-translate PRs"
             exit 0
           fi
+          # gh pr update-branch の出力をケース分け:
+          #   - 成功 (新 merge commit 追加): 普通の info
+          #   - 既に最新: info (PR が既に追従済みなだけで異常ではない)
+          #   - それ以外 (conflict / auth / network 等): warning で個別 PR を記録するが job は止めない
+          #     (batch の他 PR を止めず、次の push で再試行できるように warning に留める)
           for PR in $PRS; do
-            echo "Updating PR #$PR"
-            gh pr update-branch "$PR" || echo "::warning::Failed to update PR #$PR (conflict or already up-to-date)"
+            echo "::group::PR #$PR"
+            if output=$(gh pr update-branch "$PR" 2>&1); then
+              echo "$output"
+            elif echo "$output" | grep -qi "already up.to.date\|already up to date"; then
+              echo "PR #$PR is already up to date"
+            else
+              echo "::warning::Failed to update PR #$PR (possible conflict): $output"
+            fi
+            echo "::endgroup::"
           done

--- a/.github/workflows/trigger-sync-from-pr-comment.yml
+++ b/.github/workflows/trigger-sync-from-pr-comment.yml
@@ -59,10 +59,10 @@ jobs:
               event_type: 'notion-sync-blog-lacolaco',
             });
 
-  # main push 時に:
-  #   - blog-contents 側の既存 sync PR を最新 main base で refresh する dispatch を投げる
-  #   - 自リポの open な auto-translate PR を main に追従させる (auto-merge は base behind を自動解決しない)
-  propagate-main-update:
+  # main push 契機:
+  #   - blog-contents 側 sync PR への dispatch
+  #   - 自リポ auto-translate PR を main に追従させる (auto-merge は base behind を解決しない)
+  refresh-stale-prs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

GitHub auto-merge は base branch が behind になっても自動で解決しないため、auto-translate PR が main 更新で BEHIND 化したまま stuck することがあった (PR #1838 が 4 日 stuck)。

既存の push-trigger ジョブ (blog-contents 側 sync workflow への `repository_dispatch`) と同じ構造で、main push 時に自リポの auto-translate workflow を `workflow_dispatch` で再送するステップを追加。ジョブを統合し `dispatch-syncs` に改名。

再送された auto-translate は最新 main HEAD を起点に新ブランチ + 新 PR を生成する (= 新 PR の base は behind でないので CI 通って auto-merge される)。旧 stuck PR のクローズは別途。

## Test plan

- [ ] (マージ後) 次の main 更新時に `dispatch-syncs.Re-dispatch auto-translate workflow` ステップが実行され、auto-translate ワークフローが起動する
- [ ] (マージ後) 新規 PR が最新 main を base にして生成され、CI 通れば auto-merge される