### PR TITLE
fix(ci): clean up conflicting refs before auto-translate push

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -71,6 +71,12 @@ jobs:
           BRANCH="auto-translate"
           git config user.name "lacolaco-actions-worker[bot]"
           git config user.email "lacolaco-actions-worker[bot]@users.noreply.github.com"
+          # 旧デザイン (SHA ベースブランチ) の残骸が auto-translate/* に残っていると
+          # git ref の directory/file 衝突で push が失敗する。push 前にクリーンアップする
+          for ref in $(git ls-remote --heads origin "refs/heads/${BRANCH}/*" | awk '{print $2}'); do
+            echo "Deleting conflicting ref: $ref"
+            git push origin --delete "${ref#refs/heads/}" || true
+          done
           # fetch-depth:1 の checkout では remote-tracking ref がないため、
           # --force-with-lease を機能させるには明示的に fetch する必要がある
           git fetch origin "$BRANCH" || true


### PR DESCRIPTION
## Summary
- auto-translate ワークフローの push ステップで、旧デザイン (SHA ベースブランチ `auto-translate/<sha>`) の残骸が git ref の directory/file 衝突を引き起こし push が失敗する問題を修正
- push 前に `auto-translate/*` パターンのリモート ref を自動削除するステップを追加

## 背景
- PR #1850 で SHA ベースブランチから固定ブランチ `auto-translate` へ移行したが、旧ブランチ `auto-translate/318e3f28...` がリモートに残っていた
- 2026-07-12 以降、auto-translate ワークフローが全件失敗し、EN 版記事のフロントマター (channels 等) が同期されなくなっていた
- 既存の衝突ブランチは本 PR の作業で削除済み

## Test plan
- [ ] CI が通ること
- [ ] マージ後に auto-translate ワークフローを `workflow_dispatch` で手動実行し、push が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)