### PR TITLE
fix(deploy): expose IMAGE_CDN_BASE_URL to Cloud Run runtime env

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -99,8 +99,11 @@ jobs:
           no-traffic: 'true'
           revision-tag: 'pr-${{ github.event.number }}'
           # GCP_PROJECT_IDはCloud Runメタデータサーバーから取得するため不要
+          # IMAGE_CDN_BASE_URL は SSR 実行時 (rehype-image-cdn) が読むため runtime env にも渡す。
+          # Build 時のみ渡すと Astro server build の <img src> が生パスのまま Cloud Run で返され CDN 未変換になる
           env-vars: |
             FIRESTORE_DATABASE=likes-preview
+            IMAGE_CDN_BASE_URL=${{ vars.IMAGE_CDN_BASE_URL }}
 
       - name: Comment preview URL on PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -86,5 +86,8 @@ jobs:
           deploy-image: 'asia-northeast1-docker.pkg.dev/blog-lacolaco-net/cloud-run-source-deploy/web:${{ github.sha }}'
           revision-traffic: 'LATEST=100'
           # GCP_PROJECT_IDはCloud Runメタデータサーバーから取得するため不要
+          # IMAGE_CDN_BASE_URL は SSR 実行時 (rehype-image-cdn) が読むため runtime env にも渡す。
+          # Build 時のみ渡すと Astro server build の <img src> が生パスのまま Cloud Run で返され CDN 未変換になる
           env-vars: |
             FIRESTORE_DATABASE=likes-production
+            IMAGE_CDN_BASE_URL=${{ vars.IMAGE_CDN_BASE_URL }}


### PR DESCRIPTION
## 症状

production の全記事で本文中の画像が壊れている。
例: [ふりかえりの本質・事象評価の4象限・KPTの矯正効果](https://blog.lacolaco.net/posts/344dd234430d) は本文 6 枚の画像が全て 404。

網羅チェックした結果、`public/images/` 配下 **93 slug / 241 ファイル 全てが `blog.lacolaco.net/images/...` から 404**。R2 直接 URL (`https://images.blog.lacolaco.net/{slug}/{file}`) では **241/241 が 200 OK** で、R2 バケット側の画像は完全に揃っている。

## 根本原因

Astro は `output: 'static'` + `mode: 'server'` (SSR) で、記事ページ (`/posts/[slug]`) は Cloud Run で SSR。

`tools/rehype-image-cdn/index.ts` は `process.env.IMAGE_CDN_BASE_URL` を読んで `<img src>` を CDN URL に書き換えるが、**この処理は build 時ではなく SSR 実行時に走る**。

`.github/workflows/deploy-production.yml` の Build step には `IMAGE_CDN_BASE_URL` を env で渡していたが、これは静的 build 時のみ有効で SSR には届かない。Cloud Run の `env-vars` は `FIRESTORE_DATABASE=likes-production` のみで、`IMAGE_CDN_BASE_URL` が含まれていなかったため、SSR 時に `baseUrl` が undefined になり rehype-image-cdn が変換を skip。結果、`<img src="/images/...">` の生パスが HTML に残り、Cloud Run にはその静的アセットが無い (`.dockerignore` で除外) ため 404 になる。

## 修正

`deploy-production.yml` と `deploy-preview.yml` の Cloud Run `env-vars` に `IMAGE_CDN_BASE_URL=\${{ vars.IMAGE_CDN_BASE_URL }}` を追加 (計 2 ファイル 6 行差分)。next deploy で全 93 記事 241 画像が一斉復旧見込み。

## 検証

- ローカルの `public/images/` に含まれる全 241 ファイルを `https://images.blog.lacolaco.net/{path}` に HEAD → **241/241 が 200 OK** で R2 側の完備を確認済み。
- `https://blog.lacolaco.net/images/{path}` は 241/241 が 404 (Server: cloudflare、Cloud Run 由来)。
- 最新 production deploy (run 28485632833) のログで `IMAGE_CDN_BASE_URL: https://images.blog.lacolaco.net` が Build step には渡っていることを確認 (SSR runtime には届いていないことも同時に確認)。

## Post-deploy 検証項目

- [ ] main merge → deploy-production 成功
- [ ] `https://blog.lacolaco.net/posts/344dd234430d` を開いて `<img src>` が `https://images.blog.lacolaco.net/...` に変換されているか
- [ ] 他 slug (例 `/posts/inside-laco-feed`) でも同様に変換されているか

🤖 Generated with [Claude Code](https://claude.com/claude-code)