### PR TITLE
fix(deploy): pass IMAGE_CDN_BASE_URL to install step for astro sync

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -81,6 +81,10 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        # postinstall の `astro sync` が content-layer cache を生成する時点で IMAGE_CDN_BASE_URL を評価するため
+        # install step にも env を渡す。build step にだけ渡すと cache 済みの生パスがそのまま prerender に流れる
+        env:
+          IMAGE_CDN_BASE_URL: ${{ vars.IMAGE_CDN_BASE_URL }}
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -39,6 +39,10 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        # postinstall の `astro sync` が content-layer cache を生成する時点で IMAGE_CDN_BASE_URL を評価するため
+        # install step にも env を渡す。build step にだけ渡すと cache 済みの生パスがそのまま prerender に流れる
+        env:
+          IMAGE_CDN_BASE_URL: ${{ vars.IMAGE_CDN_BASE_URL }}
 
       - name: Build
         run: pnpm run build


### PR DESCRIPTION
> 前 PR #1868 は誤診断 (Cloud Run runtime env 追加) だったため close。本 PR が正しい修正。

## 症状

production の全記事で本文中の画像が壊れている (`Server: cloudflare` から 404)。
網羅チェックで **93 slug / 241 ファイル 全てが `blog.lacolaco.net/images/...` から 404**。ただし R2 直接 URL (`https://images.blog.lacolaco.net/{slug}/{file}`) では **241/241 が 200 OK** で、R2 バケット側は完備。

つまり **URL 書き換えのみが漏れて** いる。prerendered static HTML の `<img src>` が生パス (`/images/...`) のまま Cloud Run にデプロイされている。

## 根本原因

`package.json` に `"postinstall": "astro sync"` があり、CI ではこの順序で走る:

1. **Install ステップ** (`pnpm install --frozen-lockfile`) → postinstall で `astro sync` → content-layer が md をロードし、rehype パイプラインを通した中間出力を `.astro/data-store.json` に cache
2. **Build ステップ** (`pnpm run build`) → content-layer cache を再利用して prerender

`tools/rehype-image-cdn/index.ts` は plugin factory 実行時に `process.env.IMAGE_CDN_BASE_URL` を評価してキャプチャする (`const baseUrl = (options.baseUrl || process.env.IMAGE_CDN_BASE_URL)?...`)。もし install 時に env が無ければ `baseUrl` が undefined になり、`if (!baseUrl) return;` で src 書き換えを skip。この状態が cache に焼き込まれ、build ステップで env が渡っても cache 再利用のため変換されない。

現在の deploy-production.yml / deploy-preview.yml は **Build ステップにだけ** env を渡していたため、この罠にはまっていた。

## 修正

Install ステップにも同じ env を渡す。 (2 workflow 計 8 行差分、コメント付き)

## ローカル完全 clean 再現検証

`node_modules/`, `.astro/`, `dist/` を全削除した状態から:

| Install 時 env | Build 時 env | 結果 |
|---|---|---|
| 無 | 有 | `src=\"/images/...\"` (生パス) ❌ 現状の CI と同じ |
| 有 | 有 | `src=\"https://images.blog.lacolaco.net/...\"` ✅ 修正後の期待動作 |

## 前 PR #1868 の反省 (misdiagnosis)

- 最初の仮説「rehype-image-cdn は SSR 実行時に走る、Cloud Run runtime env が必要」は誤り。
- 実際には rehype は build 時 (astro sync 内) に走り、prerendered HTML に URL が焼き込まれる。
- preview URL で画像が変換されない事実に気づいて再調査、docker image を pull して prerendered HTML を直接確認して確定。
- Cloud Run runtime env の追加 (前 PR) は無効かつ misleading なので採用せず close。

## Post-deploy 検証項目

- [ ] main merge → deploy-production 成功
- [ ] `https://blog.lacolaco.net/posts/344dd234430d` を開いて `<img src>` が `https://images.blog.lacolaco.net/...` に変換されているか
- [ ] 他 slug (例 `/posts/inside-laco-feed`) でも同様に変換されているか

🤖 Generated with [Claude Code](https://claude.com/claude-code)