### PR TITLE
fix(ci): use GITHUB_TOKEN with actions:write for auto-translate dispatch

### DIFF
--- a/.github/workflows/trigger-sync-from-pr-comment.yml
+++ b/.github/workflows/trigger-sync-from-pr-comment.yml
@@ -93,19 +93,10 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      actions: write
     steps:
-      - name: Generate App token (for self repo)
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.WORKER_APP_ID }}
-          private-key: ${{ secrets.WORKER_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-
       - name: Re-dispatch auto-translate workflow
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: gh workflow run auto-translate.yml --ref main


### PR DESCRIPTION
## Summary

PR #1847 マージ後の本番実行で `dispatch-auto-translate` ジョブが 403 (`Resource not accessible by integration`) で失敗。原因は WORKER_APP の installation permissions に `actions: write` が含まれていないため、App token では `workflow_dispatch` API が叩けない。

GitHub Actions 公式仕様により `workflow_dispatch` (および `repository_dispatch`) は GITHUB_TOKEN で起動しても triggered workflow が動作する recursion 防止の例外。App token を諦め、ジョブ permissions に `actions: write` を付与した GITHUB_TOKEN で叩く実装に切り替える。

## Test plan

- [ ] (マージ後) 次の main 更新で `dispatch-auto-translate` ジョブが pass し、auto-translate workflow が `workflow_dispatch` で起動する