### PR TITLE
fix: 記事詳細の前後記事に自分の翻訳版が出るのを修正

### DIFF
--- a/src/components/PostNavigation.astro
+++ b/src/components/PostNavigation.astro
@@ -1,11 +1,8 @@
 ---
-import type { CollectionEntry } from 'astro:content';
+import type { AdjacentPosts } from '../libs/query';
 import { getRelativePostUrl } from '../libs/compat';
 
-type Props = {
-  prev: CollectionEntry<'posts'> | null;
-  next: CollectionEntry<'posts'> | null;
-};
+type Props = AdjacentPosts;
 
 const { prev, next } = Astro.props;
 

--- a/src/layouts/PostDetailPage.astro
+++ b/src/layouts/PostDetailPage.astro
@@ -15,15 +15,12 @@ import ArticleSummarizer from '../components/ArticleSummarizer';
 import LikeButton from '../components/LikeButton';
 import ImageLightbox from '../components/ImageLightbox.astro';
 import { SITE_TITLE } from '../consts';
-import { queryAvailablePosts } from '@lib/query';
+import { queryAvailablePosts, type AdjacentPosts } from '@lib/query';
 import { getRelativePostUrl, getChannels } from '../libs/compat';
 
 type Props = {
   entry: CollectionEntry<'posts'>;
-  adjacentPosts: {
-    prev: CollectionEntry<'posts'> | null;
-    next: CollectionEntry<'posts'> | null;
-  };
+  adjacentPosts: AdjacentPosts;
 };
 
 const { entry, adjacentPosts } = Astro.props;

--- a/src/libs/query/posts.spec.ts
+++ b/src/libs/query/posts.spec.ts
@@ -82,7 +82,7 @@ describe('queryAdjacentPosts', () => {
       createMockPost('post-3', new Date('2023-01-03')),
     ];
 
-    const result = queryAdjacentPosts(posts, 'post-2');
+    const result = queryAdjacentPosts(posts, posts[1]);
 
     expect(result.prev).not.toBeNull();
     expect(result.prev?.data.slug).toBe('post-1');
@@ -97,7 +97,7 @@ describe('queryAdjacentPosts', () => {
       createMockPost('post-3', new Date('2023-01-03')),
     ];
 
-    const result = queryAdjacentPosts(posts, 'post-1');
+    const result = queryAdjacentPosts(posts, posts[0]);
 
     expect(result.prev).toBeNull();
     expect(result.next).not.toBeNull();
@@ -111,7 +111,7 @@ describe('queryAdjacentPosts', () => {
       createMockPost('post-3', new Date('2023-01-03')),
     ];
 
-    const result = queryAdjacentPosts(posts, 'post-3');
+    const result = queryAdjacentPosts(posts, posts[2]);
 
     expect(result.prev).not.toBeNull();
     expect(result.prev?.data.slug).toBe('post-2');
@@ -121,35 +121,33 @@ describe('queryAdjacentPosts', () => {
   it('記事が1つしかない場合、両方nullになる', () => {
     const posts = [createMockPost('post-1', new Date('2023-01-01'))];
 
-    const result = queryAdjacentPosts(posts, 'post-1');
+    const result = queryAdjacentPosts(posts, posts[0]);
 
     expect(result.prev).toBeNull();
     expect(result.next).toBeNull();
   });
 
-  it('存在しないスラッグの場合、両方nullになる', () => {
+  it('集合に含まれない記事の場合、両方nullになる', () => {
     const posts = [createMockPost('post-1', new Date('2023-01-01')), createMockPost('post-2', new Date('2023-01-02'))];
+    const current = createMockPost('non-existent', new Date('2023-01-03'));
 
-    const result = queryAdjacentPosts(posts, 'non-existent');
+    const result = queryAdjacentPosts(posts, current);
 
     expect(result.prev).toBeNull();
     expect(result.next).toBeNull();
   });
 
-  it('ロケールが異なる記事も含まれる', () => {
-    const posts = [
+  it('ロケールが異なる記事は隣接記事に含まれない', () => {
+    const posts: Array<CollectionEntry<'posts' | 'postsEn'>> = [
       createMockPost('post-1', new Date('2023-01-01')),
-      createMockPost('post-2', new Date('2023-01-02'), 'en'),
-      createMockPost('post-3', new Date('2023-01-03'), 'ja'),
+      createMockEnPost('post-2', new Date('2023-01-02')),
+      createMockPost('post-3', new Date('2023-01-03')),
     ];
 
-    const result = queryAdjacentPosts(posts, 'post-2');
+    const result = queryAdjacentPosts(posts, posts[0]);
 
-    // ロケールが異なっても前後の記事として取得される
-    expect(result.prev).not.toBeNull();
-    expect(result.prev?.data.slug).toBe('post-1');
-    expect(result.prev?.data.locale).toBe('ja');
-    expect(result.next).not.toBeNull();
+    // ja 記事の隣接記事は ja のみ。間にある en 記事は飛ばされる
+    expect(result.prev).toBeNull();
     expect(result.next?.data.slug).toBe('post-3');
     expect(result.next?.data.locale).toBe('ja');
   });
@@ -161,7 +159,7 @@ describe('queryAdjacentPosts', () => {
       createMockPost('post-2', new Date('2023-01-02')),
     ];
 
-    const result = queryAdjacentPosts(posts, 'post-2');
+    const result = queryAdjacentPosts(posts, posts[2]);
 
     // ソート後、post-1 → post-2 → post-3 となる
     expect(result.prev?.data.slug).toBe('post-1');
@@ -171,10 +169,79 @@ describe('queryAdjacentPosts', () => {
   it('空の配列の場合、両方nullになる', () => {
     const posts: Array<CollectionEntry<'posts'>> = [];
 
-    const result = queryAdjacentPosts(posts, 'post-1');
+    const result = queryAdjacentPosts(posts, createMockPost('post-1', new Date('2023-01-01')));
 
     expect(result.prev).toBeNull();
     expect(result.next).toBeNull();
+  });
+
+  it('ja 記事の隣接記事に自分の翻訳版が現れない', () => {
+    // 翻訳版は ja とほぼ同じ created_time を持つため、locale を混ぜると必ず隣に並ぶ
+    const jaPost = createMockPost('post-1', new Date('2023-01-01'));
+    const posts: Array<CollectionEntry<'posts' | 'postsEn'>> = [
+      createMockPost('post-0', new Date('2022-12-30')),
+      jaPost,
+      createMockEnPost('post-1', new Date('2023-01-01')),
+      createMockPost('post-2', new Date('2023-01-03')),
+    ];
+
+    const result = queryAdjacentPosts(posts, jaPost);
+
+    expect(result.prev?.data.slug).toBe('post-0');
+    expect(result.next?.data.slug).toBe('post-2');
+    expect(result.next?.data.locale).toBe('ja');
+  });
+
+  it('翻訳版の created_time が ja より前でも prev に現れない', () => {
+    const jaPost = createMockPost('post-1', new Date('2023-01-02'));
+    const posts: Array<CollectionEntry<'posts' | 'postsEn'>> = [
+      createMockPost('post-0', new Date('2022-12-30')),
+      createMockEnPost('post-1', new Date('2023-01-01')),
+      jaPost,
+    ];
+
+    const result = queryAdjacentPosts(posts, jaPost);
+
+    expect(result.prev?.data.slug).toBe('post-0');
+    expect(result.prev?.data.locale).toBe('ja');
+  });
+
+  it('同 locale で slug が衝突していても現在の記事を id で特定する', () => {
+    // dev では draft を含む全件が渡るため (queryAvailablePosts)、
+    // content/posts/ の下書きが Notion 由来の記事と slug 衝突しうる
+    const draft = createMockPostWithId('posts/foo.md', 'foo', new Date('2023-01-02'));
+    const published = createMockPostWithId('notion/posts/foo.md', 'foo', new Date('2023-01-04'));
+    const posts = [
+      createMockPost('post-1', new Date('2023-01-01')),
+      draft,
+      published,
+      createMockPost('post-2', new Date('2023-01-05')),
+    ];
+
+    const result = queryAdjacentPosts(posts, published);
+
+    expect(result.prev?.id).toBe('posts/foo.md');
+    expect(result.next?.data.slug).toBe('post-2');
+  });
+
+  it('en 記事の隣接記事は en 記事から選ばれる', () => {
+    // 同 slug の ja 記事が先に見つかって位置がずれる回帰を防ぐ
+    const enPost = createMockEnPost('post-2', new Date('2023-01-02'));
+    const posts: Array<CollectionEntry<'posts' | 'postsEn'>> = [
+      createMockPost('post-1', new Date('2023-01-01')),
+      createMockEnPost('post-1', new Date('2023-01-01')),
+      createMockPost('post-2', new Date('2023-01-02')),
+      enPost,
+      createMockPost('post-3', new Date('2023-01-03')),
+      createMockEnPost('post-3', new Date('2023-01-03')),
+    ];
+
+    const result = queryAdjacentPosts(posts, enPost);
+
+    expect(result.prev?.data.slug).toBe('post-1');
+    expect(result.prev?.data.locale).toBe('en');
+    expect(result.next?.data.slug).toBe('post-3');
+    expect(result.next?.data.locale).toBe('en');
   });
 });
 

--- a/src/libs/query/posts.ts
+++ b/src/libs/query/posts.ts
@@ -134,19 +134,36 @@ export async function queryListPagePosts(): Promise<PostWithTranslations[]> {
   return buildListPagePosts(allPosts);
 }
 
+/** 記事詳細ページの前後記事。同一 locale 内の時系列で決まる */
+export interface AdjacentPosts {
+  prev: CollectionEntry<'posts' | 'postsEn'> | null;
+  next: CollectionEntry<'posts' | 'postsEn'> | null;
+}
+
 /**
- * 時系列順に前後の記事を取得する
- * カテゴリやロケールは区別しない
+ * 同じ locale の記事の中から、時系列順に前後の記事を取得する。
+ * カテゴリは区別しない。
+ *
+ * 読者に提示する導線は、その読者が読んでいる言語の記事に閉じる。
+ * locale を混ぜると、翻訳版 (同 slug の en 版) が ja 記事と同時刻かその後の created_time を持つため
+ * 時系列順で隣に並びやすい。修正前は、ja/en 両方を持つ 15 記事のうち 14 件で「次の記事」が
+ * 自分の翻訳版になっていた。
+ *
+ * current を slug 文字列ではなく entry で受け取るのは、slug と locale の組が食い違わないようにするため。
  */
 export function queryAdjacentPosts(
-  posts: Array<CollectionEntry<'posts'>>,
-  currentSlug: string,
-): { prev: CollectionEntry<'posts'> | null; next: CollectionEntry<'posts'> | null } {
-  // 時系列順（古い順）にソート
-  const sortedPosts = [...posts].sort((a, b) => compareAsc(a.data.created_time, b.data.created_time));
+  posts: Array<CollectionEntry<'posts' | 'postsEn'>>,
+  current: CollectionEntry<'posts' | 'postsEn'>,
+): AdjacentPosts {
+  // 同じ locale の記事に絞り、時系列順（古い順）にソート
+  const sortedPosts = posts
+    .filter((post) => post.data.locale === current.data.locale)
+    .sort((a, b) => compareAsc(a.data.created_time, b.data.created_time));
 
-  // 現在の記事のインデックスを取得
-  const currentIndex = sortedPosts.findIndex((post) => post.data.slug === currentSlug);
+  // 現在の記事のインデックスを取得する。
+  // slug ではなく id で照合するのは、dev では draft も含む全件が渡り (queryAvailablePosts)、
+  // content/posts/ の下書きが Notion 由来の記事と slug 衝突しうるため。id は衝突しない
+  const currentIndex = sortedPosts.findIndex((post) => post.id === current.id);
 
   if (currentIndex === -1) {
     return { prev: null, next: null };

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -1,7 +1,7 @@
 ---
 import { type CollectionEntry } from 'astro:content';
 import PostDetailPage from 'src/layouts/PostDetailPage.astro';
-import { queryAvailablePosts, queryAdjacentPosts } from '@lib/query';
+import { queryAvailablePosts, queryAdjacentPosts, type AdjacentPosts } from '@lib/query';
 
 export async function getStaticPaths() {
   const posts = await queryAvailablePosts();
@@ -10,7 +10,7 @@ export async function getStaticPaths() {
 
   return jaPosts.map((entry) => {
     // ビルド時に隣接記事を事前計算
-    const adjacentPosts = queryAdjacentPosts(posts, entry.data.slug);
+    const adjacentPosts = queryAdjacentPosts(posts, entry);
     return {
       params: {
         slug: entry.data.slug,
@@ -24,10 +24,7 @@ export async function getStaticPaths() {
 }
 type Props = {
   entry: CollectionEntry<'posts'>;
-  adjacentPosts: {
-    prev: CollectionEntry<'posts'> | null;
-    next: CollectionEntry<'posts'> | null;
-  };
+  adjacentPosts: AdjacentPosts;
 };
 const { entry, adjacentPosts } = Astro.props;
 ---

--- a/src/pages/posts/[slug].en.astro
+++ b/src/pages/posts/[slug].en.astro
@@ -1,7 +1,7 @@
 ---
 import { type CollectionEntry } from 'astro:content';
 import PostDetailPage from 'src/layouts/PostDetailPage.astro';
-import { queryAvailablePosts, queryAdjacentPosts } from '@lib/query';
+import { queryAvailablePosts, queryAdjacentPosts, type AdjacentPosts } from '@lib/query';
 
 export async function getStaticPaths() {
   const posts = await queryAvailablePosts();
@@ -10,7 +10,7 @@ export async function getStaticPaths() {
 
   return enPosts.map((entry) => {
     // ビルド時に隣接記事を事前計算
-    const adjacentPosts = queryAdjacentPosts(posts, entry.data.slug);
+    const adjacentPosts = queryAdjacentPosts(posts, entry);
     return {
       params: {
         slug: entry.data.slug,
@@ -24,10 +24,7 @@ export async function getStaticPaths() {
 }
 type Props = {
   entry: CollectionEntry<'posts'>;
-  adjacentPosts: {
-    prev: CollectionEntry<'posts'> | null;
-    next: CollectionEntry<'posts'> | null;
-  };
+  adjacentPosts: AdjacentPosts;
 };
 const { entry, adjacentPosts } = Astro.props;
 ---


### PR DESCRIPTION
## 何を直したか

記事詳細ページの前後記事ナビゲーションで、翻訳版がある記事の「←」が常に自分の英訳版を指していた問題を修正する。

## 原因

`queryAdjacentPosts` が locale を区別せず、`findIndex` も slug のみで現在位置を判定していた。

`<slug>.en.md` の `created_time` は ja 版と同時刻かその後になるため、時系列順に並べると ja 記事の直後に自分の翻訳版が来る。`PostNavigation.astro` は `next` (より新しい記事) を左カラムに `arrow-left` で描画しているため、UI 上の「←」が常に翻訳版になっていた。

英語版ページでも同根の不具合があり、`findIndex` が同 slug の ja エントリを拾うことで隣接記事の位置がずれていた。

前後記事ナビゲーション自体は #1165 (2025-11-08) で追加されたもので、当時すでに英語記事が 11 件あったため、導入当初からこの不具合を含んでいた。テストに「ロケールが異なる記事も含まれる」として仕様固定されていたことと、同一 slug の ja/en ペアを渡すテストがなかったことが、検出を長引かせた。

## どう直したか

- 隣接記事の候補を同じ locale の記事だけに絞る
- 現在の記事を slug 文字列ではなく `CollectionEntry` で受け取り、slug と locale の組が食い違わないようにする
- 現在位置の照合を slug ではなく `id` で行う。dev では `queryAvailablePosts` が draft を含む全件を返すため、`content/posts/` の下書きが Notion 由来の記事と slug 衝突すると位置を取り違え、「次の記事」が自分自身になり得た
- `{prev, next}` の形を `AdjacentPosts` として `posts.ts` に集約する。同じ形が 5 箇所に手書きされており、型を広げる変更で 5 箇所すべてを編集する必要があった

## 影響

公開中の日本語記事 343 件のうち 19 件で「次の記事」が英語記事になっていた (うち 14 件は自分の翻訳版、5 件は別記事の英語版)。修正後は 0 件。

英語版ページの前後記事も、英語版どうしで繋がるようになる。

## 検証

- `pnpm lint` / `pnpm format:check` 通過
- `pnpm test` 通過 (tools 284 件 / libs 197 件)。回帰テストを 4 件追加し、いずれも修正前の実装で赤になることを確認済み
- `pnpm build` 後、生成 HTML を走査して ja 343 ページ / en 22 ページ・ナビゲーションリンク 726 本すべてが同一 locale を指し、自己参照リンクがないことを確認
- 修正前の実装を実データの frontmatter に適用し、上記の影響件数を実測

code-critic-reviewed: 4f5197e5
