### PR TITLE
feat(auto-translate): add pluggable URL replacer for translated output

### DIFF
--- a/tools/auto-translate/translator.spec.ts
+++ b/tools/auto-translate/translator.spec.ts
@@ -635,6 +635,55 @@ describe('translateOne', () => {
     });
   });
 
+  describe('URL 置換の統合', () => {
+    test('翻訳成功時、出力 en の angular.jp / MDN ja URL が英語版 URL に置換される', async () => {
+      const jaWithUrls = buildJaContent({
+        body: '[ガイド](https://angular.jp/guide/signals) を参照。\n\nhttps://developer.mozilla.org/ja/docs/Web/API/Window/fetch\n',
+      });
+      const geminiClient: GeminiClient = mock.fn(() =>
+        Promise.resolve({
+          title_en: 'Title',
+          body_en:
+            'See [the guide](https://angular.jp/guide/signals).\n\nhttps://developer.mozilla.org/ja/docs/Web/API/Window/fetch\n',
+        }),
+      );
+      const result = await translateOne(makeArgs({ jaContent: jaWithUrls, geminiClient }));
+      assert.equal(result.kind, 'translated');
+      assert.ok('enContent' in result);
+      assert.match(result.enContent, /https:\/\/angular\.dev\/guide\/signals/);
+      assert.match(result.enContent, /https:\/\/developer\.mozilla\.org\/en-US\/docs\/Web\/API\/Window\/fetch/);
+      assert.ok(!result.enContent.includes('angular.jp'));
+      assert.ok(!result.enContent.includes('/ja/docs/'));
+    });
+
+    test('キャッシュヒット時、既存 en body の未置換 URL が置換されて frontmatter-only で更新される', async () => {
+      // 置換ルール導入前に生成された en（angular.jp のまま）がキャッシュヒットするシナリオ。
+      // LLM を呼ばずに置換だけが適用されること = ルール変更がキャッシュ済み記事へ波及することの検証
+      const jaBody = '[ガイド](https://angular.jp/guide/signals) を参照。\n';
+      const ja = buildJaContent({ body: jaBody });
+      const hash = computeBodyHash(jaBody, 'タイトル', MODEL);
+      const staleEnBody = 'See [the guide](https://angular.jp/guide/signals).\n';
+      const en = buildEnContent(hash, staleEnBody);
+      const client = makeOkClient();
+      const result = await translateOne(makeArgs({ jaContent: ja, enContent: en, geminiClient: client }));
+      assert.equal(result.kind, 'frontmatter-only');
+      assert.equal((client as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 0);
+      assert.ok('enContent' in result && result.enContent.includes('https://angular.dev/guide/signals'));
+    });
+
+    test('キャッシュヒット時、既存 en body が置換済みなら skipped（冪等）', async () => {
+      const jaBody = '[ガイド](https://angular.jp/guide/signals) を参照。\n';
+      const ja = buildJaContent({ body: jaBody });
+      const hash = computeBodyHash(jaBody, 'タイトル', MODEL);
+      const replacedEnBody = 'See [the guide](https://angular.dev/guide/signals).\n';
+      const en = buildEnContent(hash, replacedEnBody);
+      const client = makeOkClient();
+      const result = await translateOne(makeArgs({ jaContent: ja, enContent: en, geminiClient: client }));
+      assert.equal(result.kind, 'skipped');
+      assert.equal((client as unknown as { mock: { calls: unknown[] } }).mock.calls.length, 0);
+    });
+  });
+
   describe('エラーハンドリング', () => {
     test('API throw → failed、既存温存', async () => {
       const client: GeminiClient = mock.fn(() => Promise.reject(new Error('network error')));

--- a/tools/auto-translate/translator.ts
+++ b/tools/auto-translate/translator.ts
@@ -6,6 +6,7 @@ import { translateCodeBlock, type CodeTranslatorClient } from './code-translator
 import { buildEnFrontmatter, getAutoTranslatedFrom, isAutoTranslated, type Frontmatter } from './frontmatter.ts';
 import { proofread, formatProofIssues, type ProofreaderClient } from './proofreader.ts';
 import { validateStructure, type ValidationResult } from './structure-validator.ts';
+import { replaceUrls } from './url-replacer.ts';
 
 // PROMPT_VERSION: プロンプト/モデル/構造検証ロジックが変わったらインクリメントしてキャッシュを invalidate する。
 // バージョン履歴は git log で追える（変更時はコミットメッセージに「PROMPT_VERSION N → N+1」と記載）
@@ -319,14 +320,16 @@ export async function translateOne(args: TranslateOneArgs): Promise<TranslateRes
     }
   }
 
-  // キャッシュヒット: API 呼ばず frontmatter 再構築
+  // キャッシュヒット: API 呼ばず frontmatter 再構築。
+  // body にも replaceUrls を適用する（決定的・冪等なため）ことで、URL 置換ルールの
+  // 追加・変更が LLM 再翻訳なしにキャッシュ済み記事へ波及する
   if (existingEnHash === newHash && cachedTranslatedTitle !== undefined && cachedEnBody !== undefined) {
     const newEnFrontmatter = buildEnFrontmatter({
       jaFrontmatter: ja.frontmatter,
       translatedTitle: cachedTranslatedTitle,
       bodyHash: newHash,
     });
-    const newEnContent = joinFrontmatter(newEnFrontmatter, cachedEnBody);
+    const newEnContent = joinFrontmatter(newEnFrontmatter, replaceUrls(cachedEnBody));
     if (newEnContent === enContent) {
       return { kind: 'skipped' };
     }
@@ -399,6 +402,7 @@ export async function translateOne(args: TranslateOneArgs): Promise<TranslateRes
     translatedTitle: outcome.output.title_en,
     bodyHash: newHash,
   });
-  const enFullContent = joinFrontmatter(enFrontmatter, outcome.output.body_en);
+  // URL 置換は構造検証・proofread 完了後の最終 body に適用する（リンク数は不変なので構造検証に影響しない）
+  const enFullContent = joinFrontmatter(enFrontmatter, replaceUrls(outcome.output.body_en));
   return { kind: 'translated', enContent: enFullContent };
 }

--- a/tools/auto-translate/url-replacer.spec.ts
+++ b/tools/auto-translate/url-replacer.spec.ts
@@ -1,0 +1,172 @@
+import { strict as assert } from 'node:assert';
+import { test, describe } from 'node:test';
+import { angularJpReplacer, mdnJaReplacer, replaceUrls, type UrlReplacer } from './url-replacer.ts';
+
+describe('angularJpReplacer', () => {
+  test('angular.jp のホストを angular.dev に置換し、パスを維持する', () => {
+    assert.equal(angularJpReplacer.replace('https://angular.jp/guide/signals'), 'https://angular.dev/guide/signals');
+  });
+
+  test('クエリ・フラグメントを維持する', () => {
+    assert.equal(
+      angularJpReplacer.replace('https://angular.jp/api/core/Signal?tab=api#usage'),
+      'https://angular.dev/api/core/Signal?tab=api#usage',
+    );
+  });
+
+  test('ルートURL（trailing slash なし）は正規化せずホストだけ置換する', () => {
+    assert.equal(angularJpReplacer.replace('https://angular.jp'), 'https://angular.dev');
+  });
+
+  test('ルートURL（trailing slash あり）も置換する', () => {
+    assert.equal(angularJpReplacer.replace('https://angular.jp/'), 'https://angular.dev/');
+  });
+
+  test('サブドメインや別ホストは置換しない', () => {
+    assert.equal(angularJpReplacer.replace('https://v17.angular.io/guide/signals'), null);
+    assert.equal(angularJpReplacer.replace('https://blog.angular.jp/post'), null);
+    assert.equal(angularJpReplacer.replace('https://example.com/angular.jp'), null);
+  });
+
+  test('パスに angular.jp を含むだけのURLは置換しない', () => {
+    assert.equal(angularJpReplacer.replace('https://example.com/docs/angular.jp/guide'), null);
+  });
+
+  test('パース不能な文字列は null', () => {
+    assert.equal(angularJpReplacer.replace('not a url'), null);
+  });
+});
+
+describe('mdnJaReplacer', () => {
+  test('/ja/docs/ を /en-US/docs/ に置換する', () => {
+    assert.equal(
+      mdnJaReplacer.replace('https://developer.mozilla.org/ja/docs/Web/API/Window/fetch'),
+      'https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch',
+    );
+  });
+
+  test('フラグメント・クエリを維持する', () => {
+    assert.equal(
+      mdnJaReplacer.replace('https://developer.mozilla.org/ja/docs/Web/CSS/color#syntax'),
+      'https://developer.mozilla.org/en-US/docs/Web/CSS/color#syntax',
+    );
+  });
+
+  test('/en-US/ のURLは置換しない', () => {
+    assert.equal(mdnJaReplacer.replace('https://developer.mozilla.org/en-US/docs/Web/CSS/color'), null);
+  });
+
+  test('他ロケール・ロケールなしURLは置換しない', () => {
+    assert.equal(mdnJaReplacer.replace('https://developer.mozilla.org/fr/docs/Web/CSS/color'), null);
+    assert.equal(mdnJaReplacer.replace('https://developer.mozilla.org/docs/Web/CSS/color'), null);
+  });
+
+  test('パスが /ja そのもの（/ja/ で始まらない）は置換しない', () => {
+    // /javascript のような prefix 誤爆がないこと
+    assert.equal(mdnJaReplacer.replace('https://developer.mozilla.org/javascript'), null);
+  });
+
+  test('MDN 以外のホストの /ja/ パスは置換しない', () => {
+    assert.equal(mdnJaReplacer.replace('https://example.com/ja/docs/page'), null);
+  });
+});
+
+describe('replaceUrls', () => {
+  test('inline link の URL を置換する（リンクテキストは維持）', () => {
+    const input = 'See [Signals guide](https://angular.jp/guide/signals) for details.\n';
+    const expected = 'See [Signals guide](https://angular.dev/guide/signals) for details.\n';
+    assert.equal(replaceUrls(input), expected);
+  });
+
+  test('bare autolink は href とテキストの両方が置換される', () => {
+    const input = 'Reference:\n\nhttps://developer.mozilla.org/ja/docs/Web/API/Window/fetch\n';
+    const expected = 'Reference:\n\nhttps://developer.mozilla.org/en-US/docs/Web/API/Window/fetch\n';
+    assert.equal(replaceUrls(input), expected);
+  });
+
+  test('definition（参照リンク定義）の URL を置換する', () => {
+    const input = 'See [guide][1].\n\n[1]: https://angular.jp/guide/signals\n';
+    const expected = 'See [guide][1].\n\n[1]: https://angular.dev/guide/signals\n';
+    assert.equal(replaceUrls(input), expected);
+  });
+
+  test('code block 内の URL は置換しない', () => {
+    const input = '```ts\nconst url = "https://angular.jp/guide/signals";\n```\n';
+    assert.equal(replaceUrls(input), input);
+  });
+
+  test('inline code 内の URL は置換しない', () => {
+    const input = 'Use `https://angular.jp/api` as base.\n';
+    assert.equal(replaceUrls(input), input);
+  });
+
+  test('blockquote 内のリンクは置換する', () => {
+    const input = '> See [guide](https://angular.jp/guide/signals).\n';
+    const expected = '> See [guide](https://angular.dev/guide/signals).\n';
+    assert.equal(replaceUrls(input), expected);
+  });
+
+  test('複数の URL が混在しても全て置換される', () => {
+    const input = [
+      '[A](https://angular.jp/guide/signals) and [B](https://developer.mozilla.org/ja/docs/Web/CSS/color).',
+      '',
+      'https://angular.jp/api/core',
+      '',
+      '[C](https://example.com/keep) stays.',
+      '',
+    ].join('\n');
+    const expected = [
+      '[A](https://angular.dev/guide/signals) and [B](https://developer.mozilla.org/en-US/docs/Web/CSS/color).',
+      '',
+      'https://angular.dev/api/core',
+      '',
+      '[C](https://example.com/keep) stays.',
+      '',
+    ].join('\n');
+    assert.equal(replaceUrls(input), expected);
+  });
+
+  test('対象 URL がなければ入力をそのまま返す', () => {
+    const input = 'No links here.\n\n[X](https://example.com/page)\n';
+    assert.equal(replaceUrls(input), input);
+  });
+
+  test('冪等性: 2 回適用しても結果が変わらない', () => {
+    const input = '[A](https://angular.jp/guide) and https://developer.mozilla.org/ja/docs/Web/API\n';
+    const once = replaceUrls(input);
+    assert.equal(replaceUrls(once), once);
+  });
+
+  test('replacers を DI で差し替えられる', () => {
+    const custom: UrlReplacer = {
+      name: 'custom',
+      replace: (url) => (url === 'https://old.example.com/x' ? 'https://new.example.com/x' : null),
+    };
+    const input = '[link](https://old.example.com/x) and [keep](https://angular.jp/guide)\n';
+    const expected = '[link](https://new.example.com/x) and [keep](https://angular.jp/guide)\n';
+    assert.equal(replaceUrls(input, [custom]), expected);
+  });
+
+  test('replacer が無変更の URL を返した場合は no-match 扱いで次の replacer に委ねる（契約違反の防御）', () => {
+    const broken: UrlReplacer = { name: 'broken', replace: (url) => url };
+    const fixer: UrlReplacer = {
+      name: 'fixer',
+      replace: (url) => (url.includes('target') ? 'https://fixed.example/' : null),
+    };
+    const result = replaceUrls('[x](https://target.example.com/)\n', [broken, fixer]);
+    assert.match(result, /https:\/\/fixed\.example\//);
+  });
+
+  test('最初にマッチした replacer が優先される', () => {
+    const first: UrlReplacer = {
+      name: 'first',
+      replace: (url) => (url.includes('target') ? 'https://a.example' : null),
+    };
+    const second: UrlReplacer = {
+      name: 'second',
+      replace: (url) => (url.includes('target') ? 'https://b.example' : null),
+    };
+    const result = replaceUrls('[x](https://target.example.com/)\n', [first, second]);
+    assert.match(result, /https:\/\/a\.example/);
+  });
+});

--- a/tools/auto-translate/url-replacer.spec.ts
+++ b/tools/auto-translate/url-replacer.spec.ts
@@ -35,6 +35,10 @@ describe('angularJpReplacer', () => {
   test('パース不能な文字列は null', () => {
     assert.equal(angularJpReplacer.replace('not a url'), null);
   });
+
+  test('大文字混じりドメインも置換され、ホストは正規形（小文字）で出力される', () => {
+    assert.equal(angularJpReplacer.replace('https://ANGULAR.JP/guide/signals'), 'https://angular.dev/guide/signals');
+  });
 });
 
 describe('mdnJaReplacer', () => {
@@ -68,6 +72,13 @@ describe('mdnJaReplacer', () => {
 
   test('MDN 以外のホストの /ja/ パスは置換しない', () => {
     assert.equal(mdnJaReplacer.replace('https://example.com/ja/docs/page'), null);
+  });
+
+  test('大文字混じりドメインも置換され、ホストは正規形（小文字）で出力される', () => {
+    assert.equal(
+      mdnJaReplacer.replace('https://DEVELOPER.MOZILLA.ORG/ja/docs/Web/CSS/color'),
+      'https://developer.mozilla.org/en-US/docs/Web/CSS/color',
+    );
   });
 });
 

--- a/tools/auto-translate/url-replacer.ts
+++ b/tools/auto-translate/url-replacer.ts
@@ -27,11 +27,16 @@ function tryParse(url: string): URL | null {
 // URL#toString() で再構築すると正規化（例: https://angular.jp → https://angular.dev/）で
 // 原文と乖離するため、マッチ判定のみ URL パースで行い、置換は正規表現による文字列操作で行う
 
+// ホスト部はドメイン名が大文字小文字を区別しないため i フラグでマッチさせる
+// （hostname 判定は WHATWG URL の正規化で常に小文字になるのに対し、置換は原文文字列に
+// 対して行うため、フラグがないと大文字混じりドメインが置換から漏れる）。
+// 置換結果のホストは正規形（小文字）で出力する
+
 export const angularJpReplacer: UrlReplacer = {
   name: 'angular.jp',
   replace(url) {
     if (tryParse(url)?.hostname !== 'angular.jp') return null;
-    return url.replace(/^(https?:\/\/)angular\.jp(?=[/:?#]|$)/, '$1angular.dev');
+    return url.replace(/^(https?:\/\/)angular\.jp(?=[/:?#]|$)/i, '$1angular.dev');
   },
 };
 
@@ -44,7 +49,7 @@ export const mdnJaReplacer: UrlReplacer = {
     const parsed = tryParse(url);
     if (parsed?.hostname !== 'developer.mozilla.org') return null;
     if (parsed.pathname !== '/ja' && !parsed.pathname.startsWith('/ja/')) return null;
-    return url.replace(/^(https?:\/\/developer\.mozilla\.org)\/ja(?=[/?#]|$)/, '$1/en-US');
+    return url.replace(/^(https?:\/\/)developer\.mozilla\.org\/ja(?=[/?#]|$)/i, '$1developer.mozilla.org/en-US');
   },
 };
 

--- a/tools/auto-translate/url-replacer.ts
+++ b/tools/auto-translate/url-replacer.ts
@@ -1,0 +1,96 @@
+// 翻訳後の en body に対して、日本語向けサイト URL を英語版 URL に置換する後処理。
+// 置換は決定的かつ冪等なので、キャッシュヒット経路にも適用でき、ルールの追加・変更が
+// LLM 再翻訳なしにキャッシュ済み記事へ波及する（PROMPT_VERSION の bump 不要）。
+
+import { remark } from 'remark';
+import remarkGfm from 'remark-gfm';
+import { visitParents } from 'unist-util-visit-parents';
+
+const remarkProcessor = remark().use(remarkGfm);
+
+// 1 ルール = 1 replacer。マッチしなければ null を返す。
+// 制約: 置換結果はどの replacer にも再マッチしないこと（冪等性）。破ると
+// キャッシュヒット経路で毎回 body が書き換わり skipped 判定が成立しなくなる
+export interface UrlReplacer {
+  name: string;
+  replace(url: string): string | null;
+}
+
+function tryParse(url: string): URL | null {
+  try {
+    return new URL(url);
+  } catch {
+    return null;
+  }
+}
+
+// URL#toString() で再構築すると正規化（例: https://angular.jp → https://angular.dev/）で
+// 原文と乖離するため、マッチ判定のみ URL パースで行い、置換は正規表現による文字列操作で行う
+
+export const angularJpReplacer: UrlReplacer = {
+  name: 'angular.jp',
+  replace(url) {
+    if (tryParse(url)?.hostname !== 'angular.jp') return null;
+    return url.replace(/^(https?:\/\/)angular\.jp(?=[/:?#]|$)/, '$1angular.dev');
+  },
+};
+
+// MDN のロケールはパス第 1 セグメント。/ja/<path> → /en-US/<path> はスラッグが
+// ロケール間で同一（mdn/translated-content の規約で slug 一致必須）なため常に有効。
+// en-US は正規形表記（/en-us/ は MDN 側で 301 正規化されるが、生成 URL は正規形を使う）
+export const mdnJaReplacer: UrlReplacer = {
+  name: 'mdn-ja',
+  replace(url) {
+    const parsed = tryParse(url);
+    if (parsed?.hostname !== 'developer.mozilla.org') return null;
+    if (parsed.pathname !== '/ja' && !parsed.pathname.startsWith('/ja/')) return null;
+    return url.replace(/^(https?:\/\/developer\.mozilla\.org)\/ja(?=[/?#]|$)/, '$1/en-US');
+  },
+};
+
+export const defaultUrlReplacers: UrlReplacer[] = [angularJpReplacer, mdnJaReplacer];
+
+function applyReplacers(url: string, replacers: UrlReplacer[]): string | null {
+  for (const replacer of replacers) {
+    const replaced = replacer.replace(url);
+    // 無変更の戻り値は no-match 扱いにする: hostname 判定は通るが置換 regex が
+    // 不一致になる URL（userinfo・ポート付き等）で replacer が元の URL をそのまま
+    // 返しても、契約（マッチしなければ null）違反が下流へ波及しないよう防御する
+    if (replaced !== null && replaced !== url) return replaced;
+  }
+  return null;
+}
+
+// markdown 中の link / definition ノードの URL を走査し、最初にマッチした replacer で置換する。
+// code / inlineCode は link ノードにならないため自然に対象外（コード中の URL は書き換えない）。
+// blockquote 内のリンクは置換対象に含める（引用中でも読者を英語版ページへ誘導するのが目的のため）
+export function replaceUrls(markdown: string, replacers: UrlReplacer[] = defaultUrlReplacers): string {
+  const tree = remarkProcessor.parse(markdown);
+  const edits: { start: number; end: number; replacement: string }[] = [];
+
+  visitParents(tree, (node) => {
+    if (node.type !== 'link' && node.type !== 'definition') return;
+    const newUrl = applyReplacers(node.url, replacers);
+    if (newUrl === null) return;
+    const pos = node.position;
+    if (pos == null) return;
+    const start = pos.start.offset;
+    const end = pos.end.offset;
+    if (start == null || end == null) return;
+
+    // ノードの source slice 内で旧 URL の全出現を置換する。
+    // bare autolink はリンクテキスト = URL なので href とテキストの両方が置き換わる。
+    // mdast の url がソース表記と一致しない場合（エンティティ参照等）は fail-safe でスキップ
+    const slice = markdown.slice(start, end);
+    if (!slice.includes(node.url)) return;
+    edits.push({ start, end, replacement: slice.split(node.url).join(newUrl) });
+  });
+
+  // 右から左へ置換することでオフセットがズレないようにする
+  edits.sort((a, b) => b.start - a.start);
+  let result = markdown;
+  for (const e of edits) {
+    result = result.slice(0, e.start) + e.replacement + result.slice(e.end);
+  }
+  return result;
+}


### PR DESCRIPTION
## 概要

auto-translate が生成する `.en.md` の本文中に残る日本語向けサイト URL を、英語版 URL に置換するプラガブルな後処理機構を追加します。

## 初期ルール

| Replacer | 置換 |
|---|---|
| `angularJpReplacer` | `https://angular.jp/...` → `https://angular.dev/...` (ホスト置換、パス・クエリ・フラグメント維持) |
| `mdnJaReplacer` | `https://developer.mozilla.org/ja/...` → `.../en-US/...` (ロケールプレフィックス置換) |

MDN の仕様は一次情報 (mdn/yari `VALID_LOCALES` / mdn/translated-content の slug 一致規約) と実測 (HEAD リクエスト) で確認済み。スラッグはロケール間で同一のため `/ja/docs/X` → `/en-US/docs/X` は常に有効なページに解決されます。

## 設計

- **プラガブル**: `UrlReplacer` インターフェース (`replace(url) => string | null`)。ルール追加は replacer を 1 つ書いて `defaultUrlReplacers` に足すだけ
- **挿入位置**: 構造検証・proofread 完了後の最終 en body への後処理。ja ソースは変更しない
- **キャッシュ波及**: 置換は決定的・冪等なのでキャッシュヒット経路 (`frontmatter-only`) にも適用。ルールの追加・変更が LLM 再翻訳なし (API コスト 0) で既存のキャッシュ済み記事へ波及するため `PROMPT_VERSION` の bump は不要
- **走査**: code-extractor と同型の remark AST + offset ベース右→左置換。link / definition ノードが対象で、コードブロック・インラインコード内の URL は書き換えない。bare autolink は href とテキストの両方を置換

## 検証

- `pnpm test:tools` 282 件 pass (新規 spec 25 件 + translator 統合 3 件を含む)
- 実記事 2 件 (`angular-v22-injectasync.en.md` / `angular-v22-onpush-by-default.en.md`) で置換の入出力を確認し、置換先 URL 全件が HTTP 200 で実在することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)