### PR TITLE
feat: 記事下のシェアにWeb Share APIボタンを追加

### DIFF
--- a/src/components/NativeShareButton.spec.tsx
+++ b/src/components/NativeShareButton.spec.tsx
@@ -1,0 +1,137 @@
+/**
+ * NativeShareButton コンポーネントテスト
+ * src/pages/ に配置するとAstroがルートとして処理するため src/components/ に配置
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import NativeShareButton from './NativeShareButton';
+
+const { mockTrackEvent } = vi.hoisted(() => ({ mockTrackEvent: vi.fn() }));
+
+vi.mock('../libs/analytics', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../libs/analytics')>();
+  return { ...original, trackEvent: mockTrackEvent };
+});
+
+/** jsdomのnavigatorにshareを生やす（jsdomは未実装のためdefinePropertyで注入する） */
+function setShare(share: unknown): void {
+  Object.defineProperty(navigator, 'share', { value: share, configurable: true, writable: true });
+}
+
+function deleteShare(): void {
+  if ('share' in navigator) {
+    delete (navigator as unknown as { share?: unknown }).share;
+  }
+}
+
+describe('NativeShareButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    deleteShare();
+  });
+
+  afterEach(() => {
+    cleanup();
+    deleteShare();
+  });
+
+  const props = { title: 'テスト記事 | lacolaco.net', url: 'https://blog.lacolaco.net/posts/test' };
+
+  it('Web Share API 非対応の場合、ボタンを描画しない', async () => {
+    render(<NativeShareButton {...props} />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+  });
+
+  it('Web Share API 対応の場合、ボタンを描画する', async () => {
+    setShare(vi.fn().mockResolvedValue(undefined));
+    render(<NativeShareButton {...props} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '共有' })).toBeInTheDocument();
+    });
+  });
+
+  it('locale=enの場合、英語のラベルを表示する', async () => {
+    setShare(vi.fn().mockResolvedValue(undefined));
+    render(<NativeShareButton {...props} locale="en" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Share' })).toBeInTheDocument();
+    });
+  });
+
+  it('クリックするとタイトルとURLを共有し、完了イベントを送信する', async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    setShare(share);
+    render(<NativeShareButton {...props} />);
+    const button = await screen.findByRole('button');
+
+    button.click();
+
+    expect(share).toHaveBeenCalledWith({ title: props.title, url: props.url });
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith({ name: 'share_complete' });
+    });
+  });
+
+  it('ユーザーがキャンセルした場合、エラーイベントを送信しない', async () => {
+    setShare(vi.fn().mockRejectedValue(new DOMException('Share canceled', 'AbortError')));
+    render(<NativeShareButton {...props} />);
+    const button = await screen.findByRole('button');
+
+    button.click();
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith({ name: 'share_cancel' });
+    });
+    expect(mockTrackEvent).not.toHaveBeenCalledWith(expect.objectContaining({ name: 'share_error' }));
+  });
+
+  it('共有中の再クリックを無視する（共有シートが開いている間の二重呼び出しを防ぐ）', async () => {
+    let resolveShare: () => void = () => {};
+    const share = vi.fn().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveShare = resolve;
+        }),
+    );
+    setShare(share);
+    render(<NativeShareButton {...props} />);
+    const button = await screen.findByRole('button');
+
+    button.click();
+    button.click();
+
+    expect(share).toHaveBeenCalledTimes(1);
+
+    resolveShare();
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith({ name: 'share_complete' });
+    });
+
+    // 共有完了後は再度共有できる
+    button.click();
+    expect(share).toHaveBeenCalledTimes(2);
+  });
+
+  it('共有が失敗した場合、エラーイベントを送信する', async () => {
+    setShare(vi.fn().mockRejectedValue(new Error('Permission denied')));
+    render(<NativeShareButton {...props} />);
+    const button = await screen.findByRole('button');
+
+    button.click();
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith({
+        name: 'share_error',
+        params: { error_message: 'Permission denied' },
+      });
+    });
+  });
+});

--- a/src/components/NativeShareButton.tsx
+++ b/src/components/NativeShareButton.tsx
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { shareEvents, trackEvent } from '../libs/analytics';
+import { checkShareAvailability, shareContent } from '../libs/share';
+
+interface Props {
+  title: string;
+  url: string;
+  locale?: string;
+}
+
+const i18n = {
+  ja: { share: '共有' },
+  en: { share: 'Share' },
+};
+
+/**
+ * Web Share API による共有ボタン
+ * 非対応ブラウザでは何も描画しない（既存のSNS共有リンクのみが残る）
+ */
+export default function NativeShareButton({ title, url, locale = 'ja' }: Props) {
+  const [available, setAvailable] = useState(false);
+  /** 共有シートが開いている間の二重呼び出し（navigator.share が InvalidStateError で失敗する）を防ぐ */
+  const sharing = useRef(false);
+
+  // navigator は SSR 時に存在しないため、マウント後に機能検出する
+  useEffect(() => {
+    setAvailable(checkShareAvailability() === 'available');
+  }, []);
+
+  const share = useCallback(async () => {
+    if (sharing.current) {
+      return;
+    }
+    sharing.current = true;
+
+    const result = await shareContent({ title, url }).finally(() => {
+      sharing.current = false;
+    });
+
+    switch (result.status) {
+      case 'success':
+        trackEvent(shareEvents.complete());
+        break;
+      case 'cancelled':
+        trackEvent(shareEvents.cancel());
+        break;
+      case 'error':
+        trackEvent(shareEvents.error(result.message));
+        break;
+      case 'unavailable':
+        // マウント後に利用不可になるケース（機能検出の取りこぼし）ではボタンを隠す
+        setAvailable(false);
+        break;
+    }
+  }, [title, url]);
+
+  // onClick は void を返す必要があるため Promise を切り離す
+  const handleClick = useCallback(() => {
+    void share();
+  }, [share]);
+
+  if (!available) {
+    return null;
+  }
+
+  const t = locale === 'en' ? i18n.en : i18n.ja;
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="inline-flex items-center justify-center w-10 h-10 rounded-full border border-gray-300 text-muted hover:text-default hover:bg-gray-100 transition-colors cursor-pointer"
+      title={t.share}
+      aria-label={t.share}
+    >
+      <span className="icon-[mdi--share-variant] inline-block text-base" aria-hidden="true" />
+    </button>
+  );
+}

--- a/src/components/ShareButtons.astro
+++ b/src/components/ShareButtons.astro
@@ -1,15 +1,21 @@
 ---
+import NativeShareButton from './NativeShareButton';
+
 type Props = {
   title: string;
   url: string;
+  locale?: string;
 };
 
-const { title, url } = Astro.props;
+const { title, url, locale = 'ja' } = Astro.props;
 
 const encodedTitle = encodeURIComponent(title);
 ---
 
 <section class="flex items-center gap-3">
+  {/* Web Share API 対応ブラウザのみクライアント側で描画される */}
+  <NativeShareButton title={title} url={url} locale={locale} client:idle />
+
   <a
     href={`https://twitter.com/intent/tweet?original_referer=${url}&text=${encodedTitle}&url=${url}`}
     target="_blank"

--- a/src/layouts/PostDetailPage.astro
+++ b/src/layouts/PostDetailPage.astro
@@ -138,7 +138,7 @@ const alternatePost = alternateLocalePosts.length > 0 ? alternateLocalePosts[0] 
         </div>
 
         <div class="mt-6">
-          <ShareButtons url={Astro.url.toString()} title={`${title} | ${SITE_TITLE}`} />
+          <ShareButtons url={Astro.url.toString()} title={`${title} | ${SITE_TITLE}`} locale={locale || 'ja'} />
         </div>
 
         <PostNavigation prev={adjacentPosts.prev} next={adjacentPosts.next} />

--- a/src/libs/analytics.ts
+++ b/src/libs/analytics.ts
@@ -33,6 +33,17 @@ export const ttsEvents = {
   }),
 };
 
+/** ネイティブ共有（Web Share API）イベントファクトリー */
+export const shareEvents = {
+  complete: (): AnalyticsEvent => ({ name: 'share_complete' }),
+  /** ユーザーが共有シートを閉じた場合。エラーと区別して記録する */
+  cancel: (): AnalyticsEvent => ({ name: 'share_cancel' }),
+  error: (errorMessage: string): AnalyticsEvent => ({
+    name: 'share_error',
+    params: { error_message: errorMessage },
+  }),
+};
+
 /** いいねイベントファクトリー */
 export const likeEvents = {
   toggle: (slug: string, liked: boolean): AnalyticsEvent => ({

--- a/src/libs/share/feature-detection.spec.ts
+++ b/src/libs/share/feature-detection.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { checkShareAvailability } from './feature-detection';
+
+/** globalThis.navigator は getter のみのためvi.stubGlobalで差し替える */
+function setNavigator(value: unknown): void {
+  vi.stubGlobal('navigator', value);
+}
+
+function clearNavigator(): void {
+  vi.unstubAllGlobals();
+}
+
+describe('checkShareAvailability', () => {
+  afterEach(() => {
+    clearNavigator();
+  });
+
+  it('navigatorが存在しない場合、unavailableを返す', () => {
+    setNavigator(undefined);
+    expect(checkShareAvailability()).toBe('unavailable');
+  });
+
+  it('navigator.shareが存在しない場合、unavailableを返す', () => {
+    setNavigator({});
+    expect(checkShareAvailability()).toBe('unavailable');
+  });
+
+  it('navigator.shareが関数でない場合、unavailableを返す', () => {
+    setNavigator({ share: 'not a function' });
+    expect(checkShareAvailability()).toBe('unavailable');
+  });
+
+  it('navigator.shareが関数の場合、availableを返す', () => {
+    setNavigator({ share: vi.fn() });
+    expect(checkShareAvailability()).toBe('available');
+  });
+});

--- a/src/libs/share/feature-detection.ts
+++ b/src/libs/share/feature-detection.ts
@@ -1,0 +1,14 @@
+import type { ShareAvailability } from './types';
+
+/**
+ * Web Share API の利用可能性を確認
+ *
+ * navigator.canShare() は判定に使わない。共有するのは title / url のみで、
+ * navigator.share が存在する環境では canShare も常に true を返すため。
+ */
+export function checkShareAvailability(): ShareAvailability {
+  if (typeof navigator === 'undefined' || typeof navigator.share !== 'function') {
+    return 'unavailable';
+  }
+  return 'available';
+}

--- a/src/libs/share/index.ts
+++ b/src/libs/share/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Share モジュール
+ * Web Share API ラッパー
+ */
+
+// 型定義
+export type { ShareAvailability, ShareContent, ShareResult } from './types';
+
+// Feature Detection
+export { checkShareAvailability } from './feature-detection';
+
+// Share Functions
+export { shareContent } from './share';

--- a/src/libs/share/share.spec.ts
+++ b/src/libs/share/share.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { shareContent } from './share';
+
+/** globalThis.navigator は getter のみのためvi.stubGlobalで差し替える */
+function setNavigator(value: unknown): void {
+  vi.stubGlobal('navigator', value);
+}
+
+function clearNavigator(): void {
+  vi.unstubAllGlobals();
+}
+
+const content = { title: 'テスト記事 | lacolaco.net', url: 'https://blog.lacolaco.net/posts/test' };
+
+describe('shareContent', () => {
+  afterEach(() => {
+    clearNavigator();
+  });
+
+  it('Web Share API 非対応の場合、unavailableを返す', async () => {
+    setNavigator({});
+    expect(await shareContent(content)).toEqual({ status: 'unavailable' });
+  });
+
+  it('共有が成功した場合、successを返す', async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    setNavigator({ share });
+
+    expect(await shareContent(content)).toEqual({ status: 'success' });
+    expect(share).toHaveBeenCalledWith({ title: content.title, url: content.url });
+  });
+
+  it('ユーザーが共有シートを閉じた場合(AbortError)、cancelledを返す', async () => {
+    const abortError = Object.assign(new Error('Share canceled'), { name: 'AbortError' });
+    setNavigator({ share: vi.fn().mockRejectedValue(abortError) });
+
+    expect(await shareContent(content)).toEqual({ status: 'cancelled' });
+  });
+
+  it('AbortErrorがDOMExceptionで投げられた場合もcancelledを返す', async () => {
+    setNavigator({ share: vi.fn().mockRejectedValue(new DOMException('Share canceled', 'AbortError')) });
+
+    expect(await shareContent(content)).toEqual({ status: 'cancelled' });
+  });
+
+  it('その他の失敗の場合、errorとメッセージを返す', async () => {
+    setNavigator({ share: vi.fn().mockRejectedValue(new Error('Permission denied')) });
+
+    expect(await shareContent(content)).toEqual({ status: 'error', message: 'Permission denied' });
+  });
+
+  it('Errorでない値がthrowされた場合もerrorを返す', async () => {
+    setNavigator({ share: vi.fn().mockRejectedValue('unknown failure') });
+
+    expect(await shareContent(content)).toEqual({ status: 'error', message: 'unknown failure' });
+  });
+});

--- a/src/libs/share/share.ts
+++ b/src/libs/share/share.ts
@@ -1,0 +1,31 @@
+import { checkShareAvailability } from './feature-detection';
+import type { ShareContent, ShareResult } from './types';
+
+/**
+ * ユーザーが共有シートを閉じたときのエラーか判定する
+ * DOMException / Error のどちらで投げられても name で判定できるようにする
+ */
+function isAbortError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'name' in error && error.name === 'AbortError';
+}
+
+/**
+ * Web Share API でコンテンツを共有する
+ * 呼び出しはユーザー操作（クリック等）のハンドラ内から行う必要がある
+ */
+export async function shareContent(content: ShareContent): Promise<ShareResult> {
+  if (checkShareAvailability() === 'unavailable') {
+    return { status: 'unavailable' };
+  }
+
+  try {
+    await navigator.share({ title: content.title, url: content.url });
+    return { status: 'success' };
+  } catch (error) {
+    // ユーザーによるキャンセルは AbortError になるためエラーとして扱わない
+    if (isAbortError(error)) {
+      return { status: 'cancelled' };
+    }
+    return { status: 'error', message: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/src/libs/share/types.ts
+++ b/src/libs/share/types.ts
@@ -1,0 +1,21 @@
+/** Web Share API の利用可能性 */
+export type ShareAvailability = 'available' | 'unavailable';
+
+/** 共有するコンテンツ */
+export type ShareContent = {
+  title: string;
+  url: string;
+};
+
+/**
+ * 共有の実行結果
+ * - success: 共有シートでの共有が完了した（共有先アプリは取得できない）
+ * - cancelled: ユーザーが共有シートを閉じた（AbortError）。エラーではない
+ * - unavailable: Web Share API 非対応
+ * - error: 上記以外の失敗
+ */
+export type ShareResult =
+  | { status: 'success' }
+  | { status: 'cancelled' }
+  | { status: 'unavailable' }
+  | { status: 'error'; message: string };


### PR DESCRIPTION
## 概要

記事本文下のシェア欄に Web Share API によるネイティブ共有ボタンを追加した。対応ブラウザ（主にモバイル）では OS の共有シートが開き、LINE・Slack・メモアプリなど任意のアプリに記事を共有できる。

プログレッシブエンハンスメントとして実装しており、**非対応ブラウザでは何も描画されない**（既存の X / Bluesky / Misskey / Mastodon リンクはそのまま残る）。ボタンはシェア欄の先頭（Xの左）に配置。

## 変更内容

- `src/libs/share/` を追加
  - `feature-detection.ts`: `navigator.share` の機能検出。`canShare()` は共有内容が title/url のみのため判定に使わない（理由をコメント）
  - `share.ts`: `navigator.share` のラッパー。ユーザーのキャンセル（`AbortError`）を `cancelled` として成功/失敗と区別
- `src/components/NativeShareButton.tsx` を追加
  - マウント後に機能検出し、非対応なら `null` を返す
  - 共有シートが開いている間の二重呼び出し（`InvalidStateError`）を ref でガード
  - ラベルは locale に応じて「共有」/「Share」
- `src/components/ShareButtons.astro`: `client:idle` で島として読み込み、`locale` prop を追加（既定 `ja`）
- `src/layouts/PostDetailPage.astro`: 記事の locale を `ShareButtons` へ渡す
- `src/libs/analytics.ts`: `shareEvents`（`share_complete` / `share_cancel` / `share_error`）を追加。キャンセルはエラーとして計上しない

## テスト

TDD で先にテストを書き、失敗を確認してから実装した。

- `src/libs/share/feature-detection.spec.ts`（4件）
- `src/libs/share/share.spec.ts`（6件）— AbortError が `Error` / `DOMException` どちらで投げられても cancelled になることを含む
- `src/components/NativeShareButton.spec.tsx`（7件）— 非対応時に描画しない / クリックで title・url を共有 / キャンセル時にエラーイベントを送らない / 共有中の再クリックを無視する
- `pnpm test`: 193 passed、`pnpm lint`・`pnpm format`・`pnpm build` すべて通過

## 動作確認

Playwright + Chromium で `navigator.share` を stub し、375 / 768 / 1024 / 1440px の4幅で確認した。

- 非対応時: ボタンは描画されず、既存レイアウトと差分なし（Xボタンの位置も同一）
- 対応時: 40px の円形ボタンがシェア欄先頭に入り、以降が 52px シフト。セクション高さは 40px のまま、横スクロールの発生なし
- クリック時に `navigator.share({ title, url })` が期待どおりの値で呼ばれることを確認

（768px の横スクロールは変更前から発生している既存挙動で、本 PR による差分ではない）

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSieo7g8oSrWTCKxMMnDtK)_