### PR TITLE
fix(ci): reuse single auto-translate PR via fixed branch + force-push

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -78,6 +78,16 @@ jobs:
             git commit -m "chore: auto-translate ja → en for ${COMMIT_SHA}"
             git push origin "$BRANCH"
           fi
-          gh pr create --base main --head "$BRANCH" \
+          NEW_PR_URL=$(gh pr create --base main --head "$BRANCH" \
             --title "chore: auto-translate ja → en (${COMMIT_SHA:0:7})" \
-            --body "Automated translation for content merged in ${COMMIT_SHA}."
+            --body "Automated translation for content merged in ${COMMIT_SHA}.")
+          NEW_PR_NUMBER="${NEW_PR_URL##*/}"
+
+          # 旧 SHA で作られた open な auto-translate PR は新 PR に置き換わるため close する
+          # (放置すると base behind PR が滞留し、stuck と分裂を生む)
+          gh pr list --state open --limit 100 --json number,headRefName \
+            --jq ".[] | select(.headRefName | startswith(\"auto-translate/\")) | select(.number != $NEW_PR_NUMBER) | .number" \
+            | while read -r OLD_PR; do
+              [[ -z "$OLD_PR" ]] && continue
+              gh pr close "$OLD_PR" --delete-branch --comment "Superseded by #$NEW_PR_NUMBER"
+            done

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -71,6 +71,9 @@ jobs:
           BRANCH="auto-translate"
           git config user.name "lacolaco-actions-worker[bot]"
           git config user.email "lacolaco-actions-worker[bot]@users.noreply.github.com"
+          # fetch-depth:1 の checkout では remote-tracking ref がないため、
+          # --force-with-lease を機能させるには明示的に fetch する必要がある
+          git fetch origin "$BRANCH" || true
           git checkout -B "$BRANCH"
           git add content/notion/posts
           git commit -m "chore: auto-translate ja → en for ${COMMIT_SHA}"

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -18,7 +18,7 @@ on:
         required: false
         type: string
 
-# 並走時に互いの新 PR を「旧」と誤判定して close し合う race を防ぐため直列化する
+# 同 PR への並行 force-push を防ぐため直列化する
 concurrency:
   group: auto-translate
   cancel-in-progress: false
@@ -57,7 +57,7 @@ jobs:
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
-      - name: Create PR for translated files
+      - name: Create or update auto-translate PR
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           COMMIT_SHA: ${{ github.event.inputs.sha || github.sha }}
@@ -66,36 +66,19 @@ jobs:
             echo "No translation changes"
             exit 0
           fi
-          BRANCH="auto-translate/${COMMIT_SHA}"
-          # 再実行時の冪等性ガード: branch 存在 → PR 状態 (open/closed/merged) の 2 段判定
-          if git ls-remote --exit-code --heads origin "refs/heads/$BRANCH" >/dev/null 2>&1; then
-            PR_COUNT=$(gh pr list --head "$BRANCH" --state all --json number --jq 'length')
-            if [ "$PR_COUNT" -gt 0 ]; then
-              echo "Branch $BRANCH と PR が既存 (open/closed/merged のいずれか)、skipping"
-              exit 0
-            fi
-            echo "Branch $BRANCH exists but no PR record, creating PR only"
-          else
-            git config user.name "lacolaco-actions-worker[bot]"
-            git config user.email "lacolaco-actions-worker[bot]@users.noreply.github.com"
-            git checkout -b "$BRANCH"
-            git add content/notion/posts
-            git commit -m "chore: auto-translate ja → en for ${COMMIT_SHA}"
-            git push origin "$BRANCH"
-          fi
-          NEW_PR_URL=$(gh pr create --base main --head "$BRANCH" \
-            --title "chore: auto-translate ja → en (${COMMIT_SHA:0:7})" \
-            --body "Automated translation for content merged in ${COMMIT_SHA}.")
-          NEW_PR_NUMBER="${NEW_PR_URL##*/}"
-          [[ "$NEW_PR_NUMBER" =~ ^[0-9]+$ ]] || { echo "::error::Failed to extract PR number from: $NEW_PR_URL"; exit 1; }
+          # 固定ブランチに翻訳結果を毎回 force-push し、PR は 1 本を再利用する
+          # (SHA ごとに別ブランチ + 別 PR を作る設計は base behind や PR 分裂の原因になる)
+          BRANCH="auto-translate"
+          git config user.name "lacolaco-actions-worker[bot]"
+          git config user.email "lacolaco-actions-worker[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add content/notion/posts
+          git commit -m "chore: auto-translate ja → en for ${COMMIT_SHA}"
+          git push --force-with-lease origin "$BRANCH"
 
-          # 旧 SHA で作られた open な auto-translate PR は新 PR に置き換わるため close する
-          # (放置すると base behind PR が滞留し、stuck と分裂を生む)
-          # --limit は正常運用なら 1〜数件しか open しないが、過去の異常時の取り残しまで拾えるよう余裕を持たせる
-          gh pr list --state open --limit 200 --json number,headRefName \
-            --jq ".[] | select(.headRefName | startswith(\"auto-translate/\")) | select(.number != $NEW_PR_NUMBER) | .number" \
-            | while read -r OLD_PR; do
-              [[ -z "$OLD_PR" ]] && continue
-              gh pr close "$OLD_PR" --delete-branch --comment "Superseded by #$NEW_PR_NUMBER" \
-                || echo "::warning::Failed to close PR #$OLD_PR"
-            done
+          # 初回のみ作成、以降は force-push が synchronize イベントで CI を再起動するだけで PR 再利用
+          if [[ "$(gh pr list --state open --head "$BRANCH" --json number --jq 'length')" -eq 0 ]]; then
+            gh pr create --base main --head "$BRANCH" \
+              --title "chore: auto-translate ja → en" \
+              --body "Latest automated translation (force-pushed on every main update)."
+          fi

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -91,9 +91,11 @@ jobs:
 
           # 旧 SHA で作られた open な auto-translate PR は新 PR に置き換わるため close する
           # (放置すると base behind PR が滞留し、stuck と分裂を生む)
-          gh pr list --state open --limit 100 --json number,headRefName \
+          # --limit は正常運用なら 1〜数件しか open しないが、過去の異常時の取り残しまで拾えるよう余裕を持たせる
+          gh pr list --state open --limit 200 --json number,headRefName \
             --jq ".[] | select(.headRefName | startswith(\"auto-translate/\")) | select(.number != $NEW_PR_NUMBER) | .number" \
             | while read -r OLD_PR; do
               [[ -z "$OLD_PR" ]] && continue
-              gh pr close "$OLD_PR" --delete-branch --comment "Superseded by #$NEW_PR_NUMBER"
+              gh pr close "$OLD_PR" --delete-branch --comment "Superseded by #$NEW_PR_NUMBER" \
+                || echo "::warning::Failed to close PR #$OLD_PR"
             done

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: string
 
+# 並走時に互いの新 PR を「旧」と誤判定して close し合う race を防ぐため直列化する
+concurrency:
+  group: auto-translate
+  cancel-in-progress: false
+
 jobs:
   translate:
     runs-on: ubuntu-latest
@@ -82,6 +87,7 @@ jobs:
             --title "chore: auto-translate ja → en (${COMMIT_SHA:0:7})" \
             --body "Automated translation for content merged in ${COMMIT_SHA}.")
           NEW_PR_NUMBER="${NEW_PR_URL##*/}"
+          [[ "$NEW_PR_NUMBER" =~ ^[0-9]+$ ]] || { echo "::error::Failed to extract PR number from: $NEW_PR_URL"; exit 1; }
 
           # 旧 SHA で作られた open な auto-translate PR は新 PR に置き換わるため close する
           # (放置すると base behind PR が滞留し、stuck と分裂を生む)


### PR DESCRIPTION
## Summary

auto-translate.yml が main push の度に SHA ベースの新ブランチ + 新 PR を作る設計を廃止し、固定ブランチ `auto-translate` に毎回 force-push する設計に変更。PR は 1 本だけ常存し、再利用される。

旧設計の問題:
- SHA ごとに別 PR → main 進行で base behind になり stuck
- 別 PR が並存する分裂 (#1838 と #1849 の事例)

新設計:
- ブランチ名固定 (`auto-translate`)
- 翻訳生成後 `git push --force-with-lease` で上書き
- 初回のみ `gh pr create`、以降は force-push の synchronize イベントで PR が更新される
- `concurrency: group: auto-translate, cancel-in-progress: false` で並走を防止

## Test plan

- [ ] (マージ後) 翻訳変更を含む main push で auto-translate.yml が起動し、固定ブランチ `auto-translate` に force-push されること
- [ ] (マージ後) 既存 PR がない場合は新規 PR が作成され、ある場合は同じ PR が更新されること