### PR TITLE
docs: clarify code-review gate scope and auto-workflow verification rules

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -74,6 +74,7 @@ jobs:
           # 旧デザイン (SHA ベースブランチ auto-translate/<sha>) の残骸が残っていると
           # git ref の directory/file 衝突で push が失敗する。push 前にクリーンアップする
           # SHA 形式 (7-40桁の hex) のみ削除し、意図しないブランチの誤削除を防ぐ
+          # 削除失敗は || true で許容する (best-effort: 本来の翻訳処理を止めない)
           for ref in $(git ls-remote --heads origin "refs/heads/${BRANCH}/*" | awk '{print $2}'); do
             branch_name="${ref#refs/heads/}"
             suffix="${branch_name#${BRANCH}/}"

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -77,7 +77,7 @@ jobs:
           for ref in $(git ls-remote --heads origin "refs/heads/${BRANCH}/*" | awk '{print $2}'); do
             branch_name="${ref#refs/heads/}"
             suffix="${branch_name#${BRANCH}/}"
-            if echo "$suffix" | grep -qE '^[0-9a-f]{7,40}$'; then
+            if [[ "$suffix" =~ ^[0-9a-f]{7,40}$ ]]; then
               echo "Deleting stale SHA-based ref: $ref"
               git push origin --delete "$branch_name" || true
             else

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -71,11 +71,18 @@ jobs:
           BRANCH="auto-translate"
           git config user.name "lacolaco-actions-worker[bot]"
           git config user.email "lacolaco-actions-worker[bot]@users.noreply.github.com"
-          # 旧デザイン (SHA ベースブランチ) の残骸が auto-translate/* に残っていると
+          # 旧デザイン (SHA ベースブランチ auto-translate/<sha>) の残骸が残っていると
           # git ref の directory/file 衝突で push が失敗する。push 前にクリーンアップする
+          # SHA 形式 (7-40桁の hex) のみ削除し、意図しないブランチの誤削除を防ぐ
           for ref in $(git ls-remote --heads origin "refs/heads/${BRANCH}/*" | awk '{print $2}'); do
-            echo "Deleting conflicting ref: $ref"
-            git push origin --delete "${ref#refs/heads/}" || true
+            branch_name="${ref#refs/heads/}"
+            suffix="${branch_name#${BRANCH}/}"
+            if echo "$suffix" | grep -qE '^[0-9a-f]{7,40}$'; then
+              echo "Deleting stale SHA-based ref: $ref"
+              git push origin --delete "$branch_name" || true
+            else
+              echo "Skipping non-SHA ref: $ref"
+            fi
           done
           # fetch-depth:1 の checkout では remote-tracking ref がないため、
           # --force-with-lease を機能させるには明示的に fetch する必要がある

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ These 3 rules are NON-NEGOTIABLE. Violating any = STOP and reassess.
 
 **TRIGGER**: After lint/format/build pass, BEFORE `git commit`
 
-For significant changes (new features, refactoring, multi-file):
+For significant changes (new features, refactoring, multi-file, CI/CD workflow, deployment configuration):
 1. Run ビルトイン `/code-review` (既定 `medium`)
 2. Fix all findings
 3. Run `/code-review` AGAIN to verify
@@ -55,6 +55,7 @@ merge を除いた以下は 1 単位として実行 (途中で止めるな):
 - `.en.md` (auto-translate 生成) の問題 → `tools/auto-translate/` パイプライン (prompt / proofreader / validator) で対応
 - **auto-translate のスコープは `content/notion/posts/` のみ**。直接執筆 (`content/posts/`) は対象外で、英訳が必要なら手書きで `<slug>.en.md` を置く (auto-translate は手動 en を `protect-manual` ロジックで上書きしない)
 - **sync-with-notion への force-push は sync workflow の正常動作**。「自分の修正が消された」と誤認して再 push せず、`origin/sync-with-notion` を fetch して**新しい真実として再観測**してから動く
+- **自動ワークフロー (auto-translate, sync-with-notion, deploy 等) を実行・待機した後は、次の行動の前に実際の状態を確認せよ**。ワークフロー成功 ≠ 手動対応が必要。content-only PR は ci.yml の auto-merge ゲート (content-review pass + code-review skip) で自動マージされる。確認コマンド: `gh pr list --state merged --search "auto-translate" --limit 3` / `gh pr view <PR> --json state,mergedAt`。推測でリトライするな
 
 ### 3. TDD is Mandatory
 Kent Beck style. Tests = spec. Fix implementation, not tests.
@@ -263,6 +264,11 @@ Before implementing with external libraries:
 - Web Speech API (SpeechSynthesis)
 - Components: TTSControls.tsx, src/libs/tts/
 - Analytics: tts_start, tts_complete, tts_error
+
+### Auto-translate (ja → en)
+- `content/notion/posts/*.md` 変更時に auto-translate.yml が起動し、EN版を生成して固定ブランチ `auto-translate` に force-push
+- content-only PR は ci.yml の auto-merge ゲートで自動マージされる（条件は ci.yml 冒頭コメント参照）
+- 本文未変更でもフロントマター差分 (channels 等) があれば `frontmatter-only` で EN 版を更新する
 
 ### Image CDN (Cloudflare R2)
 - 画像はビルド時にR2 CDN URLに書き換え


### PR DESCRIPTION
## Summary
- §1 Pre-Commit Review Gate: "significant changes" に CI/CD workflow, deployment configuration を明記（Interpretation 段階の曖昧性を解消）
- §2b: sync-with-notion 限定だった「再観測」ルールを全自動ワークフローに一般化。auto-merge 条件と確認コマンドを追記（Inspection 段階の検証手順強化）
- Feature Documentation: auto-translate パイプラインのポインタを追加

## 背景
auto-translate ワークフロー復旧後、PR #1904 が auto-merge 済みであることを確認せず、重複 PR #1905 のマージを試行 → コンフリクト → 盲目的にワークフロー再実行という失敗をした。retrospective で Inspection (状態検証欠如) と Interpretation (significant の定義曖昧) を真因として特定。

## Test plan
- [ ] CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)